### PR TITLE
Harden AI budget parsing on job reads

### DIFF
--- a/tests/review-job-persistence.test.ts
+++ b/tests/review-job-persistence.test.ts
@@ -206,3 +206,38 @@ test('budget stops are exposed as durable partial results with their configured 
     }
   }
 });
+
+test('malformed budget config cannot break job reads and warns once', () => {
+  const previousBudget = process.env[AI_JOB_BUDGET_ENV];
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  process.env[AI_JOB_BUDGET_ENV] = '5 USD';
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.join(' '));
+  };
+
+  try {
+    const first = toReviewJobResponse({
+      job: makeJob(),
+      listings: [makeListing()],
+      events: [],
+    });
+    const second = toReviewJobResponse({
+      job: makeJob(),
+      listings: [makeListing()],
+      events: [],
+    });
+
+    assert.equal(first.job.aiCostBudgetUsd, 5);
+    assert.equal(second.job.aiCostBudgetUsd, 5);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /Using the \$5\.00 default on job read paths/);
+  } finally {
+    console.warn = originalWarn;
+    if (previousBudget == null) {
+      delete process.env[AI_JOB_BUDGET_ENV];
+    } else {
+      process.env[AI_JOB_BUDGET_ENV] = previousBudget;
+    }
+  }
+});

--- a/web/src/lib/aiBudget.ts
+++ b/web/src/lib/aiBudget.ts
@@ -3,6 +3,8 @@ export const DEFAULT_AI_JOB_BUDGET_USD = 5;
 
 export type AiBudgetPhase = 'ai-reviews' | 'ai-photos' | 'triage';
 
+const warnedInvalidReadValues = new Set<string>();
+
 export function resolveAiJobBudgetUsd(
   rawValue: string | number | null | undefined = process.env[AI_JOB_BUDGET_ENV],
 ): number | null {
@@ -25,6 +27,24 @@ export function resolveAiJobBudgetUsd(
   }
 
   return parsed === 0 ? null : parsed;
+}
+
+export function resolveAiJobBudgetUsdForRead(
+  rawValue: string | number | null | undefined = process.env[AI_JOB_BUDGET_ENV],
+): number | null {
+  try {
+    return resolveAiJobBudgetUsd(rawValue);
+  } catch (error) {
+    const warningKey = String(rawValue);
+    if (!warnedInvalidReadValues.has(warningKey)) {
+      warnedInvalidReadValues.add(warningKey);
+      console.warn(
+        `Warning: ${error instanceof Error ? error.message : String(error)}. `
+        + `Using the $${DEFAULT_AI_JOB_BUDGET_USD.toFixed(2)} default on job read paths.`,
+      );
+    }
+    return DEFAULT_AI_JOB_BUDGET_USD;
+  }
 }
 
 export function hasReachedAiJobBudget(

--- a/web/src/lib/reviewJobs.ts
+++ b/web/src/lib/reviewJobs.ts
@@ -28,7 +28,7 @@ import {
   parseStoredBoundingBox,
 } from './searchJobs.js';
 import { buildAiCostBreakdown } from './aiCosts.js';
-import { resolveAiJobBudgetUsd } from './aiBudget.js';
+import { resolveAiJobBudgetUsdForRead } from './aiBudget.js';
 
 const EARTH_RADIUS_METERS = 6371000;
 
@@ -400,7 +400,7 @@ export function toReviewJobState(
     aiCostBudgetUsd:
       options.aiCostBudgetUsd !== undefined
         ? options.aiCostBudgetUsd
-        : resolveAiJobBudgetUsd(),
+        : resolveAiJobBudgetUsdForRead(),
     aiCostBudgetExceeded: job.analysisCurrentPhase === 'budget-exceeded',
     durationMs: job.durationMs ?? null,
     startedAt: job.startedAt?.toISOString() ?? null,


### PR DESCRIPTION
## Summary

- add a read-safe AI budget resolver for job and results responses
- fall back to the existing $5 default when `STAYREVIEWR_AI_JOB_BUDGET_USD` is malformed
- log one warning per malformed value instead of throwing on every API read
- keep `resolveAiJobBudgetUsd()` strict in the worker so malformed configuration still blocks spend-sensitive analysis

## Root cause

`toReviewJobState` called the worker-grade strict parser while serializing every job response. A typo such as `5 USD` therefore turned read-only job and results endpoints into HTTP 500 responses.

## Validation

- regression coverage calls `toReviewJobResponse` twice with `5 USD`, confirms both responses use $5, and confirms only one warning
- strict parser coverage still confirms malformed/negative values throw
- `pnpm test` — 52 passing
- `pnpm run build`
- `pnpm run lint`
- `cd web && npm run build`
- `cd web && npm run lint`
- `cd web && npm run test:pricing` — 3 passing
- `cd web && npm run test:ui` — 2 passing
- `git diff --check`

Closes #34
