### PR TITLE
Harden Booking GraphQL review pagination

### DIFF
--- a/docs/booking.md
+++ b/docs/booking.md
@@ -131,7 +131,9 @@ Duplicate URLs (same hotel_name + country_code) are automatically deduplicated.
 1. Reads all CSV files from `data/booking/input/`
 2. Extracts hotel names and country codes from each URL
 3. Resolves each Booking hotel ID from its page name and country code
-4. Fetches the live review count and paginates the `ReviewList` GraphQL operation, 10 reviews per page with a 0.5s delay
+4. Fetches the live review count and paginates the `ReviewList` GraphQL operation newest-first,
+   10 reviews per page with a 0.5s delay. Pagination stops early if a non-first page has no
+   approved cards, because Booking's advertised count can include filtered cards.
 5. Saves results to JSON in `data/booking/output/`
 6. Skips files that have already been processed
 
@@ -174,6 +176,11 @@ interface Review {
   owner_resp_text: string | null;
 }
 ```
+
+`ReviewList` exposes `helpfulVotesCount` but no unhelpful-vote count. The legacy
+`found_unhelpful` field is therefore retained as an always-`0` compatibility value; it must not
+be interpreted as an observed metric. The `NEWEST_FIRST` sorter was live-probed on 2026-07-23:
+two complete three-page reads returned the same 29 unique IDs in monotonic date order.
 
 ### Error Handling
 
@@ -240,7 +247,8 @@ Before analysis, low-quality reviews are filtered out: reviews with titles <=15 
 - **Temporal Analysis**: Date ranges, years covered, reviews per year
 - **Geographic Data**: Country counts, top 3 review countries by volume
 - **Language Analysis**: Language diversity, top 3 languages
-- **Engagement Metrics**: Helpful votes, owner response rates
+- **Engagement Metrics**: Helpful votes and owner response rates. Unhelpful votes are unavailable
+  from the current GraphQL operation; the raw compatibility column is always `0`.
 
 ### Advanced Business Intelligence Metrics
 

--- a/src/booking/scraper.ts
+++ b/src/booking/scraper.ts
@@ -20,6 +20,7 @@ const BOOKING_GRAPHQL_URL = 'https://www.booking.com/dml/graphql';
 const INPUT_DIR = 'data/booking/input';
 const OUTPUT_DIR = 'data/booking/output';
 const REVIEWS_PER_PAGE = 10;
+const REVIEW_SORTER = 'NEWEST_FIRST';
 
 // Captured from Booking.com's live hotel page on 2026-07-23. Keep these
 // operations explicit: Booking disables GraphQL introspection, while the
@@ -150,6 +151,13 @@ export interface BookingReviewScrapeProgress {
   offset: number;
   maxOffset: number;
   totalReviewsSoFar: number;
+}
+
+export function shouldStopBookingReviewPagination(
+  pageIndex: number,
+  cardCount: number,
+): boolean {
+  return pageIndex > 0 && cardCount === 0;
 }
 
 interface BookingGraphQlResponse<T> {
@@ -384,6 +392,14 @@ export async function scrapeHotelReviews(
         totalReviewsSoFar: allReviews.length,
       });
 
+      if (shouldStopBookingReviewPagination(pageIndex, page.cards.length)) {
+        console.warn(
+          `  Booking returned no approved review cards on page ${pageIndex + 1}; `
+          + 'stopping pagination before the advertised review count.',
+        );
+        break;
+      }
+
       // Be a good internet citizen: add a small delay between requests
       if (pageIndex + 1 < totalPages) {
         await new Promise((resolve) => setTimeout(resolve, 500));
@@ -472,7 +488,9 @@ export function buildBookingReviewListVariables(
       hotelId,
       ufi: 0,
       hotelCountryCode: countryCode,
-      sorter: 'MOST_RELEVANT',
+      // Live-probed on 2026-07-23: unlike relevance ranking, this keeps
+      // offset pages in a deterministic chronological order.
+      sorter: REVIEW_SORTER,
       filters: {
         text: '',
       },
@@ -584,6 +602,8 @@ export function mapBookingReviewCard(card: BookingReviewCard, hotelName: string)
     full_review: fullReview,
     en_full_review: originalLang?.toLowerCase().startsWith('en') ? fullReview : null,
     found_helpful: Number.isFinite(card.helpfulVotesCount) ? Math.max(0, card.helpfulVotesCount as number) : 0,
+    // ReviewList exposes helpfulVotesCount but no corresponding unhelpful count.
+    // Keep the legacy field at 0 for artifact/analytics schema compatibility.
     found_unhelpful: 0,
     owner_resp_text: cleanNullableText(card.partnerReply?.reply),
   };

--- a/tests/booking-review-graphql.test.ts
+++ b/tests/booking-review-graphql.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { buildBookingReviewListVariables, mapBookingReviewCard } from '../src/booking/scraper.js';
+import {
+  buildBookingReviewListVariables,
+  mapBookingReviewCard,
+  shouldStopBookingReviewPagination,
+} from '../src/booking/scraper.js';
 
 test('buildBookingReviewListVariables preserves the captured ReviewList input shape', () => {
   assert.deepEqual(buildBookingReviewListVariables(8_413_015, 'fr', 20), {
@@ -9,7 +13,7 @@ test('buildBookingReviewListVariables preserves the captured ReviewList input sh
       hotelId: 8_413_015,
       ufi: 0,
       hotelCountryCode: 'fr',
-      sorter: 'MOST_RELEVANT',
+      sorter: 'NEWEST_FIRST',
       filters: {
         text: '',
       },
@@ -22,6 +26,13 @@ test('buildBookingReviewListVariables preserves the captured ReviewList input sh
       },
     },
   });
+});
+
+test('empty approved-card pages stop pagination only after the first page', () => {
+  assert.equal(shouldStopBookingReviewPagination(0, 0), false);
+  assert.equal(shouldStopBookingReviewPagination(1, 0), true);
+  assert.equal(shouldStopBookingReviewPagination(50, 0), true);
+  assert.equal(shouldStopBookingReviewPagination(1, 1), false);
 });
 
 test('mapBookingReviewCard preserves the legacy review artifact contract', () => {


### PR DESCRIPTION
## Summary

- switch Booking ReviewList pagination from `MOST_RELEVANT` to the live-supported `NEWEST_FIRST` sorter
- stop after a non-first page returns zero approved cards instead of walking the advertised count
- document that GraphQL exposes helpful votes but not unhelpful votes, so legacy `found_unhelpful` remains a compatibility-only zero
- add focused coverage for the sorter input and empty-page stopping rule

## Live API evidence

Tested `ReviewList` through the configured Evomi proxy on 2026-07-23 against hotel 8413015:

- `NEWEST_FIRST` and `OLDEST_FIRST` both returned `ReviewListFrontendResult`; `NEWEST` and `OLDEST` were rejected
- two full `NEWEST_FIRST` reads across offsets 0/10/20 returned 29/29 cards
- each run had 29 unique review IDs, the sequences were identical, and dates were monotonically newest-first across page boundaries
- a full batch review scrape with this branch fetched 29/29 reviews in 4s through the proxy; the persisted artifact had 29 unique composite reviews and monotonic dates

## Validation

- `pnpm exec tsx --test tests/booking-review-graphql.test.ts` — 4 passing
- `pnpm test` — 52 passing
- `pnpm run build`
- `pnpm run lint`
- `git diff --check`

Closes #29
