### PR TITLE
Fix Airbnb viewport search retry storm

### DIFF
--- a/src/airbnb/search.ts
+++ b/src/airbnb/search.ts
@@ -1,14 +1,14 @@
 // src/airbnb/search.ts
 //
-// Airbnb listing search via v2 explore_tabs API
-// Primary: v2 explore_tabs (40 results/page, API key only)
-// Fallback: SSR HTML parsing (18-20 results/page, no auth)
+// Airbnb listing search via SSR HTML parsing (18-20 map results/page, no auth)
+//
+// Airbnb's v2 explore_tabs endpoint started returning HTTP 400 for every search
+// in July 2026. Keep viewport search on the server-rendered staysSearch state so
+// it does not need an API key or enter a retry/refresh storm before returning
+// map pins.
 
-import { makeRequest, getApiKey, BROWSER_HEADERS, API_HEADERS } from './scraper.js';
-import {
-  parseAirbnbPricingQuote,
-  parseAirbnbStructuredDisplayPrice,
-} from './pricing.js';
+import { makeRequest, BROWSER_HEADERS } from './scraper.js';
+import { parseAirbnbStructuredDisplayPrice } from './pricing.js';
 import {
   countNewChildIds,
   hasMeaningfulChildGain,
@@ -18,20 +18,11 @@ import {
 } from '../search/adaptive.js';
 import { bboxIntersectsCircle, subdivideBbox } from '../search/geo.js';
 import { filterSearchResults } from '../search/filters.js';
-import type {
-  AirbnbSearchParams,
-  SearchResult,
-  SearchPage,
-  BoundingBox,
-  ProgressCallback,
-} from '../search/types.js';
+import type { AirbnbSearchParams, SearchResult, BoundingBox, ProgressCallback } from '../search/types.js';
 
 const AIRBNB_BASE_URL = 'https://www.airbnb.com';
-const ITEMS_PER_PAGE = 50;
 const PAGE_DELAY_MS = 250;
 const CELL_DELAY_MS = 500;
-const MAX_CONSECUTIVE_ERRORS = 5;
-const ERROR_THRESHOLD_FOR_KEY_REFRESH = 3;
 const AIRBNB_SUBDIVISION_CONFIG: AdaptiveSubdivisionConfig = {
   forceProbeDepth: 2,
   maxDepth: 3,
@@ -41,52 +32,26 @@ const AIRBNB_SUBDIVISION_CONFIG: AdaptiveSubdivisionConfig = {
   minGainRatio: 0.05,
 };
 
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-interface AirbnbCellSearchOutput {
-  cellResults: SearchResult[];
-  apiKey: string;
-  sawRateLimit: boolean;
-  encounteredFatalError: boolean;
-}
+type AirbnbRequest = typeof makeRequest;
 
-// --- v2 explore_tabs (primary) ---
-
-function buildExploreUrl(
-  apiKey: string,
-  params: AirbnbSearchParams,
-  bbox: BoundingBox,
-  offset: number = 0,
-): string {
-  const url = new URL(`${AIRBNB_BASE_URL}/api/v2/explore_tabs`);
-
-  // Map search
+function buildSsrSearchUrl(params: AirbnbSearchParams, bbox: BoundingBox, cursor?: string): string {
+  const url = new URL(`${AIRBNB_BASE_URL}/s/${encodeURIComponent(params.location || 'homes')}/homes`);
+  url.searchParams.set('tab_id', 'home_tab');
+  url.searchParams.set('refinement_paths[]', '/homes');
+  url.searchParams.set('search_type', 'filter_change');
   url.searchParams.set('search_by_map', 'true');
   url.searchParams.set('ne_lat', String(bbox.neLat));
   url.searchParams.set('ne_lng', String(bbox.neLng));
   url.searchParams.set('sw_lat', String(bbox.swLat));
   url.searchParams.set('sw_lng', String(bbox.swLng));
-
-  // Pagination
-  url.searchParams.set('items_per_grid', String(ITEMS_PER_PAGE));
-  url.searchParams.set('items_offset', String(offset));
-  url.searchParams.set('refinement_paths[]', '/homes');
-
-  // Auth
-  url.searchParams.set('key', apiKey);
-
-  // Currency
   url.searchParams.set('currency', params.currency);
+  url.searchParams.set('adults', String(params.adults));
 
-  // Dates
   if (params.checkin) url.searchParams.set('checkin', params.checkin);
   if (params.checkout) url.searchParams.set('checkout', params.checkout);
-
-  // Guests
-  url.searchParams.set('adults', String(params.adults));
   if (params.children) url.searchParams.set('children', String(params.children));
-
-  // Filters
   if (params.priceMin != null) url.searchParams.set('price_min', String(params.priceMin));
   if (params.priceMax != null) url.searchParams.set('price_max', String(params.priceMax));
   if (params.minBedrooms != null) {
@@ -110,205 +75,38 @@ function buildExploreUrl(
   if (params.superhost) url.searchParams.set('superhost', 'true');
   if (params.instantBook) url.searchParams.set('ib', 'true');
 
-  if (params.amenities?.length) {
-    for (const id of params.amenities) {
-      url.searchParams.append('amenities[]', String(id));
-    }
+  for (const amenityId of params.amenities ?? []) {
+    url.searchParams.append('amenities[]', String(amenityId));
   }
+
+  if (cursor) url.searchParams.set('cursor', cursor);
 
   return url.toString();
 }
 
-function parseExploreListing(item: any, params: AirbnbSearchParams): SearchResult | null {
-  const listing = item?.listing;
-  if (!listing) return null;
-
-  // Use id_str to avoid precision issues with large numeric IDs
-  const id = String(listing.id_str || listing.id);
-  if (!id) return null;
-
-  const pricingQuote = item?.pricing_quote;
-  const pricing = parseAirbnbPricingQuote(pricingQuote, params.currency);
-
-  return {
-    id,
-    platform: 'airbnb',
-    name: listing.name || '',
-    url: `${AIRBNB_BASE_URL}/rooms/${id}`,
-    rating: listing.star_rating ?? listing.avg_rating ?? null,
-    reviewCount: listing.reviews_count ?? 0,
-    pricing,
-    coordinates: listing.lat != null && listing.lng != null
-      ? { lat: listing.lat, lng: listing.lng }
-      : null,
-    propertyType: listing.room_type ?? listing.room_type_category ?? null,
-    photoUrl: listing.picture_url ?? listing.picture?.url ?? null,
-    bedrooms: listing.bedrooms ?? undefined,
-    beds: listing.beds ?? undefined,
-    bathrooms: listing.bathrooms ?? undefined,
-    maxGuests: listing.person_capacity ?? listing.guest_label ? parseInt(listing.guest_label) || undefined : undefined,
-    superhost: listing.is_superhost ?? undefined,
-    instantBook: pricingQuote?.can_instant_book ?? undefined,
-    amenityIds: listing.amenity_ids ?? undefined,
-    hostId: listing.user?.id ? String(listing.user.id) : undefined,
-  };
-}
-
-function parseExplorePage(data: any, params: AirbnbSearchParams, pageIndex: number): SearchPage {
-  const sections = data?.explore_tabs?.[0]?.sections || [];
-  const listingsSection = sections.find((s: any) => s.listings);
-  const listings = listingsSection?.listings || [];
-
-  const results: SearchResult[] = [];
-  for (const item of listings) {
-    const parsed = parseExploreListing(item, params);
-    if (parsed) results.push(parsed);
-  }
-
-  const pagination = data?.explore_tabs?.[0]?.pagination_metadata;
-  const hasNextPage = !!(pagination?.has_next_page && listings.length > 0);
-
-  return { results, hasNextPage, pageIndex };
-}
-
-/**
- * Search a single bbox cell via v2 explore_tabs, with pagination
- */
-async function searchAirbnbCell(
-  params: AirbnbSearchParams,
-  bbox: BoundingBox,
-  apiKey: string,
-  maxResults?: number,
-  onProgress?: ProgressCallback,
-): Promise<AirbnbCellSearchOutput> {
-  const cellResults: SearchResult[] = [];
-  const cellSeenIds = new Set<string>();
-  let offset = 0;
-  let pageIndex = 0;
-  let currentKey = apiKey;
-  let consecutiveErrors = 0;
-  let sawRateLimit = false;
-  let encounteredFatalError = false;
-
-  while (true) {
-    const url = buildExploreUrl(currentKey, params, bbox, offset);
-
-    try {
-      const response = await makeRequest(url, {
-        headers: {
-          ...BROWSER_HEADERS,
-          ...API_HEADERS,
-          referer: `${AIRBNB_BASE_URL}/`,
-          'X-Airbnb-API-Key': currentKey,
-          'x-airbnb-api-key': currentKey,
-        },
-      });
-
-      const data = JSON.parse(response.data);
-      const page = parseExplorePage(data, params, pageIndex);
-      const filteredPageResults = filterSearchResults(page.results, params);
-
-      const newCellResults: SearchResult[] = [];
-      for (const result of filteredPageResults) {
-        if (!cellSeenIds.has(result.id)) {
-          cellSeenIds.add(result.id);
-          cellResults.push(result);
-          newCellResults.push(result);
-        }
-      }
-
-      consecutiveErrors = 0;
-
-      if (onProgress) {
-        onProgress({ ...page, results: newCellResults });
-      }
-
-      // Check termination conditions
-      if (!page.hasNextPage) break;
-      if (maxResults && cellResults.length >= maxResults) break;
-
-      offset += ITEMS_PER_PAGE;
-      pageIndex++;
-      await sleep(PAGE_DELAY_MS);
-    } catch (error: any) {
-      encounteredFatalError = true;
-      if (error?.message?.includes('429')) {
-        sawRateLimit = true;
-      }
-      consecutiveErrors++;
-      console.log(`  ❌ Page ${pageIndex} error: ${error.message}`);
-
-      if (consecutiveErrors >= ERROR_THRESHOLD_FOR_KEY_REFRESH) {
-        try {
-          console.log('  🔄 Refreshing API key...');
-          currentKey = await getApiKey();
-          consecutiveErrors = 0;
-          continue;
-        } catch {
-          // Key refresh failed
-        }
-      }
-
-      if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
-        console.log(`  ⚠️  Too many errors (${consecutiveErrors}), stopping cell search`);
-        break;
-      }
-
-      await sleep(1000 * consecutiveErrors);
-    }
-  }
-
-  return {
-    cellResults,
-    apiKey: currentKey,
-    sawRateLimit,
-    encounteredFatalError,
-  };
-}
-
-// --- SSR fallback ---
-
 async function searchAirbnbSSR(
   params: AirbnbSearchParams,
   bbox: BoundingBox,
-  seenIds: Set<string>,
   maxResults?: number,
   onProgress?: ProgressCallback,
+  request: AirbnbRequest = makeRequest,
 ): Promise<SearchResult[]> {
   const results: SearchResult[] = [];
+  const seenIds = new Set<string>();
   let cursor: string | undefined;
   let pageIndex = 0;
 
   while (true) {
-    const url = new URL(`${AIRBNB_BASE_URL}/s/${encodeURIComponent(params.location || 'homes')}/homes`);
-    url.searchParams.set('tab_id', 'home_tab');
-    url.searchParams.set('refinement_paths[]', '/homes');
-    url.searchParams.set('search_type', 'filter_change');
-    url.searchParams.set('search_by_map', 'true');
-    url.searchParams.set('ne_lat', String(bbox.neLat));
-    url.searchParams.set('ne_lng', String(bbox.neLng));
-    url.searchParams.set('sw_lat', String(bbox.swLat));
-    url.searchParams.set('sw_lng', String(bbox.swLng));
-    url.searchParams.set('currency', params.currency);
-
-    if (params.checkin) url.searchParams.set('checkin', params.checkin);
-    if (params.checkout) url.searchParams.set('checkout', params.checkout);
-    if (params.adults) url.searchParams.set('adults', String(params.adults));
-    if (params.priceMin != null) url.searchParams.set('price_min', String(params.priceMin));
-    if (params.priceMax != null) url.searchParams.set('price_max', String(params.priceMax));
-    if (params.minBedrooms != null) {
-      url.searchParams.set('min_bedrooms', String(params.minBedrooms));
-    }
-    if (params.minBeds != null) {
-      url.searchParams.set('min_beds', String(params.minBeds));
-    }
-
-    if (cursor) url.searchParams.set('cursor', cursor);
+    const url = buildSsrSearchUrl(params, bbox, cursor);
 
     try {
-      const response = await makeRequest(url.toString(), {
-        headers: BROWSER_HEADERS,
-      });
+      const response = await request(
+        url,
+        {
+          headers: BROWSER_HEADERS,
+        },
+        1,
+      );
 
       // Extract deferred state JSON from SSR HTML
       const match = response.data.match(/<script\s+id="data-deferred-state-0"[^>]*>([\s\S]*?)<\/script>/);
@@ -356,15 +154,13 @@ async function searchAirbnbSSR(
         seenIds.add(id);
 
         const coord = listing.location?.coordinate || listing.coordinate;
-        const pricing = parseAirbnbStructuredDisplayPrice(
-          item?.structuredDisplayPrice,
-          params.currency,
-        );
+        const pricing = parseAirbnbStructuredDisplayPrice(item?.structuredDisplayPrice, params.currency);
 
         // Check for superhost badge
         const badges = item?.badges || [];
-        const isSuperhost = badges.some((b: any) =>
-          b?.text === 'Superhost' || b?.loggingContext?.badgeType === 'SUPERHOST');
+        const isSuperhost = badges.some(
+          (b: any) => b?.text === 'Superhost' || b?.loggingContext?.badgeType === 'SUPERHOST',
+        );
 
         // Parse rating from "4.93 (177)" format
         let rating: number | null = null;
@@ -442,6 +238,7 @@ async function searchAirbnbSSR(
 export async function searchAirbnb(
   params: AirbnbSearchParams,
   onProgress?: ProgressCallback,
+  request: AirbnbRequest = makeRequest,
 ): Promise<{ results: SearchResult[]; pagesScanned: number }> {
   const bbox = params.boundingBox;
   if (!bbox) throw new Error('Airbnb search requires a bounding box');
@@ -449,17 +246,6 @@ export async function searchAirbnb(
   const seenIds = new Set<string>();
   const allResults: SearchResult[] = [];
   let pagesScanned = 0;
-  let shouldFallbackToSSR = false;
-
-  // Try v2 explore_tabs first
-  let apiKey: string;
-  try {
-    apiKey = await getApiKey();
-  } catch (error: any) {
-    console.log(`⚠️  Could not get API key (${error.message}), falling back to SSR`);
-    const ssrResults = await searchAirbnbSSR(params, bbox, seenIds, params.maxResults, onProgress);
-    return { results: ssrResults, pagesScanned: 0 };
-  }
 
   const progressTracker: ProgressCallback = (page) => {
     pagesScanned++;
@@ -478,38 +264,18 @@ export async function searchAirbnb(
     return newResults;
   };
 
-  let currentKey = apiKey;
-  const markFallbackIfNeeded = (output: AirbnbCellSearchOutput) => {
-    if (
-      allResults.length === 0 &&
-      (output.sawRateLimit || output.encounteredFatalError)
-    ) {
-      shouldFallbackToSSR = true;
-    }
-  };
-
   if (!params.exhaustive) {
     // Quick mode: search the bbox directly
-    console.log(`🔍 Quick search: paginating bbox directly (max ${params.maxResults || 'unlimited'} results)...`);
-    const output = await searchAirbnbCell(
-      params,
-      bbox,
-      currentKey,
-      params.maxResults,
-      progressTracker,
+    console.log(
+      `🔍 Quick Airbnb SSR search: paginating bbox directly (max ${params.maxResults || 'unlimited'} results)...`,
     );
-    currentKey = output.apiKey;
-    addUniqueResults(output.cellResults);
-    markFallbackIfNeeded(output);
+    const results = await searchAirbnbSSR(params, bbox, params.maxResults, progressTracker, request);
+    addUniqueResults(results);
   } else {
-    console.log('🔍 Exhaustive search: adaptive quadrant subdivision...');
+    console.log('🔍 Exhaustive Airbnb SSR search: adaptive quadrant subdivision...');
     let visitedCells = 0;
 
-    const visitCell = async (
-      cell: BoundingBox,
-      depth: number,
-      seededResults?: SearchResult[],
-    ): Promise<void> => {
+    const visitCell = async (cell: BoundingBox, depth: number, seededResults?: SearchResult[]): Promise<void> => {
       visitedCells++;
       const label = `Cell ${visitedCells} (depth ${depth})`;
       console.log(`  📍 ${label}`);
@@ -517,17 +283,9 @@ export async function searchAirbnb(
       let effectiveResults = seededResults ?? [];
 
       if (!seededResults) {
-        const output = await searchAirbnbCell(
-          params,
-          cell,
-          currentKey,
-          undefined,
-          progressTracker,
-        );
-        currentKey = output.apiKey;
-        markFallbackIfNeeded(output);
-        effectiveResults = output.cellResults;
-        addUniqueResults(output.cellResults);
+        const results = await searchAirbnbSSR(params, cell, undefined, progressTracker, request);
+        effectiveResults = results;
+        addUniqueResults(results);
       }
 
       console.log(`    ↳ ${effectiveResults.length} filtered results`);
@@ -558,18 +316,10 @@ export async function searchAirbnb(
 
       for (const child of childCells) {
         await sleep(CELL_DELAY_MS);
-        const output = await searchAirbnbCell(
-          params,
-          child,
-          currentKey,
-          undefined,
-          progressTracker,
-        );
-        currentKey = output.apiKey;
-        markFallbackIfNeeded(output);
-        addUniqueResults(output.cellResults);
-        childSearches.push({ cell: child, results: output.cellResults });
-        for (const result of output.cellResults) {
+        const results = await searchAirbnbSSR(params, child, undefined, progressTracker, request);
+        addUniqueResults(results);
+        childSearches.push({ cell: child, results });
+        for (const result of results) {
           childUnionIds.add(result.id);
         }
         if (params.maxResults && allResults.length >= params.maxResults) {
@@ -609,12 +359,6 @@ export async function searchAirbnb(
     };
 
     await visitCell(bbox, 0, undefined);
-  }
-
-  if (allResults.length === 0 && shouldFallbackToSSR) {
-    console.log('⚠️  Airbnb API search was blocked or rate limited, falling back to SSR map parsing');
-    const ssrResults = await searchAirbnbSSR(params, bbox, seenIds, params.maxResults, progressTracker);
-    allResults.push(...ssrResults);
   }
 
   console.log(`✅ Airbnb search complete: ${allResults.length} unique results, ${pagesScanned} pages scanned`);

--- a/tests/airbnb-search.test.ts
+++ b/tests/airbnb-search.test.ts
@@ -1,0 +1,139 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { searchAirbnb } from '../src/airbnb/search.js';
+import type { SearchPage } from '../src/search/types.js';
+
+function makeSsrSearchHtml(): string {
+  const listingId = Buffer.from('StayListing:123456789').toString('base64');
+  const deferredState = {
+    niobeClientData: [
+      [
+        'StaysSearch',
+        {
+          data: {
+            presentation: {
+              staysSearch: {
+                mapResults: {
+                  mapSearchResults: [
+                    {
+                      demandStayListing: {
+                        id: listingId,
+                        roomType: 'Entire home',
+                        location: {
+                          coordinate: {
+                            latitude: 40.758,
+                            longitude: -73.9855,
+                          },
+                        },
+                      },
+                      title: 'Midtown test stay',
+                      avgRatingLocalized: '4.91 (123)',
+                      contextualPictures: [{ picture: 'https://example.com/listing.jpg' }],
+                      structuredContent: {
+                        primaryLine: [{ body: '2 bedrooms' }, { body: '3 beds' }],
+                      },
+                      badges: [
+                        {
+                          text: 'Superhost',
+                          loggingContext: { badgeType: 'SUPERHOST' },
+                        },
+                      ],
+                    },
+                  ],
+                },
+                results: {
+                  paginationInfo: {
+                    nextPageCursor: null,
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    ],
+  };
+
+  return `<html><script id="data-deferred-state-0">${JSON.stringify(deferredState)}</script></html>`;
+}
+
+test('Airbnb quick search uses SSR staysSearch directly without API-key retries', async () => {
+  const requests: Array<{
+    url: string;
+    maxRetries: number | undefined;
+    headers: Record<string, string> | undefined;
+  }> = [];
+  const pages: SearchPage[] = [];
+
+  const output = await searchAirbnb(
+    {
+      platform: 'airbnb',
+      location: 'New York',
+      boundingBox: {
+        neLat: 40.78,
+        neLng: -73.95,
+        swLat: 40.72,
+        swLng: -74.01,
+      },
+      checkin: '2026-08-21',
+      checkout: '2026-08-23',
+      adults: 2,
+      children: 1,
+      currency: 'USD',
+      priceMin: 100,
+      priceMax: 500,
+      minBedrooms: 2,
+      minBeds: 3,
+      propertyType: 'entire',
+      superhost: true,
+      instantBook: true,
+      amenities: [4, 8],
+      maxResults: 100,
+      exhaustive: false,
+    },
+    (page) => pages.push(page),
+    async (url, options, maxRetries) => {
+      requests.push({
+        url,
+        maxRetries,
+        headers: options?.headers,
+      });
+      return {
+        data: makeSsrSearchHtml(),
+        status: 200,
+        statusText: 'OK',
+      };
+    },
+  );
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].maxRetries, 1);
+  assert.match(requests[0].headers?.Accept ?? '', /^text\/html/);
+
+  const requestUrl = new URL(requests[0].url);
+  assert.equal(requestUrl.origin, 'https://www.airbnb.com');
+  assert.equal(requestUrl.pathname, '/s/New%20York/homes');
+  assert.notEqual(requestUrl.pathname, '/api/v2/explore_tabs');
+  assert.equal(requestUrl.searchParams.get('key'), null);
+  assert.equal(requestUrl.searchParams.get('search_by_map'), 'true');
+  assert.equal(requestUrl.searchParams.get('children'), '1');
+  assert.equal(requestUrl.searchParams.get('room_types[]'), 'Entire home/apt');
+  assert.equal(requestUrl.searchParams.get('superhost'), 'true');
+  assert.equal(requestUrl.searchParams.get('ib'), 'true');
+  assert.deepEqual(requestUrl.searchParams.getAll('amenities[]'), ['4', '8']);
+
+  assert.equal(output.pagesScanned, 1);
+  assert.equal(output.results.length, 1);
+  assert.equal(output.results[0].id, '123456789');
+  assert.equal(output.results[0].rating, 4.91);
+  assert.equal(output.results[0].reviewCount, 123);
+  assert.deepEqual(output.results[0].coordinates, {
+    lat: 40.758,
+    lng: -73.9855,
+  });
+  assert.equal(output.results[0].bedrooms, 2);
+  assert.equal(output.results[0].beds, 3);
+  assert.equal(output.results[0].superhost, true);
+  assert.equal(pages.length, 1);
+  assert.equal(pages[0].results.length, 1);
+});


### PR DESCRIPTION
Closes #45.

## Root cause

Airbnb's legacy `GET /api/v2/explore_tabs` path now returns HTTP 400 for every viewport request. The search code treated those failures as retryable at two layers, refreshed the scraped homepage API key, and only then invoked the still-working SSR parser. A single UI search therefore waited minutes for Airbnb even though Booking had already completed.

## What changed

- Promote Airbnb's existing server-rendered `staysSearch` deferred-state parser to the only viewport-search path.
- Remove the dead `explore_tabs` request, API-key bootstrap, key-refresh loop, and nested error backoff from `src/airbnb/search.ts`.
- Keep quick-search pagination and exhaustive adaptive quadrant subdivision behavior.
- Forward guest and Airbnb filter parameters through the SSR URL.
- Limit each SSR page fetch to one request so an upstream failure returns promptly instead of recreating a retry chain.
- Add a regression test that exercises the public `searchAirbnb` entry point and proves it uses `/s/.../homes`, passes no API key, requests one attempt, parses pin-ready coordinates, and preserves filters.

## Impact

Viewport searches no longer depend on Airbnb homepage API-key scraping and no longer call the retired endpoint. Airbnb results can complete independently in a few seconds, allowing the combined quick-search response to reach the map well inside its 60-second budget.

## Validation

- `pnpm test` — 63/63 passing.
- `pnpm run build` — passing.
- `npm --prefix web run build` — passing.
- Patched direct `searchAirbnb` call using the previously failing New York bbox: 20 results, 20 with coordinates, 1 page, 3.14s.
- Patched combined `/api/quick-search` replay: HTTP 200 in 21.6s; 20 Airbnb + 97 Booking; 117/117 with coordinates.
- Independent exact UI-payload replays by the orchestrator: 15.6s cold (20 Airbnb + 91 Booking) and 6.2s warm (20 Airbnb + 90 Booking), all results with coordinates.
- Patched server logs contain zero `explore_tabs` calls, API-key refreshes, or HTTP 400 retry chains.

The browser extensions were unavailable during final verification, so the last two checks replayed the exact UI request payload at the API boundary and verified every returned result was pin-ready; the draft remains available for the post-merge visual retry on the live `:3000` stack.
