### PR TITLE
Harden Booking ReviewList retries and failure persistence

### DIFF
--- a/src/batch.ts
+++ b/src/batch.ts
@@ -162,6 +162,10 @@ export interface BatchResult {
   totalTimeMs: number;
 }
 
+export interface BatchDependencies {
+  scrapeBookingHotelReviews?: typeof bookingScraper.scrapeHotelReviews;
+}
+
 // --- Helpers ---
 
 function formatDuration(ms: number): string {
@@ -603,8 +607,14 @@ function buildReviewProgressPayload(input: {
 
 // --- Main batch function ---
 
-export async function runBatch(filePaths: string[], options: BatchOptions): Promise<BatchResult> {
+export async function runBatch(
+  filePaths: string[],
+  options: BatchOptions,
+  dependencies: BatchDependencies = {},
+): Promise<BatchResult> {
   const startTime = Date.now();
+  const scrapeBookingHotelReviews =
+    dependencies.scrapeBookingHotelReviews || bookingScraper.scrapeHotelReviews;
   const manifestPath = getManifestPath(options);
   let artifactCache: ArtifactCache | null = options.artifactCache ?? null;
   if (options.artifactCache === undefined) {
@@ -1390,7 +1400,7 @@ export async function runBatch(filePaths: string[], options: BatchOptions): Prom
           } else {
             const t = Date.now();
             try {
-              const reviews = await bookingScraper.scrapeHotelReviews(
+              const reviews = await scrapeBookingHotelReviews(
                 hotelInfo,
                 async (progress) => {
                   if (!shouldEmitReviewProgressEvent(progress)) {
@@ -2206,7 +2216,7 @@ export async function runBatch(filePaths: string[], options: BatchOptions): Prom
       message: `${failureCount} listing${failureCount > 1 ? 's' : ''} with failures \u2014 auto-retrying`,
       payload: { failureCount },
     });
-    await runBatch([], { ...options, retryFailed: true });
+    await runBatch([], { ...options, retryFailed: true }, dependencies);
   } else if (failureCount > 0) {
     console.log(`  ${failureCount} listing${failureCount > 1 ? 's' : ''} still failing \u2014 retry with: reviewr batch ${manifestPath} --retry`);
   }

--- a/src/booking/scraper.ts
+++ b/src/booking/scraper.ts
@@ -22,6 +22,7 @@ const INPUT_DIR = 'data/booking/input';
 const OUTPUT_DIR = 'data/booking/output';
 const REVIEWS_PER_PAGE = 10;
 const REVIEW_SORTER = 'NEWEST_FIRST';
+const GRAPHQL_INVALID_JSON_ATTEMPTS = 5;
 
 // Captured from Booking.com's live hotel page on 2026-07-23. Keep these
 // operations explicit: Booking disables GraphQL introspection, while the
@@ -153,6 +154,29 @@ export interface BookingReviewScrapeProgress {
   offset: number;
   maxOffset: number;
   totalReviewsSoFar: number;
+}
+
+export interface BookingReviewPage {
+  cards: BookingReviewCard[];
+  reviewsCount: number;
+}
+
+export type BookingHttpRequest = (
+  url: string,
+  maxRetries?: number,
+  init?: RequestInit,
+) => Promise<{ data: string; status: number; statusText: string }>;
+
+export interface BookingGraphQlRequestDependencies {
+  request?: BookingHttpRequest;
+  sleep?: (delayMs: number) => Promise<void>;
+  maxInvalidJsonAttempts?: number;
+}
+
+export interface BookingReviewScrapeDependencies {
+  resolveHotelId?: (hotelInfo: HotelInfo) => Promise<number>;
+  fetchPage?: (hotelId: number, countryCode: string, skip: number) => Promise<BookingReviewPage>;
+  sleep?: (delayMs: number) => Promise<void>;
 }
 
 export function shouldStopBookingReviewPagination(
@@ -358,12 +382,16 @@ function outputFileExists(inputFileName: string, outputDir: string = OUTPUT_DIR)
 export async function scrapeHotelReviews(
   hotelInfo: HotelInfo,
   onProgress?: (progress: BookingReviewScrapeProgress) => void | Promise<void>,
+  dependencies: BookingReviewScrapeDependencies = {},
 ): Promise<Review[]> {
   console.log(`Starting scraper for hotel: ${hotelInfo.hotel_name} (${hotelInfo.country_code})...`);
 
   try {
-    const hotelId = await resolveBookingHotelId(hotelInfo);
-    const firstPage = await fetchReviewPage(hotelId, hotelInfo.country_code, 0);
+    const resolveHotelId = dependencies.resolveHotelId || resolveBookingHotelId;
+    const fetchPage = dependencies.fetchPage || fetchReviewPage;
+    const sleep = dependencies.sleep || ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)));
+    const hotelId = await resolveHotelId(hotelInfo);
+    const firstPage = await fetchPage(hotelId, hotelInfo.country_code, 0);
     const totalReviews = Math.max(firstPage.reviewsCount, firstPage.cards.length);
     const totalPages = Math.max(1, Math.ceil(totalReviews / REVIEWS_PER_PAGE));
     const maxOffset = (totalPages - 1) * REVIEWS_PER_PAGE;
@@ -376,7 +404,7 @@ export async function scrapeHotelReviews(
       const offset = pageIndex * REVIEWS_PER_PAGE;
       console.log(`  Scraping page: ${pageIndex + 1}/${totalPages}...`);
 
-      const page = pageIndex === 0 ? firstPage : await fetchReviewPage(hotelId, hotelInfo.country_code, offset);
+      const page = pageIndex === 0 ? firstPage : await fetchPage(hotelId, hotelInfo.country_code, offset);
 
       for (const card of page.cards) {
         const reviewId = card.reviewUrl || null;
@@ -407,24 +435,51 @@ export async function scrapeHotelReviews(
 
       // Be a good internet citizen: add a small delay between requests
       if (pageIndex + 1 < totalPages) {
-        await new Promise((resolve) => setTimeout(resolve, 500));
+        await sleep(500);
       }
+    }
+
+    if (totalReviews > 0 && allReviews.length === 0) {
+      throw new Error(
+        `Booking advertised ${totalReviews} reviews for ${hotelInfo.hotel_name} `
+        + 'but returned no approved review cards',
+      );
     }
 
     console.log(`  ✅ Scraped ${allReviews.length} reviews for ${hotelInfo.hotel_name}`);
     return allReviews;
   } catch (error) {
     console.error(`Error scraping hotel ${hotelInfo.hotel_name}:`, error);
-    return [];
+    throw error;
   }
 }
 
-async function makeBookingGraphQlRequest<T>(
+function describeBookingNonJsonResponse(body: string): string {
+  const prefix = body.trimStart().slice(0, 4096).toLowerCase();
+  const looksLikeHtml = /^(?:<!doctype\s+html|<html|<head|<body)/.test(prefix);
+  if (!looksLikeHtml) {
+    return 'non-JSON response';
+  }
+
+  const looksLikeChallenge =
+    /aws.?waf|captcha|challenge|verify you are human|access denied|robot check/.test(prefix);
+  return looksLikeChallenge ? 'HTML challenge response' : 'HTML response';
+}
+
+export async function makeBookingGraphQlRequest<T>(
   operationName: string,
   variables: Record<string, unknown>,
   query: string,
+  dependencies: BookingGraphQlRequestDependencies = {},
 ): Promise<T> {
-  const response = await makeRequest(BOOKING_GRAPHQL_URL, 3, {
+  const request = dependencies.request || makeRequest;
+  const sleep = dependencies.sleep || ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)));
+  const requestedAttempts = dependencies.maxInvalidJsonAttempts ?? GRAPHQL_INVALID_JSON_ATTEMPTS;
+  const maxInvalidJsonAttempts =
+    Number.isFinite(requestedAttempts) && requestedAttempts >= 1
+      ? Math.floor(requestedAttempts)
+      : GRAPHQL_INVALID_JSON_ATTEMPTS;
+  const requestInit: RequestInit = {
     method: 'POST',
     headers: {
       Accept: 'application/json',
@@ -436,27 +491,49 @@ async function makeBookingGraphQlRequest<T>(
       extensions: {},
       query,
     }),
-  });
+  };
 
-  let payload: BookingGraphQlResponse<T>;
-  try {
-    payload = JSON.parse(response.data) as BookingGraphQlResponse<T>;
-  } catch {
-    throw new Error(`Booking GraphQL ${operationName} returned invalid JSON`);
+  for (let attempt = 1; attempt <= maxInvalidJsonAttempts; attempt++) {
+    const response = await request(BOOKING_GRAPHQL_URL, 3, requestInit);
+    let payload: BookingGraphQlResponse<T>;
+    try {
+      const parsed = JSON.parse(response.data) as unknown;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('Unexpected JSON payload type');
+      }
+      payload = parsed as BookingGraphQlResponse<T>;
+    } catch {
+      const responseKind = describeBookingNonJsonResponse(response.data);
+      const message =
+        `Booking GraphQL ${operationName} returned invalid JSON (${responseKind})`;
+      if (attempt === maxInvalidJsonAttempts) {
+        throw new Error(`${message} after ${maxInvalidJsonAttempts} attempts`);
+      }
+
+      const delay = Math.min(1000 * Math.pow(2, attempt - 1), 5000);
+      console.warn(
+        `${message}; retrying with a fresh connection `
+        + `(attempt ${attempt}/${maxInvalidJsonAttempts})`,
+      );
+      await sleep(delay);
+      continue;
+    }
+
+    if (payload.errors?.length) {
+      const messages = payload.errors
+        .map((error) => error.message)
+        .filter(Boolean)
+        .join('; ');
+      throw new Error(`Booking GraphQL ${operationName} failed: ${messages || 'unknown error'}`);
+    }
+    if (!payload.data) {
+      throw new Error(`Booking GraphQL ${operationName} returned no data`);
+    }
+
+    return payload.data;
   }
 
-  if (payload.errors?.length) {
-    const messages = payload.errors
-      .map((error) => error.message)
-      .filter(Boolean)
-      .join('; ');
-    throw new Error(`Booking GraphQL ${operationName} failed: ${messages || 'unknown error'}`);
-  }
-  if (!payload.data) {
-    throw new Error(`Booking GraphQL ${operationName} returned no data`);
-  }
-
-  return payload.data;
+  throw new Error(`Booking GraphQL ${operationName} exhausted invalid JSON retries`);
 }
 
 async function resolveBookingHotelId(hotelInfo: HotelInfo): Promise<number> {
@@ -514,7 +591,7 @@ async function fetchReviewPage(
   hotelId: number,
   countryCode: string,
   skip: number,
-): Promise<{ cards: BookingReviewCard[]; reviewsCount: number }> {
+): Promise<BookingReviewPage> {
   const data = await makeBookingGraphQlRequest<ReviewListData>(
     'ReviewList',
     buildBookingReviewListVariables(hotelId, countryCode, skip),

--- a/tests/booking-review-graphql.test.ts
+++ b/tests/booking-review-graphql.test.ts
@@ -1,11 +1,175 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 import {
   buildBookingReviewListVariables,
+  makeBookingGraphQlRequest,
   mapBookingReviewCard,
+  scrapeHotelReviews,
   shouldStopBookingReviewPagination,
 } from '../src/booking/scraper.js';
+import { runBatch } from '../src/batch.js';
+
+test('Booking GraphQL retries an HTTP-200 HTML challenge and recovers', async () => {
+  const responseBodies = [
+    '<!doctype html><html><body>AWS WAF CAPTCHA challenge</body></html>',
+    JSON.stringify({ data: { recovered: true } }),
+  ];
+  const requestedMaxRetries: number[] = [];
+  const delays: number[] = [];
+
+  const data = await makeBookingGraphQlRequest<{ recovered: boolean }>(
+    'ReviewList',
+    { input: { skip: 0 } },
+    'query ReviewList { __typename }',
+    {
+      request: async (_url, maxRetries) => {
+        requestedMaxRetries.push(maxRetries ?? 0);
+        return {
+          data: responseBodies.shift()!,
+          status: 200,
+          statusText: 'OK',
+        };
+      },
+      sleep: async (delayMs) => {
+        delays.push(delayMs);
+      },
+    },
+  );
+
+  assert.deepEqual(data, { recovered: true });
+  assert.deepEqual(requestedMaxRetries, [3, 3]);
+  assert.deepEqual(delays, [1000]);
+});
+
+test('Booking GraphQL bounds invalid-JSON retries', async () => {
+  let requestCount = 0;
+
+  await assert.rejects(
+    makeBookingGraphQlRequest(
+      'ReviewList',
+      { input: { skip: 0 } },
+      'query ReviewList { __typename }',
+      {
+        request: async () => {
+          requestCount++;
+          return {
+            data: '<html><body>Access denied</body></html>',
+            status: 200,
+            statusText: 'OK',
+          };
+        },
+        sleep: async () => {},
+        maxInvalidJsonAttempts: 2,
+      },
+    ),
+    /returned invalid JSON \(HTML challenge response\) after 2 attempts/,
+  );
+
+  assert.equal(requestCount, 2);
+});
+
+test('Booking scraper propagates an exhausted first-page error instead of returning zero reviews', async () => {
+  await assert.rejects(
+    scrapeHotelReviews(
+      {
+        hotel_name: 'example-hotel',
+        country_code: 'us',
+        url: 'https://www.booking.com/hotel/us/example-hotel.en-gb.html',
+      },
+      undefined,
+      {
+        resolveHotelId: async () => 123,
+        fetchPage: async () => {
+          throw new Error('ReviewList page retries exhausted');
+        },
+      },
+    ),
+    /ReviewList page retries exhausted/,
+  );
+});
+
+test('Booking scraper distinguishes a genuine zero-review result from an advertised empty result', async () => {
+  const hotelInfo = {
+    hotel_name: 'example-hotel',
+    country_code: 'us',
+    url: 'https://www.booking.com/hotel/us/example-hotel.en-gb.html',
+  };
+  const resolveHotelId = async () => 123;
+
+  const reviews = await scrapeHotelReviews(hotelInfo, undefined, {
+    resolveHotelId,
+    fetchPage: async () => ({ cards: [], reviewsCount: 0 }),
+  });
+  assert.deepEqual(reviews, []);
+
+  await assert.rejects(
+    scrapeHotelReviews(hotelInfo, undefined, {
+      resolveHotelId,
+      fetchPage: async () => ({ cards: [], reviewsCount: 10 }),
+    }),
+    /advertised 10 reviews.*returned no approved review cards/,
+  );
+});
+
+test('Booking batch records all-pages-errored as failed, never fetched zero', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reviewr-booking-review-error-'));
+  const outputDir = path.join(tempDir, 'output');
+  const urlsFile = path.join(tempDir, 'urls.txt');
+  const hotelName = 'example-hotel';
+  fs.writeFileSync(
+    urlsFile,
+    `https://www.booking.com/hotel/us/${hotelName}.en-gb.html\n`,
+  );
+
+  try {
+    const result = await runBatch(
+      [urlsFile],
+      {
+        fetchDetails: false,
+        fetchReviews: true,
+        fetchPhotos: false,
+        aiReviews: false,
+        aiPhotos: false,
+        triage: false,
+        aiReviewsExplicit: false,
+        aiPhotosExplicit: false,
+        triageExplicit: false,
+        force: false,
+        retryFailed: false,
+        downloadPhotosAll: false,
+        outputDir,
+        print: false,
+        artifactCache: null,
+      },
+      {
+        scrapeBookingHotelReviews: async () => {
+          throw new Error('ReviewList page retries exhausted');
+        },
+      },
+    );
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(outputDir, 'batch_manifest.json'), 'utf-8'),
+    );
+    const reviews = manifest.listings[`booking/${hotelName}`].reviews;
+
+    assert.equal(reviews.status, 'failed');
+    assert.equal(reviews.count, undefined);
+    assert.match(reviews.error, /ReviewList page retries exhausted/);
+    assert.equal(result.booking.reviews.fetched, 0);
+    assert.equal(result.booking.reviews.failed, 1);
+    assert.equal(
+      fs.existsSync(path.join(outputDir, 'reviews', `${hotelName}_reviews.json`)),
+      false,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
 
 test('buildBookingReviewListVariables preserves the captured ReviewList input shape', () => {
   assert.deepEqual(buildBookingReviewListVariables(8_413_015, 'fr', 20), {


### PR DESCRIPTION
Closes #50

## What changed

- Retry HTTP-200 invalid/non-JSON Booking GraphQL responses through up to five fresh proxy connections with bounded exponential backoff.
- Distinguish HTML/WAF-style response bodies in retry logs.
- Propagate exhausted review-page failures instead of converting them to an empty review list.
- Reject advertised nonzero review sets that produce zero approved cards, while preserving genuine zero-review listings.
- Add dependency-injected coverage from the GraphQL request layer through batch manifest persistence, including the automatic retry pass.

## Root cause and impact

`makeRequest` retried transport and non-2xx failures, but Booking sometimes returned a challenge body with HTTP 200. JSON parsing therefore failed outside the retry boundary. `scrapeHotelReviews` then swallowed the terminal error and returned `[]`, allowing the batch layer to emit a zero-review artifact and, when no expected count was available, record a false success that later runs could skip.

After this change, transient challenge responses rotate to a fresh exit. A terminal request failure is persisted as `failed`, with no zero-review artifact, so the normal retry path remains active.

## Validation

- `pnpm run build`
- `pnpm test` — 72/72 passing
- `pnpm run lint`
- `npm run build` in `web/`
- Isolated live Booking scrape through the configured rotating residential proxy:
  - Days Inn Chinatown: 422/422
  - The Nolita Express 1927: 2,286/2,286
  - Untitled at 3 Freeman Alley: 2,080/2,080
  - citizenM New York Bowery: 2,705/2,705
  - Result: 4 fetched, 0 failed in 21m32s; all artifact counts matched array lengths and review identities were unique.
  - The run encountered and recovered multiple real HTTP-200 non-JSON responses plus ordinary transport faults.

The live `:3000` stack, database, active job artifacts, and main worktree were not modified. Local rollout remains deferred until the active analysis run reaches its safe window.
