### PR TITLE
Backfill historical AI costs from retained manifests

### DIFF
--- a/tests/ai-cost-backfill.test.ts
+++ b/tests/ai-cost-backfill.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildAiCostBackfillPlan,
+  hasZeroAiCosts,
+} from '../web/src/lib/ai-cost-backfill.js';
+
+test('AI cost backfill extracts listing and job totals from manifest phases', () => {
+  const plan = buildAiCostBackfillPlan({
+    version: 2,
+    listings: {
+      'airbnb/123': {
+        platform: 'airbnb',
+        id: '123',
+        aiReviews: { status: 'fetched', cost: 0.01234 },
+        aiPhotos: { status: 'fetched', cost: 0.05678 },
+        triage: { status: 'fetched', cost: 0.00999 },
+      },
+      'booking/example': {
+        platform: 'booking',
+        id: 'example',
+        aiReviews: { status: 'fetched', cost: 0.1 },
+        aiPhotos: { status: 'failed', cost: Number.NaN },
+        triage: { status: 'fetched', cost: 0.2 },
+      },
+      'booking/no-cost': {
+        platform: 'booking',
+        id: 'no-cost',
+        aiReviews: { status: 'skipped' },
+        aiPhotos: { status: 'skipped', cost: -1 },
+        triage: { status: 'skipped' },
+      },
+    },
+  });
+
+  assert.deepEqual(plan.entries, [
+    {
+      manifestKey: 'airbnb/123',
+      platform: 'airbnb',
+      listingId: '123',
+      costs: {
+        aiReviewsCostUsd: 0.0123,
+        aiPhotosCostUsd: 0.0568,
+        triageCostUsd: 0.01,
+        totalAiCostUsd: 0.0791,
+      },
+    },
+    {
+      manifestKey: 'booking/example',
+      platform: 'booking',
+      listingId: 'example',
+      costs: {
+        aiReviewsCostUsd: 0.1,
+        aiPhotosCostUsd: 0,
+        triageCostUsd: 0.2,
+        totalAiCostUsd: 0.3,
+      },
+    },
+  ]);
+  assert.deepEqual(plan.costs, {
+    aiReviewsCostUsd: 0.1123,
+    aiPhotosCostUsd: 0.0568,
+    triageCostUsd: 0.21,
+    totalAiCostUsd: 0.3791,
+  });
+});
+
+test('AI cost backfill rejects malformed manifests and recognizes zero costs', () => {
+  assert.throws(
+    () => buildAiCostBackfillPlan({ version: 2 }),
+    /listings object/,
+  );
+  assert.equal(hasZeroAiCosts({
+    aiReviewsCostUsd: 0,
+    aiPhotosCostUsd: 0,
+    triageCostUsd: 0,
+    totalAiCostUsd: 0,
+  }), true);
+  assert.equal(hasZeroAiCosts({
+    aiReviewsCostUsd: 0,
+    aiPhotosCostUsd: 0.0001,
+    triageCostUsd: 0,
+    totalAiCostUsd: 0.0001,
+  }), false);
+});

--- a/web/README.md
+++ b/web/README.md
@@ -66,3 +66,15 @@ size limit; removing the configured `REVIEWR_CACHE_DIR` is always safe.
 `web/.env.local` remains supported as a compatibility fallback for direct `web/` commands, but
 the root `.env` takes precedence. Proxy settings also fall back to
 `~/.config/reviewr/.env` created by `reviewr auth`.
+
+Historical jobs created before AI cost columns can be inspected and repaired from their retained
+`batch_manifest.json` files:
+
+```bash
+cd web
+npm run backfill:ai-costs             # dry run
+npm run backfill:ai-costs -- --apply  # persist zero-cost jobs only
+```
+
+The one-shot backfill skips jobs that already have costs or lack a readable manifest, updates
+matching per-listing analyses and job totals transactionally, and records an audit event.

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "start": "dotenv -e ../.env -e .env.local -- next start",
     "worker": "dotenv -e ../.env -e .env.local -- tsx src/lib/search-worker.ts",
     "worker:dev": "dotenv -e ../.env -e .env.local -- tsx watch src/lib/search-worker.ts",
+    "backfill:ai-costs": "dotenv -e ../.env -e .env.local -- tsx scripts/backfill-ai-costs.ts",
     "test:pricing": "tsx --test src/lib/pricing.test.ts",
     "test:ui": "tsx --test src/components/AiBudgetNotice.test.tsx",
     "lint": "eslint .",

--- a/web/scripts/backfill-ai-costs.ts
+++ b/web/scripts/backfill-ai-costs.ts
@@ -1,0 +1,218 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { Prisma, PrismaClient } from '@prisma/client';
+import {
+  buildAiCostBackfillPlan,
+  hasZeroAiCosts,
+  type AiCostFields,
+} from '../src/lib/ai-cost-backfill.js';
+
+interface CliOptions {
+  apply: boolean;
+  jobId?: string;
+}
+
+function parseArgs(args: string[]): CliOptions {
+  const options: CliOptions = { apply: false };
+
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    if (argument === '--apply') {
+      options.apply = true;
+    } else if (argument === '--job') {
+      const jobId = args[index + 1];
+      if (!jobId || jobId.startsWith('--')) {
+        throw new Error('--job requires a review-job ID');
+      }
+      options.jobId = jobId;
+      index++;
+    } else if (argument === '--help' || argument === '-h') {
+      console.log(
+        'Usage: npm run backfill:ai-costs -- [--apply] [--job <review-job-id>]\n'
+        + 'Dry-run is the default. Pass --apply to persist manifest-derived costs.',
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  return options;
+}
+
+function readJsonFile(filePath: string): unknown {
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+}
+
+function formatCosts(costs: AiCostFields): string {
+  return (
+    `reviews=$${costs.aiReviewsCostUsd.toFixed(4)}, `
+    + `photos=$${costs.aiPhotosCostUsd.toFixed(4)}, `
+    + `triage=$${costs.triageCostUsd.toFixed(4)}, `
+    + `total=$${costs.totalAiCostUsd.toFixed(4)}`
+  );
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const prisma = new PrismaClient();
+  let eligible = 0;
+  let applied = 0;
+  let skippedExisting = 0;
+  let skippedMissingManifest = 0;
+  let skippedNoCosts = 0;
+
+  try {
+    const jobs = await prisma.reviewJob.findMany({
+      where: {
+        artifactRoot: { not: null },
+        ...(options.jobId ? { id: options.jobId } : {}),
+      },
+      orderBy: { createdAt: 'asc' },
+      include: {
+        listings: {
+          include: {
+            analysis: {
+              select: {
+                id: true,
+                aiReviewsCostUsd: true,
+                aiPhotosCostUsd: true,
+                triageCostUsd: true,
+                totalAiCostUsd: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    console.log(
+      `${options.apply ? 'APPLY' : 'DRY RUN'}: scanning ${jobs.length} review job(s)`,
+    );
+
+    for (const job of jobs) {
+      const currentCosts: AiCostFields = {
+        aiReviewsCostUsd: job.aiReviewsCostUsd,
+        aiPhotosCostUsd: job.aiPhotosCostUsd,
+        triageCostUsd: job.triageCostUsd,
+        totalAiCostUsd: job.totalAiCostUsd,
+      };
+      if (!hasZeroAiCosts(currentCosts)) {
+        skippedExisting++;
+        console.log(`skip ${job.id}: already has costs (${formatCosts(currentCosts)})`);
+        continue;
+      }
+
+      const manifestPath = path.join(job.artifactRoot as string, 'batch_manifest.json');
+      if (!fs.existsSync(manifestPath)) {
+        skippedMissingManifest++;
+        console.warn(`skip ${job.id}: manifest missing at ${manifestPath}`);
+        continue;
+      }
+
+      let plan;
+      try {
+        plan = buildAiCostBackfillPlan(readJsonFile(manifestPath));
+      } catch (error) {
+        skippedMissingManifest++;
+        console.warn(
+          `skip ${job.id}: cannot read manifest (`
+          + `${error instanceof Error ? error.message : String(error)})`,
+        );
+        continue;
+      }
+
+      if (hasZeroAiCosts(plan.costs)) {
+        skippedNoCosts++;
+        console.log(`skip ${job.id}: manifest contains no positive AI costs`);
+        continue;
+      }
+
+      eligible++;
+      const listingByKey = new Map(
+        job.listings.map((listing) => [
+          `${listing.platform}/${listing.listingId}`,
+          listing,
+        ]),
+      );
+      const updates = plan.entries.flatMap((entry) => {
+        const listing = listingByKey.get(`${entry.platform}/${entry.listingId}`);
+        if (!listing?.analysis) {
+          console.warn(
+            `  ${job.id}: no persisted analysis for ${entry.manifestKey}; `
+            + 'job totals will still include its manifest cost',
+          );
+          return [];
+        }
+
+        const existing = listing.analysis;
+        if (!hasZeroAiCosts(existing)) {
+          console.warn(
+            `  ${job.id}: preserving existing listing costs for ${entry.manifestKey}`,
+          );
+          return [];
+        }
+
+        return [{
+          analysisId: existing.id,
+          manifestKey: entry.manifestKey,
+          costs: entry.costs,
+        }];
+      });
+
+      console.log(
+        `${options.apply ? 'apply' : 'would apply'} ${job.id}: `
+        + `${formatCosts(plan.costs)}; ${updates.length}/${plan.entries.length} listing rows`,
+      );
+
+      if (!options.apply) {
+        continue;
+      }
+
+      await prisma.$transaction(async (tx) => {
+        for (const update of updates) {
+          await tx.reviewJobListingAnalysis.update({
+            where: { id: update.analysisId },
+            data: update.costs,
+          });
+        }
+
+        await tx.reviewJob.update({
+          where: { id: job.id },
+          data: plan.costs,
+        });
+        await tx.reviewJobEvent.create({
+          data: {
+            jobId: job.id,
+            phase: 'analysis',
+            level: 'info',
+            message: 'Backfilled historical AI costs from batch manifest',
+            payload: {
+              source: manifestPath,
+              listingRowsUpdated: updates.length,
+              manifestEntriesWithCosts: plan.entries.length,
+              ...plan.costs,
+            } satisfies Prisma.InputJsonObject,
+          },
+        });
+      });
+      applied++;
+    }
+
+    console.log(
+      `Summary: eligible=${eligible}, applied=${applied}, `
+      + `existing=${skippedExisting}, missing_or_invalid_manifest=${skippedMissingManifest}, `
+      + `no_manifest_costs=${skippedNoCosts}`,
+    );
+    if (!options.apply && eligible > 0) {
+      console.log('Dry run only; rerun with --apply to persist these updates.');
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/web/src/lib/ai-cost-backfill.ts
+++ b/web/src/lib/ai-cost-backfill.ts
@@ -1,0 +1,110 @@
+import { buildAiCostBreakdown } from './aiCosts.js';
+
+export interface AiCostFields {
+  aiReviewsCostUsd: number;
+  aiPhotosCostUsd: number;
+  triageCostUsd: number;
+  totalAiCostUsd: number;
+}
+
+export interface AiCostBackfillEntry {
+  manifestKey: string;
+  platform: 'airbnb' | 'booking';
+  listingId: string;
+  costs: AiCostFields;
+}
+
+export interface AiCostBackfillPlan {
+  entries: AiCostBackfillEntry[];
+  costs: AiCostFields;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function readPhaseCost(entry: Record<string, unknown>, phase: string): number {
+  const phaseValue = asRecord(entry[phase]);
+  const cost = phaseValue?.cost;
+  return typeof cost === 'number' && Number.isFinite(cost) && cost > 0 ? cost : 0;
+}
+
+function toCostFields(input: {
+  aiReviewsCostUsd: number;
+  aiPhotosCostUsd: number;
+  triageCostUsd: number;
+}): AiCostFields {
+  const costs = buildAiCostBreakdown(input);
+  return {
+    aiReviewsCostUsd: costs.aiReviewsUsd,
+    aiPhotosCostUsd: costs.aiPhotosUsd,
+    triageCostUsd: costs.triageUsd,
+    totalAiCostUsd: costs.totalUsd,
+  };
+}
+
+export function hasZeroAiCosts(costs: AiCostFields): boolean {
+  return (
+    costs.aiReviewsCostUsd === 0
+    && costs.aiPhotosCostUsd === 0
+    && costs.triageCostUsd === 0
+    && costs.totalAiCostUsd === 0
+  );
+}
+
+export function buildAiCostBackfillPlan(manifestValue: unknown): AiCostBackfillPlan {
+  const manifest = asRecord(manifestValue);
+  const listings = asRecord(manifest?.listings);
+  if (!manifest || !listings) {
+    throw new Error('Manifest must contain a listings object');
+  }
+
+  const entries: AiCostBackfillEntry[] = [];
+  let aiReviewsCostUsd = 0;
+  let aiPhotosCostUsd = 0;
+  let triageCostUsd = 0;
+
+  for (const [manifestKey, value] of Object.entries(listings)) {
+    const entry = asRecord(value);
+    const platform = entry?.platform;
+    const listingId = entry?.id;
+    if (
+      !entry
+      || (platform !== 'airbnb' && platform !== 'booking')
+      || typeof listingId !== 'string'
+      || listingId.length === 0
+    ) {
+      continue;
+    }
+
+    const costs = toCostFields({
+      aiReviewsCostUsd: readPhaseCost(entry, 'aiReviews'),
+      aiPhotosCostUsd: readPhaseCost(entry, 'aiPhotos'),
+      triageCostUsd: readPhaseCost(entry, 'triage'),
+    });
+    if (hasZeroAiCosts(costs)) {
+      continue;
+    }
+
+    entries.push({
+      manifestKey,
+      platform,
+      listingId,
+      costs,
+    });
+    aiReviewsCostUsd += costs.aiReviewsCostUsd;
+    aiPhotosCostUsd += costs.aiPhotosCostUsd;
+    triageCostUsd += costs.triageCostUsd;
+  }
+
+  return {
+    entries,
+    costs: toCostFields({
+      aiReviewsCostUsd,
+      aiPhotosCostUsd,
+      triageCostUsd,
+    }),
+  };
+}


### PR DESCRIPTION
## Summary

- add a dry-run-by-default, one-shot AI cost backfill sourced from retained `batch_manifest.json` files
- update zero-cost job and matching listing-analysis rows transactionally
- preserve any existing nonzero costs and record an audit event for every applied job
- document `npm run backfill:ai-costs` and the explicit `--apply` switch

## Historical-data finding

The live database contains 11 historical jobs with `artifactRoot` values, but all 11 referenced manifests have already been removed from the temporary filesystem. A real dry run therefore made no writes and reported:

```text
Summary: eligible=0, applied=0, existing=0, missing_or_invalid_manifest=11, no_manifest_costs=0
```

The script intentionally does not infer partial totals from persisted review-only metadata. If the original manifests are restored, the same command can backfill them safely.

## Verification

- `pnpm test` — 59 passed
- `pnpm run build`
- `pnpm run lint`
- `npm run test:pricing` — 3 passed
- `npm run test:ui` — 2 passed
- `npm run build` and `npm run lint` in `web/`
- disposable Postgres integration:
  - dry run predicted reviews `$0.0131`, photos `$0.0192`, triage `$0.0087`, total `$0.0410`
  - apply updated 2/2 listing rows plus the job aggregate and audit event
  - a second apply skipped the already-filled job
  - the disposable job was removed and verified absent

Closes #37
