### PR TITLE
Follow Airbnb PDP country-domain handoffs

### DIFF
--- a/src/airbnb/listing.ts
+++ b/src/airbnb/listing.ts
@@ -127,9 +127,34 @@ function stripHtml(html: string): string {
     .trim();
 }
 
-interface AirbnbPdpPageData {
+export interface AirbnbPdpPageData {
   sections: any[];
   metadata: any;
+}
+
+type AirbnbRequest = typeof makeRequest;
+
+const MAX_DOMAIN_SWITCHES = 2;
+
+export function extractAirbnbDomainSwitchOrigin(html: string): string | null {
+  const formAction = html.match(
+    /<form\b[^>]*\baction=["']([^"']+\/v2\/domain_switch\/handoff(?:\?[^"']*)?)["'][^>]*>/i,
+  )?.[1];
+  if (!formAction) {
+    return null;
+  }
+
+  try {
+    const target = new URL(formAction);
+    const isAirbnbHostname = /^www\.airbnb\.[a-z]{2,}(?:\.[a-z]{2,})?$/.test(target.hostname);
+    if (target.protocol !== 'https:' || !isAirbnbHostname || target.pathname !== '/v2/domain_switch/handoff') {
+      return null;
+    }
+
+    return target.origin;
+  } catch {
+    return null;
+  }
 }
 
 export function extractPdpSectionsFromHtml(html: string): AirbnbPdpPageData | null {
@@ -189,24 +214,48 @@ function buildListingPageUrl(
   return url.toString();
 }
 
-async function fetchListingPageData(
+export async function fetchListingPageData(
   roomId: string,
   options?: { checkIn?: string; checkOut?: string; adults?: number },
+  request: AirbnbRequest = makeRequest,
 ): Promise<AirbnbPdpPageData> {
-  const pageUrl = buildListingPageUrl(roomId, options);
-  const response = await makeRequest(pageUrl, {
-    headers: {
-      ...BROWSER_HEADERS,
-      'User-Agent': API_HEADERS['User-Agent'],
-    },
-  });
+  let pageUrl = buildListingPageUrl(roomId, options);
+  const visitedOrigins = new Set<string>();
 
-  const extracted = extractPdpSectionsFromHtml(response.data);
-  if (!extracted) {
-    throw new Error('Could not extract PDP sections from Airbnb listing HTML');
+  for (let attempt = 0; attempt <= MAX_DOMAIN_SWITCHES; attempt++) {
+    const response = await request(pageUrl, {
+      headers: {
+        ...BROWSER_HEADERS,
+        'User-Agent': API_HEADERS['User-Agent'],
+      },
+    });
+
+    const extracted = extractPdpSectionsFromHtml(response.data);
+    if (extracted) {
+      return extracted;
+    }
+
+    // Rotating proxy exits can make airbnb.com return an HTTP-200 auto-submit
+    // handoff page instead of PDP HTML. The localized hostname serves the same
+    // deferred-state payload without requiring the form POST or shared cookies.
+    const targetOrigin = extractAirbnbDomainSwitchOrigin(response.data);
+    const currentUrl = new URL(pageUrl);
+    if (
+      !targetOrigin
+      || targetOrigin === currentUrl.origin
+      || visitedOrigins.has(targetOrigin)
+    ) {
+      break;
+    }
+
+    const targetUrl = new URL(targetOrigin);
+    visitedOrigins.add(currentUrl.origin);
+    currentUrl.hostname = targetUrl.hostname;
+    pageUrl = currentUrl.toString();
+    console.log(`  ↪ Following Airbnb domain handoff to ${targetUrl.hostname} for ${roomId}`);
   }
 
-  return extracted;
+  throw new Error('Could not extract PDP sections from Airbnb listing HTML');
 }
 
 function buildListingDetails(

--- a/tests/airbnb-listing-html.test.ts
+++ b/tests/airbnb-listing-html.test.ts
@@ -1,9 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { extractPdpSectionsFromHtml } from '../src/airbnb/listing.js';
+import {
+  extractAirbnbDomainSwitchOrigin,
+  extractPdpSectionsFromHtml,
+  fetchListingPageData,
+} from '../src/airbnb/listing.js';
 
-test('extractPdpSectionsFromHtml reads PDP sections from niobeClientData script blocks', () => {
-  const html = `
+function makePdpHtml(): string {
+  return `
     <html>
       <body>
         <script type="application/json">
@@ -48,7 +52,10 @@ test('extractPdpSectionsFromHtml reads PDP sections from niobeClientData script 
       </body>
     </html>
   `;
+}
 
+test('extractPdpSectionsFromHtml reads PDP sections from niobeClientData script blocks', () => {
+  const html = makePdpHtml();
   const extracted = extractPdpSectionsFromHtml(html);
   assert.ok(extracted);
   assert.equal(extracted.sections.length, 2);
@@ -59,4 +66,98 @@ test('extractPdpSectionsFromHtml reads PDP sections from niobeClientData script 
 test('extractPdpSectionsFromHtml returns null when niobe PDP data is absent', () => {
   const html = '<html><body><script type="application/json">{"hello":"world"}</script></body></html>';
   assert.equal(extractPdpSectionsFromHtml(html), null);
+});
+
+test('extractAirbnbDomainSwitchOrigin accepts localized Airbnb handoffs', () => {
+  const html = `
+    <html>
+      <body>
+        <form method="POST" action="https://www.airbnb.co.za/v2/domain_switch/handoff">
+          <input type="hidden" name="version" value="1">
+        </form>
+      </body>
+    </html>
+  `;
+
+  assert.equal(extractAirbnbDomainSwitchOrigin(html), 'https://www.airbnb.co.za');
+});
+
+test('extractAirbnbDomainSwitchOrigin rejects untrusted handoff targets', () => {
+  const malicious = `
+    <form method="POST" action="https://www.airbnb.co.za.evil.example/v2/domain_switch/handoff">
+    </form>
+  `;
+  const insecure = `
+    <form method="POST" action="http://www.airbnb.co.uk/v2/domain_switch/handoff">
+    </form>
+  `;
+
+  assert.equal(extractAirbnbDomainSwitchOrigin(malicious), null);
+  assert.equal(extractAirbnbDomainSwitchOrigin(insecure), null);
+});
+
+test('fetchListingPageData follows a localized Airbnb domain handoff', async () => {
+  const requestedUrls: string[] = [];
+  const handoffHtml = `
+    <!DOCTYPE html>
+    <html>
+      <head><title>Redirecting to www.airbnb.co.uk</title></head>
+      <body>
+        <form method="POST" action="https://www.airbnb.co.uk/v2/domain_switch/handoff">
+        </form>
+      </body>
+    </html>
+  `;
+
+  const result = await fetchListingPageData(
+    '47045396',
+    {
+      checkIn: '2026-07-29',
+      checkOut: '2026-08-11',
+      adults: 2,
+    },
+    async (url) => {
+      requestedUrls.push(url);
+      return {
+        data: requestedUrls.length === 1 ? handoffHtml : makePdpHtml(),
+        status: 200,
+        statusText: 'OK',
+      };
+    },
+  );
+
+  assert.equal(requestedUrls.length, 2);
+  assert.equal(new URL(requestedUrls[0]).hostname, 'www.airbnb.com');
+  assert.equal(new URL(requestedUrls[1]).hostname, 'www.airbnb.co.uk');
+  assert.equal(new URL(requestedUrls[1]).searchParams.get('check_in'), '2026-07-29');
+  assert.equal(new URL(requestedUrls[1]).searchParams.get('check_out'), '2026-08-11');
+  assert.equal(new URL(requestedUrls[1]).searchParams.get('adults'), '2');
+  assert.equal(result.sections.length, 2);
+  assert.equal(result.metadata.pageTitle, 'Test Airbnb Listing page');
+});
+
+test('fetchListingPageData stops a domain handoff loop', async () => {
+  const requestedHosts: string[] = [];
+
+  await assert.rejects(
+    fetchListingPageData('47045396', undefined, async (url) => {
+      const requestedHost = new URL(url).hostname;
+      requestedHosts.push(requestedHost);
+      const targetHost = requestedHost === 'www.airbnb.com' ? 'www.airbnb.co.uk' : 'www.airbnb.com';
+
+      return {
+        data: `
+          <form
+            method="POST"
+            action="https://${targetHost}/v2/domain_switch/handoff"
+          ></form>
+        `,
+        status: 200,
+        statusText: 'OK',
+      };
+    }),
+    /Could not extract PDP sections/,
+  );
+
+  assert.deepEqual(requestedHosts, ['www.airbnb.com', 'www.airbnb.co.uk']);
 });


### PR DESCRIPTION
Closes #48.

## Root cause

This is not a new `StaysPdpSections` JSON shape. With the rotating proxy, `www.airbnb.com/rooms/...` intermittently returns an HTTP-200 auto-submit page titled `Redirecting to www.airbnb.<country>` instead of PDP HTML. The current HTML parser correctly finds no deferred state, then the legacy GraphQL fallback returns HTTP 400 / `Sorry, something went wrong.`

The behavior is proxy-exit-dependent rather than listing-dependent: during reproduction all five reported failures later served normal PDP HTML, while reported control `47045396` received the bad handoff page. Live handoff targets observed were `airbnb.co.za`, `airbnb.co.uk`, and `airbnb.ca`.

## What changed

- Detect Airbnb's `/v2/domain_switch/handoff` auto-submit response.
- Validate that the target is HTTPS and an exact localized `www.airbnb.<tld>` hostname before following it.
- Retry the same room URL on the localized hostname while preserving check-in, check-out, and adults.
- Bound retries to two domain switches and track visited origins to stop loops.
- Keep the GraphQL path as the fallback for genuinely missing PDP data.
- Add regression coverage for valid handoffs, untrusted targets, localized-host retry behavior, query preservation, and handoff loops.

## Validation

- `pnpm test` — 67/67 passing.
- `pnpm run build` — passing.
- `npm --prefix web run build` — passing.
- Two live isolated passes over all five failing IDs and all three controls: 16/16 details fetches succeeded.
- Those passes exercised real handoffs to `airbnb.co.uk` and `airbnb.ca`; an earlier capture reproduced `airbnb.co.za` and confirmed the localized request returned normal PDP deferred state.
- All five former failures saved detail JSON in an isolated output tree with coordinates and 10, 14, 21, 18, and 31 photos respectively.
- The running `:3000` web/worker stack, live database, and shared artifact cache were not touched.

After merge, the orchestrator will coordinate the worker restart and rerun so successful details cache-hit and only the prior failures refetch.
