### PR TITLE
feat: add one-command StayReviewr startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,14 @@
-# Proxy Configuration
-# Set to false to disable proxy usage
-USE_PROXY=true
+# StayReviewr local services
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/stayreviewr?schema=public
+REDIS_URL=redis://127.0.0.1:6379
 
-# Proxy Settings
-PROXY_HOST=your-proxy-host.com
-PROXY_PORT=8080
-PROXY_USERNAME=your_proxy_username
-PROXY_PASSWORD=your_proxy_password
+# Gemini is required for the full review/photo/triage analysis pipeline.
+GEMINI_API_KEY=
+
+# Proxy configuration (optional)
+USE_PROXY=false
+
+PROXY_HOST=
+PROXY_PORT=
+PROXY_USERNAME=
+PROXY_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ reviewr auth http://user:pass@host:port   # Save proxy config
 reviewr auth                               # Check status
 ```
 
+### Run StayReviewr locally
+
+The web app, queue worker, Postgres, and Redis start together from the repository root:
+
+```bash
+cp .env.example .env
+# Add GEMINI_API_KEY and optional proxy credentials to .env.
+npm run up
+```
+
+Open <http://localhost:3000>. Press Ctrl-C to stop the app and worker, then run
+`npm run down` when you also want to stop Postgres and Redis.
+
 ## CLI Reference
 
 The `reviewr` CLI can also be used standalone, outside of the AI skill. It auto-detects the platform from the URL.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "reviewr": "./dist/src/cli.js"
   },
   "scripts": {
+    "up": "node scripts/up.mjs",
+    "down": "docker compose -f web/docker-compose.yml down",
     "test": "tsx --test tests/**/*.test.ts",
     "dev": "tsx watch src/booking/scraper.ts",
     "dev:cli": "tsx src/cli.ts",
@@ -30,6 +32,7 @@
     "@types/papaparse": "^5.5.2",
     "@typescript-eslint/eslint-plugin": "^8.36.0",
     "@typescript-eslint/parser": "^8.36.0",
+    "concurrently": "^9.2.4",
     "eslint": "^9.31.0",
     "prettier": "^3.6.2",
     "tsx": "^4.20.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.36.0
         version: 8.36.0(eslint@9.31.0)(typescript@5.8.3)
+      concurrently:
+        specifier: ^9.2.4
+        version: 9.2.4
       eslint:
         specifier: ^9.31.0
         version: 9.31.0
@@ -865,6 +868,10 @@ packages:
     resolution: {integrity: sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==}
     engines: {node: '>=18.17'}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -888,6 +895,11 @@ packages:
 
   concaveman@1.2.1:
     resolution: {integrity: sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw==}
+
+  concurrently@9.2.4:
+    resolution: {integrity: sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   convex-hull@1.0.3:
     resolution: {integrity: sha512-24rZAoh81t41GHPLAxcsokgjH9XNoVqU2OiSi8iMHUn6HUURfiefcEWAPt1AfwZjBBWTKadOm1xUcUMnfFukhQ==}
@@ -999,6 +1011,10 @@ packages:
     resolution: {integrity: sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1147,6 +1163,10 @@ packages:
   geojson-random@0.2.2:
     resolution: {integrity: sha512-/vZQ14mjKPG3LJ7bpyXsJ0aoz8NzvwpwwP//uBgbzIu2BCFd4uRagp1QvY3RAzRQsHOHyVh33dbYUYws7vOCkg==}
     hasBin: true
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1488,6 +1508,10 @@ packages:
   rbush@3.0.1:
     resolution: {integrity: sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -1528,6 +1552,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -1546,6 +1573,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -1587,6 +1618,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   sweepline-intersections@1.5.0:
     resolution: {integrity: sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==}
 
@@ -1603,6 +1638,10 @@ packages:
 
   topojson-server@3.0.1:
     resolution: {integrity: sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==}
+    hasBin: true
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
   ts-api-utils@2.1.0:
@@ -1889,6 +1928,18 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3410,6 +3461,12 @@ snapshots:
       undici: 7.11.0
       whatwg-mimetype: 4.0.0
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3432,6 +3489,15 @@ snapshots:
       rbush: 3.0.1
       robust-predicates: 2.0.4
       tinyqueue: 2.0.3
+
+  concurrently@9.2.4:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.9.0
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   convex-hull@1.0.3:
     dependencies:
@@ -3563,6 +3629,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.6
       '@esbuild/win32-ia32': 0.25.6
       '@esbuild/win32-x64': 0.25.6
+
+  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3737,6 +3805,8 @@ snapshots:
       rbush: 2.0.2
 
   geojson-random@0.2.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4078,6 +4148,8 @@ snapshots:
     dependencies:
       quickselect: 2.0.0
 
+  require-directory@2.1.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -4114,6 +4186,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
@@ -4125,6 +4201,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.9.0: {}
 
   signal-exit@4.1.0: {}
 
@@ -4165,6 +4243,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   sweepline-intersections@1.5.0:
     dependencies:
       tinyqueue: 2.0.3
@@ -4182,6 +4264,8 @@ snapshots:
   topojson-server@3.0.1:
     dependencies:
       commander: 2.20.3
+
+  tree-kill@1.2.2: {}
 
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
@@ -4529,5 +4613,19 @@ snapshots:
       strip-ansi: 7.2.0
 
   ws@8.19.0: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}

--- a/scripts/up.mjs
+++ b/scripts/up.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const webRoot = path.join(repoRoot, 'web');
+const envPath = path.join(repoRoot, '.env');
+
+const defaultDatabaseUrl =
+  'postgresql://postgres:postgres@127.0.0.1:5432/stayreviewr?schema=public';
+const defaultRedisUrl = 'redis://127.0.0.1:6379';
+
+process.chdir(repoRoot);
+
+function fail(message) {
+  console.error(`\nStayReviewr startup failed: ${message}`);
+  process.exit(1);
+}
+
+function commandWorks(command, args = ['--version']) {
+  return spawnSync(command, args, { stdio: 'ignore' }).status === 0;
+}
+
+function run(command, args, options = {}) {
+  console.log(`\n> ${[command, ...args].join(' ')}`);
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    env: options.env ?? process.env,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    fail(`${command} could not be started: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    fail(`${command} exited with status ${result.status ?? 'unknown'}`);
+  }
+}
+
+if (!existsSync(envPath)) {
+  fail('missing .env; copy .env.example to .env and fill in the required values');
+}
+
+if (!commandWorks('docker')) {
+  fail('Docker is not installed or is not available on PATH');
+}
+if (!commandWorks('docker', ['compose', 'version'])) {
+  fail('Docker Compose is not available');
+}
+if (!commandWorks('docker', ['info'])) {
+  fail('the Docker daemon is not running; start Docker Desktop or OrbStack and retry');
+}
+
+let pnpmCommand = 'pnpm';
+let pnpmPrefix = [];
+if (!commandWorks('pnpm')) {
+  if (!commandWorks('corepack')) {
+    fail('pnpm is required; install pnpm or enable Corepack and retry');
+  }
+  pnpmCommand = 'corepack';
+  pnpmPrefix = ['pnpm'];
+}
+
+const rootDependenciesMissing = [
+  path.join(repoRoot, 'node_modules', '.bin', 'concurrently'),
+  path.join(repoRoot, 'node_modules', 'dotenv', 'package.json'),
+  path.join(repoRoot, 'node_modules', 'playwright', 'package.json'),
+].some((dependency) => !existsSync(dependency));
+const webDependenciesMissing = [
+  path.join(webRoot, 'node_modules', '.bin', 'next'),
+  path.join(webRoot, 'node_modules', '.bin', 'prisma'),
+  path.join(webRoot, 'node_modules', '.bin', 'tsx'),
+].some((dependency) => !existsSync(dependency));
+
+if (rootDependenciesMissing) {
+  console.log('\nRoot dependencies are missing; installing them with pnpm.');
+  run(pnpmCommand, [...pnpmPrefix, 'install', '--frozen-lockfile']);
+}
+
+if (webDependenciesMissing) {
+  console.log('\nWeb dependencies are missing; installing them with npm.');
+  run('npm', ['ci', '--prefix', 'web']);
+}
+
+const { chromium } = await import('playwright');
+if (!existsSync(chromium.executablePath())) {
+  console.log('\nPlaywright Chromium is missing; installing it for Booking.com jobs.');
+  run(pnpmCommand, [...pnpmPrefix, 'exec', 'playwright', 'install', 'chromium']);
+}
+
+const { config: loadEnv } = await import('dotenv');
+const envResult = loadEnv({ path: envPath, quiet: true });
+if (envResult.error) {
+  fail(`could not read .env: ${envResult.error.message}`);
+}
+
+const runtimeEnv = {
+  ...process.env,
+  DATABASE_URL: process.env.DATABASE_URL || defaultDatabaseUrl,
+  REDIS_URL: process.env.REDIS_URL || defaultRedisUrl,
+};
+
+console.log('\nStarting Postgres and Redis.');
+run(
+  'docker',
+  [
+    'compose',
+    '-f',
+    'web/docker-compose.yml',
+    'up',
+    '-d',
+    '--wait',
+    '--wait-timeout',
+    '90',
+  ],
+  { env: runtimeEnv },
+);
+
+console.log('\nSynchronizing the Prisma schema.');
+run('npm', ['--prefix', 'web', 'run', 'db:push'], { env: runtimeEnv });
+
+console.log('\nStayReviewr is starting at http://localhost:3000');
+console.log('Postgres and Redis remain running after Ctrl-C; use npm run down to stop them.\n');
+
+const stack = spawn(
+  path.join(repoRoot, 'node_modules', '.bin', 'concurrently'),
+  [
+    '--kill-others',
+    '--kill-timeout',
+    '10000',
+    '--success',
+    'first',
+    '--names',
+    'web,worker',
+    '--no-color',
+    'npm --prefix web run dev',
+    'npm --prefix web run worker:dev',
+  ],
+  {
+    cwd: repoRoot,
+    env: runtimeEnv,
+    stdio: 'inherit',
+  },
+);
+
+stack.on('error', (error) => {
+  fail(`web/worker supervisor could not be started: ${error.message}`);
+});
+
+const { code, signal } = await new Promise((resolve) => {
+  stack.on('exit', (exitCode, exitSignal) => {
+    resolve({ code: exitCode, signal: exitSignal });
+  });
+});
+
+if (signal) {
+  process.exitCode = signal === 'SIGINT' ? 130 : 1;
+} else {
+  process.exitCode = code ?? 1;
+}

--- a/web/README.md
+++ b/web/README.md
@@ -7,47 +7,36 @@ This web app now has two search paths:
 - `POST /api/quick-search`: synchronous viewport search, no Postgres/Redis required
 - `POST /api/search`: queued full search, requires Postgres + Redis + worker
 
-### Start infra
+### Start everything
+
+From the repository root:
 
 ```bash
-cd web
-docker compose up -d
+cp .env.example .env
+# Add GEMINI_API_KEY and optional proxy credentials to .env.
+npm run up
 ```
 
-### Initialize Prisma schema
+`npm run up` checks Docker, installs missing root and web dependencies, installs Playwright
+Chromium when needed, waits for Postgres and Redis to become healthy, synchronizes the Prisma
+schema, and then runs the Next.js app and BullMQ worker together. Open
+<http://localhost:3000>.
+
+Press Ctrl-C to stop the app and worker. The data services stay available between runs; stop
+them with:
 
 ```bash
-cd web
-npm run db:push
+npm run down
 ```
 
-### Run the app
+All app, worker, database, Redis, AI, and proxy settings live in the repository-root `.env`.
+The local service defaults are:
 
-In one terminal:
-
-```bash
-cd web
-npm run worker
-```
-
-In another terminal:
-
-```bash
-cd web
-npm run dev
-```
-
-### Required env vars
-
-`web/.env.local` should contain:
-
-```bash
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/stayreviewr?schema=public
+```dotenv
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/stayreviewr?schema=public
 REDIS_URL=redis://127.0.0.1:6379
 ```
 
-Proxy settings come from the shared CLI config:
-- repo-root `.env`
-- `~/.config/reviewr/.env` created by `reviewr auth`
-
-So you do not need to duplicate `PROXY_*` values in `web/.env.local`.
+`web/.env.local` remains supported as a compatibility fallback for direct `web/` commands, but
+the root `.env` takes precedence. Proxy settings also fall back to
+`~/.config/reviewr/.env` created by `reviewr auth`.

--- a/web/package.json
+++ b/web/package.json
@@ -3,18 +3,18 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "dotenv -e ../.env -e .env.local -- next dev",
     "dev:stack": "./scripts/dev-stack.sh",
-    "build": "next build",
-    "start": "next start",
-    "worker": "dotenv -e .env.local -- tsx src/lib/search-worker.ts",
-    "worker:dev": "dotenv -e .env.local -- tsx watch src/lib/search-worker.ts",
+    "build": "dotenv -e ../.env -e .env.local -- next build",
+    "start": "dotenv -e ../.env -e .env.local -- next start",
+    "worker": "dotenv -e ../.env -e .env.local -- tsx src/lib/search-worker.ts",
+    "worker:dev": "dotenv -e ../.env -e .env.local -- tsx watch src/lib/search-worker.ts",
     "test:pricing": "tsx --test src/lib/pricing.test.ts",
     "lint": "eslint .",
-    "db:generate": "dotenv -e .env.local -- prisma generate",
-    "db:push": "dotenv -e .env.local -- prisma db push",
-    "db:migrate": "dotenv -e .env.local -- prisma migrate dev",
-    "db:studio": "dotenv -e .env.local -- prisma studio"
+    "db:generate": "dotenv -e ../.env -e .env.local -- prisma generate",
+    "db:push": "dotenv -e ../.env -e .env.local -- prisma db push",
+    "db:migrate": "dotenv -e ../.env -e .env.local -- prisma migrate dev",
+    "db:studio": "dotenv -e ../.env -e .env.local -- prisma studio"
   },
   "dependencies": {
     "@prisma/client": "^6.2.0",

--- a/web/scripts/dev-stack.sh
+++ b/web/scripts/dev-stack.sh
@@ -2,26 +2,5 @@
 
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT_DIR"
-
-WORKER_PID=""
-
-cleanup() {
-  if [[ -n "$WORKER_PID" ]] && kill -0 "$WORKER_PID" >/dev/null 2>&1; then
-    kill "$WORKER_PID" >/dev/null 2>&1 || true
-  fi
-}
-
-trap cleanup EXIT INT TERM
-
-docker compose up -d
-npm run db:push
-
-npm run worker:dev > ./.worker-dev.log 2>&1 &
-WORKER_PID=$!
-
-echo "Worker started as PID $WORKER_PID"
-echo "Worker log: $ROOT_DIR/.worker-dev.log"
-
-npm run dev
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec npm --prefix "$REPO_ROOT" run up

--- a/web/src/lib/search-worker.ts
+++ b/web/src/lib/search-worker.ts
@@ -57,7 +57,7 @@ for (const envPath of [
   path.resolve(process.cwd(), '.env'),
   path.resolve(process.cwd(), '../.env'),
 ]) {
-  loadDotEnv({ path: envPath, override: false });
+  loadDotEnv({ path: envPath, override: false, quiet: true });
 }
 
 bootstrapRuntimeProxyEnv();


### PR DESCRIPTION
## What changed

- add a root `npm run up` entry point that checks Docker, bootstraps missing root/web dependencies, installs Playwright Chromium when needed, and waits for Postgres and Redis health
- synchronize the existing Prisma schema before supervising the Next.js app and BullMQ worker together with prefixed logs and signal cleanup
- add `npm run down` while preserving the existing Compose project/volumes under `web/docker-compose.yml`
- make the repository-root `.env` the shared app/worker/Prisma configuration source, with `web/.env.local` retained as a compatibility fallback
- update the root and web setup docs and route the legacy `web` stack script through the new root command

## Why

StayReviewr previously required separate manual steps for infrastructure, schema setup, the web server, and the worker. This makes the documented fresh-clone path `.env` plus one command while preserving the existing local database/Redis layout. The schema stage remains `prisma db push` because this repository currently has no Prisma migration history.

## Validation

- dependency-free temporary copy: `.env.example` copied to `.env`, then `npm run up`
  - root and web dependencies installed
  - Postgres and Redis reported healthy
  - Prisma reported the database in sync
  - search and review workers both listened
  - `GET /` returned HTTP 200
  - Ctrl-C stopped both foreground processes
- `pnpm run build`
- `pnpm test` (40 passed)
- `pnpm run lint`
- `npm run build` in `web/`
- `npm run test:pricing` in `web/` (3 passed)
- `npm run lint` in `web/`
- `docker compose -f web/docker-compose.yml config --quiet`
- `npm run down`
