### PR TITLE
Add AI review and job cost guardrails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ REDIS_URL=redis://127.0.0.1:6379
 # Gemini is required for the full review/photo/triage analysis pipeline.
 GEMINI_API_KEY=
 
+# Cost guardrails
+AI_REVIEW_MAX_REVIEWS=250
+STAYREVIEWR_AI_JOB_BUDGET_USD=5
+
 # Proxy configuration (optional)
 USE_PROXY=false
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ npm run up
 ```
 
 Open <http://localhost:3000>. Press Ctrl-C to stop the app and worker, then run
-`npm run down` when you also want to stop Postgres and Redis.
+`npm run down` when you also want to stop Postgres and Redis. `pnpm run up` and
+`pnpm run down` are equivalent.
 
 ## CLI Reference
 
@@ -168,6 +169,21 @@ PROXY_PASSWORD=your_password
 ```
 
 Set `USE_PROXY=false` to disable proxy usage.
+
+AI analysis has two configurable cost guardrails:
+
+```env
+# Maximum most-recent, post-filter reviews sent to AI per listing.
+AI_REVIEW_MAX_REVIEWS=250
+
+# Maximum persisted AI spend per StayReviewr analysis run, in USD. Set 0 to disable.
+STAYREVIEWR_AI_JOB_BUDGET_USD=5
+```
+
+The CLI `batch` and `analyze` commands also accept `--max-ai-reviews <n>`, which takes
+precedence over `AI_REVIEW_MAX_REVIEWS`. StayReviewr checks its accumulated persisted cost
+after each paid per-listing AI operation; when the budget is reached, it preserves partial
+results and stops before starting the next AI call.
 
 ## Project Structure
 

--- a/docs/review-job-analysis-parity.md
+++ b/docs/review-job-analysis-parity.md
@@ -106,6 +106,19 @@ the same temporary file inputs that `runAnalyze`, `runAnalyzePhotos`, and
 - optional: `priorities`
 - currently Gemini-only
 
+## Cost Guardrails
+
+- `runAnalyze` applies `AI_REVIEW_MAX_REVIEWS` after room, date, and empty-review filters,
+  selecting the most recent eligible reviews. The default is 250, and CLI callers can override
+  it with `--max-ai-reviews`.
+- The web worker persists per-listing AI costs after every paid review, photo, or triage
+  operation and checks the total before starting the next AI call. When
+  `STAYREVIEWR_AI_JOB_BUDGET_USD` is reached with work remaining, it marks the run partial
+  with `analysisCurrentPhase = budget-exceeded` and preserves completed artifacts. The
+  default is USD 5; `0` disables the per-run ceiling.
+- Photo count remains governed by the existing photo pipeline. There is no separate
+  per-listing photo cap.
+
 ## Persistence Goals For The Web Job
 
 The web job should persist:

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -5,6 +5,10 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import {
+  resolveAiReviewLimit,
+  selectMostRecentReviews,
+} from './review-guardrails.js';
 
 // --- Types ---
 
@@ -935,6 +939,7 @@ export interface AnalyzeOptions {
   room?: string;
   priorities?: string;
   allYears?: boolean;
+  maxReviews?: number;
 }
 
 export interface UsageSummary {
@@ -949,6 +954,12 @@ export interface AnalysisResult {
   model: string;
   provider: LLMProvider;
   multiYear: boolean;
+  reviewSelection: {
+    eligibleCount: number;
+    includedCount: number;
+    limit: number;
+    capped: boolean;
+  };
   usage?: UsageSummary;
 }
 
@@ -1045,14 +1056,37 @@ export async function runAnalyze(options: AnalyzeOptions): Promise<AnalysisResul
     }
   }
 
-  // 5. Count non-empty reviews (after room + date filter)
-  const nonEmptyReviews = platform === 'booking'
+  // 5. Remove empty reviews, then apply the per-listing AI input cap.
+  const nonEmptyReviews: Array<BookingReview | AirbnbReview> = platform === 'booking'
     ? filterEmptyBookingReviews(reviewsData.reviews)
     : filterEmptyAirbnbReviews(reviewsData.reviews);
-  const nonEmptyCount = nonEmptyReviews.length;
-  const emptyCount = reviewsData.reviews.length - nonEmptyCount;
+  const emptyCount = reviewsData.reviews.length - nonEmptyReviews.length;
+  const reviewLimit = resolveAiReviewLimit(options.maxReviews);
+  const selectedReviews = selectMostRecentReviews(
+    nonEmptyReviews,
+    (review) =>
+      platform === 'booking'
+        ? (review as BookingReview).review_post_date
+        : (review as AirbnbReview).review_date,
+    reviewLimit,
+  );
+  const reviewSelection = {
+    eligibleCount: selectedReviews.eligibleCount,
+    includedCount: selectedReviews.includedCount,
+    limit: selectedReviews.limit,
+    capped: selectedReviews.capped,
+  };
+  reviewsData.reviews = selectedReviews.reviews;
 
-  console.error(`Reviews: ${nonEmptyCount} included, ${emptyCount} empty filtered out of ${reviewsData.reviews.length} total`);
+  console.error(
+    `Reviews: ${reviewSelection.eligibleCount} eligible, ${emptyCount} empty filtered out`,
+  );
+  if (reviewSelection.capped) {
+    console.error(
+      `Review cap: using the ${reviewSelection.includedCount} most recent of `
+      + `${reviewSelection.eligibleCount} eligible reviews`,
+    );
+  }
 
   // 6. Build system prompt
   const isCustomPrompt = !!customPrompt;
@@ -1068,7 +1102,7 @@ Include a "priorityAnalysis" section in your response analyzing each priority wi
   const jsonSchema = isCustomPrompt ? null : getAnalysisSchema(hasPriorities);
 
   // 7. Determine mode
-  const isMultiRequest = nonEmptyCount > YEAR_SPLIT_THRESHOLD;
+  const isMultiRequest = reviewSelection.includedCount > YEAR_SPLIT_THRESHOLD;
 
   // --- Dry-run: show combined text with year headers regardless of mode ---
   if (dryRun) {
@@ -1083,12 +1117,12 @@ Include a "priorityAnalysis" section in your response analyzing each priority wi
 
     // Show mode info
     if (isMultiRequest) {
-      const yearGroups = groupReviewsByYear(nonEmptyReviews, platform);
+      const yearGroups = groupReviewsByYear(selectedReviews.reviews, platform);
       const yearSummary = Array.from(yearGroups.entries()).map(([y, revs]) => `${y} (${revs.length})`).join(', ');
-      console.error(`\nMode: multi-request (${nonEmptyCount} reviews > ${YEAR_SPLIT_THRESHOLD} threshold)`);
+      console.error(`\nMode: multi-request (${reviewSelection.includedCount} reviews > ${YEAR_SPLIT_THRESHOLD} threshold)`);
       console.error(`Year groups: ${yearSummary}`);
     } else {
-      console.error(`\nMode: single-request (${nonEmptyCount} reviews)`);
+      console.error(`\nMode: single-request (${reviewSelection.includedCount} reviews)`);
     }
 
     console.log('=== SYSTEM PROMPT ===\n');
@@ -1121,7 +1155,13 @@ Include a "priorityAnalysis" section in your response analyzing each priority wi
 
     console.error(`Content length: ${fullContent.length.toLocaleString()} chars`);
 
-    return { data: null, model: dryRunConfig.model, provider: dryRunConfig.provider, multiYear: isMultiRequest };
+    return {
+      data: null,
+      model: dryRunConfig.model,
+      provider: dryRunConfig.provider,
+      multiYear: isMultiRequest,
+      reviewSelection,
+    };
   }
 
   // --- LLM call ---
@@ -1154,7 +1194,7 @@ Include a "priorityAnalysis" section in your response analyzing each priority wi
 
   if (isMultiRequest) {
     // --- Multi-request mode: per-year analysis ---
-    const yearGroups = groupReviewsByYear(nonEmptyReviews, platform);
+    const yearGroups = groupReviewsByYear(selectedReviews.reviews, platform);
     const years = Array.from(yearGroups.keys());
     const yearResults: { year: number; result: string }[] = [];
 
@@ -1205,7 +1245,19 @@ Include a "priorityAnalysis" section in your response analyzing each priority wi
     };
     console.error(`\n${formatUsageSummary(usage, modelName)}`);
     const meta = getUsageMeta(usage, modelName);
-    return { data: output, model: modelName, provider: modelConfig.provider, multiYear: true, usage: { inputTokens: meta.totals.promptTokens, outputTokens: meta.totals.responseTokens, thinkingTokens: meta.totals.thinkingTokens || undefined, cost: meta.cost.total } };
+    return {
+      data: output,
+      model: modelName,
+      provider: modelConfig.provider,
+      multiYear: true,
+      reviewSelection,
+      usage: {
+        inputTokens: meta.totals.promptTokens,
+        outputTokens: meta.totals.responseTokens,
+        thinkingTokens: meta.totals.thinkingTokens || undefined,
+        cost: meta.cost.total,
+      },
+    };
   } else {
     // --- Single-request mode: year headers + recency weighting ---
     let reviewResult: FormatResult;
@@ -1241,7 +1293,19 @@ Include a "priorityAnalysis" section in your response analyzing each priority wi
 
     console.error(`\n${formatUsageSummary(usage, modelName)}`);
     const meta = getUsageMeta(usage, modelName);
-    return { data: outputData, model: modelName, provider: modelConfig.provider, multiYear: false, usage: { inputTokens: meta.totals.promptTokens, outputTokens: meta.totals.responseTokens, thinkingTokens: meta.totals.thinkingTokens || undefined, cost: meta.cost.total } };
+    return {
+      data: outputData,
+      model: modelName,
+      provider: modelConfig.provider,
+      multiYear: false,
+      reviewSelection,
+      usage: {
+        inputTokens: meta.totals.promptTokens,
+        outputTokens: meta.totals.responseTokens,
+        thinkingTokens: meta.totals.thinkingTokens || undefined,
+        cost: meta.cost.total,
+      },
+    };
   }
 }
 

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -32,6 +32,7 @@ export interface BatchOptions {
   triage: boolean;
   aiModel?: string;
   aiPriorities?: string;
+  aiReviewLimit?: number;
   aiReviewsExplicit: boolean;  // true when --ai-reviews was explicitly passed
   aiPhotosExplicit: boolean;   // true when --ai-photos was explicitly passed
   triageExplicit: boolean;     // true when --triage was explicitly passed
@@ -108,6 +109,13 @@ export interface BatchPhaseUpdate {
   entry: ManifestEntry;
 }
 
+export interface BatchAiCheckpoint {
+  outputDir: string;
+  manifestKey: string;
+  phase: 'ai-reviews' | 'ai-photos' | 'triage';
+  entry: ManifestEntry;
+}
+
 export interface BatchHooks {
   onEvent?: (event: BatchEvent) => void | Promise<void>;
   onScrapeComplete?: (input: {
@@ -115,6 +123,8 @@ export interface BatchHooks {
     manifest: BatchManifest;
   }) => void | Promise<void>;
   onPhaseUpdate?: (input: BatchPhaseUpdate) => void | Promise<void>;
+  onBeforeAiCall?: (input: BatchAiCheckpoint) => void | Promise<void>;
+  onAiCheckpoint?: (input: BatchAiCheckpoint) => void | Promise<void>;
 }
 
 interface PhaseResult {
@@ -337,6 +347,34 @@ async function persistPhaseUpdate(
     manifestKey,
     phase,
     entry,
+  });
+}
+
+async function emitAiCheckpoint(
+  options: BatchOptions,
+  input: BatchAiCheckpoint,
+): Promise<void> {
+  if (!options.hooks?.onAiCheckpoint) {
+    return;
+  }
+
+  await options.hooks.onAiCheckpoint({
+    ...input,
+    entry: cloneManifestEntry(input.entry),
+  });
+}
+
+async function emitBeforeAiCall(
+  options: BatchOptions,
+  input: BatchAiCheckpoint,
+): Promise<void> {
+  if (!options.hooks?.onBeforeAiCall) {
+    return;
+  }
+
+  await options.hooks.onBeforeAiCall({
+    ...input,
+    entry: cloneManifestEntry(input.entry),
   });
 }
 
@@ -1117,12 +1155,19 @@ export async function runBatch(filePaths: string[], options: BatchOptions): Prom
         }
 
         const t = Date.now();
+        await emitBeforeAiCall(options, {
+          outputDir: aiOutputDir,
+          manifestKey,
+          phase: 'ai-reviews',
+          entry,
+        });
         try {
           const result: AnalysisResult = await runAnalyze({
             reviewsFile: reviewsPath,
             listingFile: listingPath && fs.existsSync(listingPath) ? listingPath : undefined,
             model: aiModel,
             priorities: options.aiPriorities,
+            maxReviews: options.aiReviewLimit,
           });
 
           // Write result to ai-reviews dir
@@ -1130,7 +1175,14 @@ export async function runBatch(filePaths: string[], options: BatchOptions): Prom
 
           console.log(`${prefix} \u2014 ai-reviews \u2713 (${formatDuration(Date.now() - t)})`);
           platformResult.aiReviews.fetched++;
-          entry.aiReviews = { status: 'fetched', file: `ai-reviews/${entry.id}.json`, model: result.model, cost: result.usage?.cost };
+          entry.aiReviews = {
+            status: 'fetched',
+            file: `ai-reviews/${entry.id}.json`,
+            model: result.model,
+            count: result.reviewSelection.includedCount,
+            expected: result.reviewSelection.eligibleCount,
+            cost: result.usage?.cost,
+          };
           await persistPhaseUpdate(options, manifest, manifestPath, manifestKey, 'aiReviews');
           await emitBatchEvent(options, {
             phase: 'ai-reviews',
@@ -1139,6 +1191,9 @@ export async function runBatch(filePaths: string[], options: BatchOptions): Prom
             manifestKey,
             platform: entry.platform,
             listingId: entry.id,
+            payload: {
+              reviewSelection: result.reviewSelection,
+            },
           });
         } catch (err: any) {
           console.log(`${prefix} \u2014 ai-reviews \u2717 ${err.message}`);
@@ -1156,6 +1211,12 @@ export async function runBatch(filePaths: string[], options: BatchOptions): Prom
           });
         }
 
+        await emitAiCheckpoint(options, {
+          outputDir: aiOutputDir,
+          manifestKey,
+          phase: 'ai-reviews',
+          entry,
+        });
       }
     }
   }
@@ -1276,6 +1337,12 @@ export async function runBatch(filePaths: string[], options: BatchOptions): Prom
         const listingPath = entry.details.file ? path.join(aiOutputDir, entry.details.file) : undefined;
 
         const t = Date.now();
+        await emitBeforeAiCall(options, {
+          outputDir: aiOutputDir,
+          manifestKey,
+          phase: 'ai-photos',
+          entry,
+        });
         try {
           const result: PhotoAnalysisResult = await runAnalyzePhotos({
             photosDir: photosPath,
@@ -1315,6 +1382,12 @@ export async function runBatch(filePaths: string[], options: BatchOptions): Prom
           });
         }
 
+        await emitAiCheckpoint(options, {
+          outputDir: aiOutputDir,
+          manifestKey,
+          phase: 'ai-photos',
+          entry,
+        });
       }
     }
   }
@@ -1436,6 +1509,12 @@ export async function runBatch(filePaths: string[], options: BatchOptions): Prom
         const aiPhotosPath = entry.aiPhotos?.file ? path.join(aiOutputDir, entry.aiPhotos.file) : undefined;
 
         const t = Date.now();
+        await emitBeforeAiCall(options, {
+          outputDir: aiOutputDir,
+          manifestKey,
+          phase: 'triage',
+          entry,
+        });
         try {
           const result: TriageResult = await runTriage({
             listingFile: listingPath,
@@ -1478,6 +1557,12 @@ export async function runBatch(filePaths: string[], options: BatchOptions): Prom
           });
         }
 
+        await emitAiCheckpoint(options, {
+          outputDir: aiOutputDir,
+          manifestKey,
+          phase: 'triage',
+          entry,
+        });
       }
     }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -404,6 +404,7 @@ program
   .option('--triage', 'Run AI triage (grade listings against priorities)')
   .option('--model <model>', 'LLM model for AI phases (default: gemini-3-flash-preview:high)')
   .option('--priorities <text>', 'Guest priorities for AI analysis (e.g. "quiet, fresh air")')
+  .option('--max-ai-reviews <n>', 'Maximum post-filter reviews sent to AI per listing (default: 250)')
   .option('--checkin <date>', 'Check-in date (YYYY-MM-DD)')
   .option('--checkout <date>', 'Check-out date (YYYY-MM-DD)')
   .option('--adults <n>', 'Number of adults')
@@ -435,6 +436,7 @@ program
       triage: hasPhaseFlag ? !!cmdOpts.triage : true,
       aiModel: cmdOpts.model || undefined,
       aiPriorities: cmdOpts.priorities || undefined,
+      aiReviewLimit: cmdOpts.maxAiReviews == null ? undefined : Number(cmdOpts.maxAiReviews),
       aiReviewsExplicit: !!cmdOpts.aiReviews,
       aiPhotosExplicit: !!cmdOpts.aiPhotos,
       triageExplicit: !!cmdOpts.triage,
@@ -477,6 +479,7 @@ program
   .option('--room <text>', 'Filter reviews by room type (substring match on room_view)')
   .option('--priorities <text>', 'Guest priorities to focus on (e.g. "quiet, fresh air, high floor")')
   .option('--all-years', 'Include all reviews regardless of age (default: last 4 years)')
+  .option('--max-ai-reviews <n>', 'Maximum post-filter reviews sent to AI (default: 250)')
   .action(async (reviewsFile: string, listingFile: string | undefined, cmdOpts: any) => {
     // Load .env for GEMINI_API_KEY
     try { await import('dotenv/config'); } catch {}
@@ -491,6 +494,7 @@ program
       room: cmdOpts.room || undefined,
       priorities: cmdOpts.priorities || undefined,
       allYears: !!cmdOpts.allYears,
+      maxReviews: cmdOpts.maxAiReviews == null ? undefined : Number(cmdOpts.maxAiReviews),
     });
     if (result.data !== null) {
       console.log(typeof result.data === 'string' ? result.data : JSON.stringify(result.data, null, 2));

--- a/src/review-guardrails.ts
+++ b/src/review-guardrails.ts
@@ -1,0 +1,71 @@
+export const AI_REVIEW_LIMIT_ENV = 'AI_REVIEW_MAX_REVIEWS';
+export const DEFAULT_AI_REVIEW_LIMIT = 250;
+
+export interface ReviewSelection<T> {
+  reviews: T[];
+  eligibleCount: number;
+  includedCount: number;
+  limit: number;
+  capped: boolean;
+}
+
+export function resolveAiReviewLimit(
+  explicitValue?: number | string | null,
+  envValue: string | undefined = process.env[AI_REVIEW_LIMIT_ENV],
+): number {
+  const rawValue =
+    explicitValue != null && explicitValue !== ''
+      ? explicitValue
+      : envValue?.trim() || DEFAULT_AI_REVIEW_LIMIT;
+  const parsed = typeof rawValue === 'number' ? rawValue : Number(rawValue);
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(
+      `${AI_REVIEW_LIMIT_ENV} must be a positive integer; received "${rawValue}"`,
+    );
+  }
+
+  return parsed;
+}
+
+export function selectMostRecentReviews<T>(
+  reviews: readonly T[],
+  getDate: (review: T) => string,
+  limit: number,
+): ReviewSelection<T> {
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error(`Review analysis limit must be a positive integer; received "${limit}"`);
+  }
+
+  const eligibleCount = reviews.length;
+  if (eligibleCount <= limit) {
+    return {
+      reviews: [...reviews],
+      eligibleCount,
+      includedCount: eligibleCount,
+      limit,
+      capped: false,
+    };
+  }
+
+  const selected = reviews
+    .map((review, index) => {
+      const parsedDate = Date.parse(getDate(review));
+      return {
+        review,
+        index,
+        timestamp: Number.isNaN(parsedDate) ? Number.NEGATIVE_INFINITY : parsedDate,
+      };
+    })
+    .sort((left, right) => right.timestamp - left.timestamp || left.index - right.index)
+    .slice(0, limit)
+    .map(({ review }) => review);
+
+  return {
+    reviews: selected,
+    eligibleCount,
+    includedCount: selected.length,
+    limit,
+    capped: true,
+  };
+}

--- a/tests/cost-guardrails.test.ts
+++ b/tests/cost-guardrails.test.ts
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { runAnalyze } from '../src/analyze.js';
+import {
+  DEFAULT_AI_REVIEW_LIMIT,
+  resolveAiReviewLimit,
+  selectMostRecentReviews,
+} from '../src/review-guardrails.js';
+import {
+  DEFAULT_AI_JOB_BUDGET_USD,
+  buildAiBudgetExceededMessage,
+  hasReachedAiJobBudget,
+  resolveAiJobBudgetUsd,
+} from '../web/src/lib/aiBudget.js';
+
+test('review limit defaults to 250 and honors explicit values before env', () => {
+  assert.equal(resolveAiReviewLimit(undefined, undefined), DEFAULT_AI_REVIEW_LIMIT);
+  assert.equal(resolveAiReviewLimit(undefined, '300'), 300);
+  assert.equal(resolveAiReviewLimit(125, '300'), 125);
+});
+
+test('review limit rejects disabled or malformed hard caps', () => {
+  assert.throws(() => resolveAiReviewLimit(0), /positive integer/);
+  assert.throws(() => resolveAiReviewLimit(undefined, '12.5'), /positive integer/);
+  assert.throws(() => resolveAiReviewLimit(undefined, 'many'), /positive integer/);
+});
+
+test('review cap selects the newest eligible reviews without mutating input', () => {
+  const input = [
+    { id: 'older', date: '2024-01-01' },
+    { id: 'newest', date: '2026-02-01' },
+    { id: 'middle', date: '2025-06-01' },
+  ];
+
+  const result = selectMostRecentReviews(input, (review) => review.date, 2);
+
+  assert.deepEqual(result.reviews.map((review) => review.id), ['newest', 'middle']);
+  assert.deepEqual(input.map((review) => review.id), ['older', 'newest', 'middle']);
+  assert.deepEqual(
+    {
+      eligibleCount: result.eligibleCount,
+      includedCount: result.includedCount,
+      limit: result.limit,
+      capped: result.capped,
+    },
+    {
+      eligibleCount: 3,
+      includedCount: 2,
+      limit: 2,
+      capped: true,
+    },
+  );
+});
+
+test('runAnalyze applies the cap after filtering and only formats selected reviews', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'review-cap-test-'));
+  const reviewsFile = path.join(tempDir, 'reviews.json');
+  const currentYear = new Date().getFullYear();
+  fs.writeFileSync(
+    reviewsFile,
+    JSON.stringify({
+      input_file: 'test',
+      scraped_at: '2026-07-23T00:00:00.000Z',
+      total_reviews: 5,
+      properties_processed: ['listing'],
+      reviews: [
+        {
+          review_date: `${currentYear - 4}-01-01`,
+          review_text: 'EXPIRED review should be removed before applying the cap.',
+          rating: 5,
+          language: 'en',
+        },
+        {
+          review_date: `${currentYear - 3}-01-01`,
+          review_text: 'OLDEST review should not reach the prompt.',
+          rating: 5,
+          language: 'en',
+        },
+        {
+          review_date: `${currentYear - 1}-01-01`,
+          review_text: 'MIDDLE review should reach the prompt.',
+          rating: 5,
+          language: 'en',
+        },
+        {
+          review_date: `${currentYear}-01-01`,
+          review_text: 'NEWEST review should reach the prompt.',
+          rating: 5,
+          language: 'en',
+        },
+        {
+          review_date: `${currentYear}-02-01`,
+          review_text: '',
+          rating: 5,
+          language: 'en',
+        },
+      ],
+    }),
+  );
+
+  const stdout: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (...args: unknown[]) => {
+    stdout.push(args.join(' '));
+  };
+  console.error = () => {};
+
+  try {
+    const result = await runAnalyze({
+      reviewsFile,
+      dryRun: true,
+      model: 'gpt-4o-mini',
+      maxReviews: 2,
+    });
+
+    assert.deepEqual(result.reviewSelection, {
+      eligibleCount: 3,
+      includedCount: 2,
+      limit: 2,
+      capped: true,
+    });
+    assert.match(stdout.join('\n'), /MIDDLE review/);
+    assert.match(stdout.join('\n'), /NEWEST review/);
+    assert.doesNotMatch(stdout.join('\n'), /OLDEST review/);
+    assert.doesNotMatch(stdout.join('\n'), /EXPIRED review/);
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('AI job budget has a safe default and supports an explicit opt-out', () => {
+  assert.equal(resolveAiJobBudgetUsd(undefined), DEFAULT_AI_JOB_BUDGET_USD);
+  assert.equal(resolveAiJobBudgetUsd('7.50'), 7.5);
+  assert.equal(resolveAiJobBudgetUsd('off'), null);
+  assert.equal(resolveAiJobBudgetUsd(0), null);
+  assert.throws(() => resolveAiJobBudgetUsd('-1'), /non-negative USD amount/);
+});
+
+test('AI job budget stops at the limit and reports actual persisted spend', () => {
+  assert.equal(hasReachedAiJobBudget(4.9999, 5), false);
+  assert.equal(hasReachedAiJobBudget(5, 5), true);
+  assert.equal(hasReachedAiJobBudget(500, null), false);
+  assert.equal(
+    buildAiBudgetExceededMessage({ totalCostUsd: 5.1234, budgetUsd: 5 }),
+    'AI cost budget reached: $5.1234 spent against $5.00 limit. '
+      + 'Analysis stopped before the next AI call.',
+  );
+});

--- a/tests/review-job-persistence.test.ts
+++ b/tests/review-job-persistence.test.ts
@@ -4,6 +4,7 @@ import {
   hasPersistedReviewJobResults,
   toReviewJobResponse,
 } from '../web/src/lib/reviewJobs.js';
+import { AI_JOB_BUDGET_ENV } from '../web/src/lib/aiBudget.js';
 
 function makeJob(overrides: Record<string, unknown> = {}) {
   return {
@@ -157,4 +158,51 @@ test('legacy html export availability remains separate from native results readi
 
   assert.equal(response.job.reportReady, false);
   assert.equal(response.job.legacyReportAvailable, true);
+});
+
+test('budget stops are exposed as durable partial results with their configured ceiling', () => {
+  const previousBudget = process.env[AI_JOB_BUDGET_ENV];
+  process.env[AI_JOB_BUDGET_ENV] = '99';
+
+  try {
+    const response = toReviewJobResponse({
+      job: makeJob({
+        analysisStatus: 'partial',
+        analysisCurrentPhase: 'budget-exceeded',
+        analysisErrorMessage: 'Analysis stopped before the next AI call.',
+      }),
+      listings: [makeListing()],
+      events: [
+        {
+          id: 'event_1',
+          jobId: 'job_1',
+          phase: 'analysis',
+          level: 'warning',
+          message: 'Analysis stopped before the next AI call.',
+          payload: {
+            reason: 'ai-cost-budget',
+            budgetUsd: 7.5,
+            totalCostUsd: 7.7,
+          },
+          listingId: null,
+          listingPlatform: null,
+          createdAt: new Date('2026-03-14T00:04:00.000Z'),
+        } as any,
+      ],
+    });
+
+    assert.equal(response.job.reportReady, true);
+    assert.equal(response.job.aiCostBudgetUsd, 7.5);
+    assert.equal(response.job.aiCostBudgetExceeded, true);
+    assert.equal(
+      response.job.analysisErrorMessage,
+      'Analysis stopped before the next AI call.',
+    );
+  } finally {
+    if (previousBudget == null) {
+      delete process.env[AI_JOB_BUDGET_ENV];
+    } else {
+      process.env[AI_JOB_BUDGET_ENV] = previousBudget;
+    }
+  }
 });

--- a/web/README.md
+++ b/web/README.md
@@ -37,6 +37,18 @@ DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/stayreviewr?schema=pu
 REDIS_URL=redis://127.0.0.1:6379
 ```
 
+The analysis cost guardrails are also configured there:
+
+```dotenv
+AI_REVIEW_MAX_REVIEWS=250
+STAYREVIEWR_AI_JOB_BUDGET_USD=5
+```
+
+The first value caps the most recent eligible reviews sent to AI per listing. The second is
+the maximum persisted AI spend per analysis run; use `0` to disable that ceiling. A run that
+reaches the ceiling stops before its next AI call and keeps its completed artifacts as partial
+results.
+
 `web/.env.local` remains supported as a compatibility fallback for direct `web/` commands, but
 the root `.env` takes precedence. Proxy settings also fall back to
 `~/.config/reviewr/.env` created by `reviewr auth`.

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "worker": "dotenv -e ../.env -e .env.local -- tsx src/lib/search-worker.ts",
     "worker:dev": "dotenv -e ../.env -e .env.local -- tsx watch src/lib/search-worker.ts",
     "test:pricing": "tsx --test src/lib/pricing.test.ts",
+    "test:ui": "tsx --test src/components/AiBudgetNotice.test.tsx",
     "lint": "eslint .",
     "db:generate": "dotenv -e ../.env -e .env.local -- prisma generate",
     "db:push": "dotenv -e ../.env -e .env.local -- prisma db push",

--- a/web/src/components/AiBudgetNotice.test.tsx
+++ b/web/src/components/AiBudgetNotice.test.tsx
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import AiBudgetNotice from './AiBudgetNotice.js';
+
+test('budget-exceeded analysis renders its partial status and phase', () => {
+  const html = renderToStaticMarkup(
+    <AiBudgetNotice
+      job={{
+        aiCostBudgetExceeded: true,
+        analysisStatus: 'partial',
+        analysisCurrentPhase: 'budget-exceeded',
+        analysisErrorMessage: 'Analysis stopped before the next AI call.',
+      }}
+    />,
+  );
+
+  assert.match(html, /Analysis stopped at the AI cost limit/);
+  assert.match(html, /Partial/);
+  assert.match(html, /budget-exceeded/);
+  assert.match(html, /Analysis stopped before the next AI call/);
+});
+
+test('budget notice stays hidden when the ceiling did not stop the run', () => {
+  const html = renderToStaticMarkup(
+    <AiBudgetNotice
+      job={{
+        aiCostBudgetExceeded: false,
+        analysisStatus: 'completed',
+        analysisCurrentPhase: 'completed',
+        analysisErrorMessage: null,
+      }}
+    />,
+  );
+
+  assert.equal(html, '');
+});

--- a/web/src/components/AiBudgetNotice.tsx
+++ b/web/src/components/AiBudgetNotice.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import type { ReviewJobState } from '@/types';
+
+interface AiBudgetNoticeProps {
+  job: Pick<
+    ReviewJobState,
+    | 'aiCostBudgetExceeded'
+    | 'analysisCurrentPhase'
+    | 'analysisErrorMessage'
+    | 'analysisStatus'
+  >;
+  variant?: 'job' | 'results';
+  className?: string;
+}
+
+function formatStatus(status: ReviewJobState['analysisStatus']): string {
+  return `${status.slice(0, 1).toUpperCase()}${status.slice(1)}`;
+}
+
+export default function AiBudgetNotice({
+  job,
+  variant = 'job',
+  className = '',
+}: AiBudgetNoticeProps) {
+  if (!job.aiCostBudgetExceeded) {
+    return null;
+  }
+
+  const isResults = variant === 'results';
+
+  return (
+    <div
+      className={`${className} rounded-2xl border border-amber-300/25 bg-amber-300/10 px-4 py-3 text-sm text-amber-100`.trim()}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="font-semibold">
+          {isResults
+            ? 'Partial results — AI cost limit reached'
+            : 'Analysis stopped at the AI cost limit'}
+        </p>
+        <span className="rounded-full border border-amber-200/20 bg-black/10 px-2.5 py-1 text-[11px] font-semibold">
+          {formatStatus(job.analysisStatus)} · {job.analysisCurrentPhase ?? 'budget-exceeded'}
+        </span>
+      </div>
+      <p className="mt-1 text-xs leading-5 text-amber-100/75">
+        {job.analysisErrorMessage
+          ?? (
+            isResults
+              ? 'The completed analysis artifacts are shown below; remaining AI calls were skipped.'
+              : 'Partial results were preserved and no further AI calls were started.'
+          )}
+      </p>
+    </div>
+  );
+}

--- a/web/src/components/JobWorkspace.tsx
+++ b/web/src/components/JobWorkspace.tsx
@@ -14,6 +14,7 @@ import {
   getStoredReviewJobPriceDisplay,
 } from '@/lib/reviewJobClient';
 import { useReviewJobPolling } from '@/hooks/useReviewJobPolling';
+import AiBudgetNotice from './AiBudgetNotice';
 import ResultCard from './ResultCard';
 
 const JobMap = dynamic(() => import('./JobMap'), {
@@ -505,6 +506,17 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
                     AI cost: {formatUsdCost(data.job.costs.totalUsd)}
                   </span>
                 )}
+                {data.job.aiCostBudgetUsd != null && (
+                  <span
+                    className={`rounded-full border px-3 py-1.5 ${
+                      data.job.aiCostBudgetExceeded
+                        ? 'border-amber-300/25 bg-amber-300/10 text-amber-100'
+                        : 'border-white/10 bg-white/[0.03]'
+                    }`}
+                  >
+                    AI budget: {formatUsdCost(data.job.aiCostBudgetUsd)}
+                  </span>
+                )}
               </div>
               {(data.job.status === 'pending' || data.job.status === 'running') && (
                 <div className="mt-4">
@@ -617,6 +629,8 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
               )}
             </div>
           </div>
+
+          <AiBudgetNotice job={data.job} />
 
           <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">

--- a/web/src/components/ResultsWorkspace.tsx
+++ b/web/src/components/ResultsWorkspace.tsx
@@ -28,6 +28,7 @@ import {
 import { useReviewJobPolling } from '@/hooks/useReviewJobPolling';
 import PlatformBadge from './PlatformBadge';
 import ResultsJobMap from './ResultsJobMap';
+import AiBudgetNotice from './AiBudgetNotice';
 
 const MIN_MAP_HEIGHT = 280;
 const TIER_ORDER = ['top_pick', 'shortlist', 'consider', 'unlikely', 'no_go'] as const;
@@ -1767,6 +1768,8 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
               </div>
             </div>
           </div>
+
+          <AiBudgetNotice job={data.job} variant="results" className="mt-4" />
 
           <div className="mt-5 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">

--- a/web/src/lib/aiBudget.ts
+++ b/web/src/lib/aiBudget.ts
@@ -1,0 +1,63 @@
+export const AI_JOB_BUDGET_ENV = 'STAYREVIEWR_AI_JOB_BUDGET_USD';
+export const DEFAULT_AI_JOB_BUDGET_USD = 5;
+
+export type AiBudgetPhase = 'ai-reviews' | 'ai-photos' | 'triage';
+
+export function resolveAiJobBudgetUsd(
+  rawValue: string | number | null | undefined = process.env[AI_JOB_BUDGET_ENV],
+): number | null {
+  if (rawValue == null || rawValue === '') {
+    return DEFAULT_AI_JOB_BUDGET_USD;
+  }
+
+  if (
+    typeof rawValue === 'string'
+    && ['off', 'none', 'disabled'].includes(rawValue.trim().toLowerCase())
+  ) {
+    return null;
+  }
+
+  const parsed = typeof rawValue === 'number' ? rawValue : Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(
+      `${AI_JOB_BUDGET_ENV} must be a non-negative USD amount or "off"; received "${rawValue}"`,
+    );
+  }
+
+  return parsed === 0 ? null : parsed;
+}
+
+export function hasReachedAiJobBudget(
+  totalCostUsd: number,
+  budgetUsd: number | null,
+): boolean {
+  return budgetUsd != null && totalCostUsd >= budgetUsd;
+}
+
+export function buildAiBudgetExceededMessage(input: {
+  totalCostUsd: number;
+  budgetUsd: number;
+}): string {
+  return (
+    `AI cost budget reached: $${input.totalCostUsd.toFixed(4)} spent against `
+    + `$${input.budgetUsd.toFixed(2)} limit. Analysis stopped before the next AI call.`
+  );
+}
+
+export class AiJobBudgetExceededError extends Error {
+  readonly totalCostUsd: number;
+  readonly budgetUsd: number;
+  readonly phase: AiBudgetPhase;
+
+  constructor(input: {
+    totalCostUsd: number;
+    budgetUsd: number;
+    phase: AiBudgetPhase;
+  }) {
+    super(buildAiBudgetExceededMessage(input));
+    this.name = 'AiJobBudgetExceededError';
+    this.totalCostUsd = input.totalCostUsd;
+    this.budgetUsd = input.budgetUsd;
+    this.phase = input.phase;
+  }
+}

--- a/web/src/lib/reviewJobs.ts
+++ b/web/src/lib/reviewJobs.ts
@@ -28,6 +28,7 @@ import {
   parseStoredBoundingBox,
 } from './searchJobs.js';
 import { buildAiCostBreakdown } from './aiCosts.js';
+import { resolveAiJobBudgetUsd } from './aiBudget.js';
 
 const EARTH_RADIUS_METERS = 6371000;
 
@@ -73,6 +74,37 @@ function asJsonObject(value: Prisma.JsonValue | null): Record<string, unknown> |
   }
 
   return value as Record<string, unknown>;
+}
+
+function getPersistedReviewJobAiBudgetUsd(
+  events: ReviewJobEventModel[],
+): number | null | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const payload = asJsonObject(events[index].payload);
+    if (!payload) {
+      continue;
+    }
+
+    if (payload.reason === 'ai-cost-budget') {
+      const exceededBudget = asNumber(payload.budgetUsd);
+      if (exceededBudget != null) {
+        return exceededBudget;
+      }
+    }
+
+    if (Object.hasOwn(payload, 'aiBudgetUsd')) {
+      if (payload.aiBudgetUsd === null) {
+        return null;
+      }
+
+      const startedBudget = asNumber(payload.aiBudgetUsd);
+      if (startedBudget != null) {
+        return startedBudget;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function asSearchPricing(value: unknown): SearchPricing | null {
@@ -324,6 +356,7 @@ export function toReviewJobState(
     resultsReady?: boolean;
     legacyReportAvailable?: boolean;
     viewerCanEdit?: boolean;
+    aiCostBudgetUsd?: number | null;
   } = {},
 ): ReviewJobState {
   return {
@@ -364,6 +397,11 @@ export function toReviewJobState(
       triageCostUsd: job.triageCostUsd,
       totalAiCostUsd: job.totalAiCostUsd,
     }),
+    aiCostBudgetUsd:
+      options.aiCostBudgetUsd !== undefined
+        ? options.aiCostBudgetUsd
+        : resolveAiJobBudgetUsd(),
+    aiCostBudgetExceeded: job.analysisCurrentPhase === 'budget-exceeded',
     durationMs: job.durationMs ?? null,
     startedAt: job.startedAt?.toISOString() ?? null,
     completedAt: job.completedAt?.toISOString() ?? null,
@@ -393,12 +431,14 @@ export function toReviewJobResponse(input: {
   viewerCanEdit?: boolean;
 }): ReviewJobResponse {
   const resultsReady = hasPersistedReviewJobResults(input.job);
+  const persistedAiBudgetUsd = getPersistedReviewJobAiBudgetUsd(input.events);
 
   return {
     job: toReviewJobState(input.job, {
       resultsReady,
       legacyReportAvailable: !!input.job.reportPath,
       viewerCanEdit: input.viewerCanEdit,
+      aiCostBudgetUsd: persistedAiBudgetUsd,
     }),
     listings: input.listings.map(toWebReviewJobListing),
     events: input.events.map(toReviewJobEvent),

--- a/web/src/lib/search-worker.ts
+++ b/web/src/lib/search-worker.ts
@@ -47,6 +47,11 @@ import {
 } from './reviewJobSearch.js';
 import { createSearchLogger } from './searchLog.js';
 import { buildAiCostBreakdown } from './aiCosts.js';
+import {
+  AiJobBudgetExceededError,
+  hasReachedAiJobBudget,
+  resolveAiJobBudgetUsd,
+} from './aiBudget.js';
 import type {
   SearchResult,
 } from '../types.js';
@@ -751,12 +756,14 @@ function getManifestEntryAiCostFields(entry: PersistableManifestEntry) {
 async function getAggregatedReviewJobAiCostFields(
   tx: Prisma.TransactionClient,
   reviewJobId: string,
+  jobListingIds?: string[],
 ) {
   const aggregate = await tx.reviewJobListingAnalysis.aggregate({
     where: {
       jobListing: {
         jobId: reviewJobId,
         hidden: false,
+        ...(jobListingIds ? { id: { in: jobListingIds } } : {}),
       },
     },
     _sum: {
@@ -780,6 +787,47 @@ async function getAggregatedReviewJobAiCostFields(
     triageCostUsd: costs.triageUsd,
     totalAiCostUsd: costs.totalUsd,
   };
+}
+
+async function resetReviewJobListingAnalyses(
+  tx: Prisma.TransactionClient,
+  jobListingIds: string[],
+) {
+  if (jobListingIds.length === 0) {
+    return;
+  }
+
+  await tx.reviewJobListingAnalysis.updateMany({
+    where: {
+      jobListingId: {
+        in: jobListingIds,
+      },
+    },
+    data: {
+      status: 'pending',
+      currentPhase: 'pending',
+      errorMessage: null,
+      startedAt: null,
+      completedAt: null,
+      durationMs: null,
+      detailsStatus: 'pending',
+      reviewsStatus: 'pending',
+      photosStatus: 'pending',
+      aiReviewsStatus: 'pending',
+      aiPhotosStatus: 'pending',
+      triageStatus: 'pending',
+      details: Prisma.DbNull,
+      aiReviews: Prisma.DbNull,
+      aiPhotos: Prisma.DbNull,
+      triage: Prisma.DbNull,
+      reviewCount: null,
+      photoCount: null,
+      aiReviewsCostUsd: 0,
+      aiPhotosCostUsd: 0,
+      triageCostUsd: 0,
+      totalAiCostUsd: 0,
+    },
+  });
 }
 
 function readArtifactJson(
@@ -1030,6 +1078,7 @@ async function runReviewJobAnalysis(reviewJobId: string) {
     },
   });
   const analysisModel = process.env.LLM_MODEL || 'gemini-3-flash-preview:high';
+  const aiBudgetUsd = resolveAiJobBudgetUsd();
   const poi = asStoredMapPoint(jobRecord.poi);
   const activeListingByKey = new Map(
     activeListings.map((listing) => [
@@ -1068,6 +1117,12 @@ async function runReviewJobAnalysis(reviewJobId: string) {
       .filter((listing) => !listing.selected)
       .map((listing) => listing.id)
     : [];
+  let persistedAiCosts = {
+    aiReviewsCostUsd: 0,
+    aiPhotosCostUsd: 0,
+    triageCostUsd: 0,
+    totalAiCostUsd: 0,
+  };
 
   fs.writeFileSync(
     urlsFilePath,
@@ -1107,6 +1162,10 @@ async function runReviewJobAnalysis(reviewJobId: string) {
         analysisStartedAt: startedAt,
         analysisCompletedAt: null,
         analysisDurationMs: null,
+        aiReviewsCostUsd: 0,
+        aiPhotosCostUsd: 0,
+        triageCostUsd: 0,
+        totalAiCostUsd: 0,
       },
     });
   });
@@ -1119,6 +1178,7 @@ async function runReviewJobAnalysis(reviewJobId: string) {
       listingCount: activeListings.length,
       artifactRoot,
       model: analysisModel,
+      aiBudgetUsd,
     },
   });
 
@@ -1183,6 +1243,32 @@ async function runReviewJobAnalysis(reviewJobId: string) {
             currentPhase: phaseUpdate.phase,
           });
         },
+        onBeforeAiCall: async (checkpoint) => {
+          if (
+            aiBudgetUsd != null
+            && hasReachedAiJobBudget(persistedAiCosts.totalAiCostUsd, aiBudgetUsd)
+          ) {
+            throw new AiJobBudgetExceededError({
+              totalCostUsd: persistedAiCosts.totalAiCostUsd,
+              budgetUsd: aiBudgetUsd,
+              phase: checkpoint.phase,
+            });
+          }
+        },
+        onAiCheckpoint: async () => {
+          persistedAiCosts = await prisma.$transaction(async (tx) => {
+            const costs = await getAggregatedReviewJobAiCostFields(
+              tx,
+              reviewJobId,
+              activeListingIds,
+            );
+            await tx.reviewJob.update({
+              where: { id: reviewJobId },
+              data: costs,
+            });
+            return costs;
+          });
+        },
         onScrapeComplete: async ({ outputDir, manifest }) => {
           injectPoiContextIntoListingArtifacts({
             rootDir: outputDir,
@@ -1240,39 +1326,7 @@ async function runReviewJobAnalysis(reviewJobId: string) {
     const completedAt = new Date();
     let overallStatus: 'completed' | 'partial' | 'failed' = 'completed';
     await prisma.$transaction(async (tx) => {
-      if (inactiveListingIds.length > 0) {
-        await tx.reviewJobListingAnalysis.updateMany({
-          where: {
-            jobListingId: {
-              in: inactiveListingIds,
-            },
-          },
-          data: {
-            status: 'pending',
-            currentPhase: 'pending',
-            errorMessage: null,
-            startedAt: null,
-            completedAt: null,
-            durationMs: null,
-            detailsStatus: 'pending',
-            reviewsStatus: 'pending',
-            photosStatus: 'pending',
-            aiReviewsStatus: 'pending',
-            aiPhotosStatus: 'pending',
-            triageStatus: 'pending',
-            details: Prisma.DbNull,
-            aiReviews: Prisma.DbNull,
-            aiPhotos: Prisma.DbNull,
-            triage: Prisma.DbNull,
-            reviewCount: null,
-            photoCount: null,
-            aiReviewsCostUsd: 0,
-            aiPhotosCostUsd: 0,
-            triageCostUsd: 0,
-            totalAiCostUsd: 0,
-          },
-        });
-      }
+      await resetReviewJobListingAnalyses(tx, inactiveListingIds);
 
       const finalAnalyses = await tx.reviewJobListingAnalysis.findMany({
         where: {
@@ -1325,6 +1379,76 @@ async function runReviewJobAnalysis(reviewJobId: string) {
       `[review-worker] analysis completed ${reviewJobId} with status ${overallStatus}`,
     );
   } catch (error) {
+    if (error instanceof AiJobBudgetExceededError) {
+      const completedAt = new Date();
+
+      await syncReviewJobArtifactsToDb({
+        reviewJobId,
+        artifactRoot,
+        poi,
+      });
+
+      await prisma.$transaction(async (tx) => {
+        await resetReviewJobListingAnalyses(tx, inactiveListingIds);
+        await tx.reviewJobListingAnalysis.updateMany({
+          where: {
+            jobListingId: {
+              in: activeListingIds,
+            },
+            status: {
+              not: 'completed',
+            },
+          },
+          data: {
+            status: 'partial',
+            currentPhase: 'budget-exceeded',
+            errorMessage: error.message,
+            completedAt,
+            durationMs: completedAt.getTime() - startedAt.getTime(),
+          },
+        });
+
+        const aggregatedAiCosts = await getAggregatedReviewJobAiCostFields(
+          tx,
+          reviewJobId,
+          activeListingIds,
+        );
+        await tx.reviewJob.update({
+          where: { id: reviewJobId },
+          data: {
+            status: 'completed',
+            currentPhase: 'results-ready',
+            analysisStatus: 'partial',
+            analysisCurrentPhase: 'budget-exceeded',
+            analysisProgress: getAnalysisPhaseProgress(error.phase),
+            analysisErrorMessage: error.message,
+            analysisCompletedAt: completedAt,
+            analysisDurationMs: completedAt.getTime() - startedAt.getTime(),
+            artifactRoot,
+            reportPath: null,
+            ...aggregatedAiCosts,
+          },
+        });
+        await tx.reviewJobEvent.create({
+          data: buildReviewJobEventData(reviewJobId, {
+            phase: 'analysis',
+            level: 'warning',
+            message: error.message,
+            payload: {
+              reason: 'ai-cost-budget',
+              phase: error.phase,
+              budgetUsd: error.budgetUsd,
+              totalCostUsd: error.totalCostUsd,
+              costs: aggregatedAiCosts,
+            },
+          }),
+        });
+      });
+
+      console.warn(`[review-worker] ${error.message}`);
+      return;
+    }
+
     const message =
       error instanceof Error ? error.message : 'Review job analysis failed';
     const completedAt = new Date();

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -247,6 +247,8 @@ export interface ReviewJobState {
   analysisStartedAt: string | null;
   analysisCompletedAt: string | null;
   costs: AiCostBreakdown;
+  aiCostBudgetUsd: number | null;
+  aiCostBudgetExceeded: boolean;
   durationMs: number | null;
   startedAt: string | null;
   completedAt: string | null;


### PR DESCRIPTION
## Summary

- Cap the most recent post-filter reviews sent to AI at 250 per listing by default in the shared `runAnalyze` path, with `AI_REVIEW_MAX_REVIEWS` and `--max-ai-reviews` overrides.
- Add a $5 default per-run StayReviewr AI budget (`STAYREVIEWR_AI_JOB_BUDGET_USD`; `0` disables it), persist accumulated costs after each paid per-listing AI operation, and stop before the next AI call once the ceiling is reached.
- Preserve completed artifacts as partial results, persist `analysisCurrentPhase = budget-exceeded`, expose the applied run budget in job state, and show the stopped state in both job and results workspaces.
- Document both guardrails and explicitly leave per-listing photo caps out of scope.

## Behavior and impact

The review cap runs after room, date-window, and empty-review filtering, then deterministically selects the newest eligible reviews. CLI options take precedence over the environment.

The worker resets run-level cost counters, checkpoints persisted per-listing costs after review/photo/triage operations, and enforces the budget immediately before the next call. A stopped run remains accessible as durable partial results, with its applied budget recovered from persisted job events so later environment changes do not rewrite historical UI state.

## UI acceptance evidence

`JobWorkspace` renders the shared `AiBudgetNotice`. The render-level UI test asserts that a stopped job visibly contains both `Partial` and `budget-exceeded`, along with the budget-stop explanation. The same notice is reused in `ResultsWorkspace`.

## Validation

- `pnpm test` — 47 passed
- `pnpm run build`
- `pnpm run lint`
- `cd web && npm run test:ui` — 2 passed
- `cd web && npm run test:pricing` — 3 passed
- `cd web && npm run build`
- `cd web && npm run lint`
- CLI help smoke-check for `batch --max-ai-reviews` and `analyze --max-ai-reviews`

No paid AI calls were made during validation.
