### PR TITLE
Run the production worker without file watching

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Open <http://localhost:3000>. Press Ctrl-C to stop the app and worker, then run
 `npm run down` when you also want to stop Postgres and Redis. `pnpm run up` and
 `pnpm run down` are equivalent.
 
+The worker in `npm run up` is deliberately non-watching so artifact writes and Git operations
+cannot restart it during paid jobs. After changing worker code, wait for active jobs to finish
+and restart the stack manually. The separate `npm --prefix web run worker:dev` command retains
+watch mode for interactive development.
+
 ## CLI Reference
 
 The `reviewr` CLI can also be used standalone, outside of the AI skill. It auto-detects the platform from the URL.

--- a/scripts/up.mjs
+++ b/scripts/up.mjs
@@ -137,7 +137,9 @@ const stack = spawn(
     'web,worker',
     '--no-color',
     'npm --prefix web run dev',
-    'npm --prefix web run worker:dev',
+    // Paid queue jobs must not be interrupted by filesystem watcher events.
+    // Restart npm run up deliberately after jobs finish to load worker changes.
+    'npm --prefix web run worker',
   ],
   {
     cwd: repoRoot,

--- a/tests/up-runtime.test.ts
+++ b/tests/up-runtime.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const upScriptPath = path.resolve('scripts/up.mjs');
+const webPackagePath = path.resolve('web/package.json');
+const upScript = fs.readFileSync(upScriptPath, 'utf-8');
+const webPackage = JSON.parse(fs.readFileSync(webPackagePath, 'utf-8')) as {
+  scripts: Record<string, string>;
+};
+
+test('one-command startup uses a stable worker while development watch stays opt-in', () => {
+  assert.match(upScript, /'npm --prefix web run worker',/);
+  assert.doesNotMatch(upScript, /'npm --prefix web run worker:dev',/);
+
+  assert.equal(
+    webPackage.scripts.worker,
+    'dotenv -e ../.env -e .env.local -- tsx src/lib/search-worker.ts',
+  );
+  assert.doesNotMatch(webPackage.scripts.worker, /\bwatch\b/);
+  assert.match(webPackage.scripts['worker:dev'], /\btsx watch\b/);
+});

--- a/web/README.md
+++ b/web/README.md
@@ -22,6 +22,12 @@ Chromium when needed, waits for Postgres and Redis to become healthy, synchroniz
 schema, and then runs the Next.js app and BullMQ worker together. Open
 <http://localhost:3000>.
 
+The worker launched by `npm run up` intentionally does not watch the filesystem. Changes under
+`data/`, `web/data/`, logs, caches, or a Git pull cannot restart it in the middle of a queued or
+paid AI job. To load worker code changes, wait for active jobs to finish and deliberately restart
+`npm run up`. Use `npm --prefix web run worker:dev` only for interactive worker development where
+watch-mode restarts are expected.
+
 Press Ctrl-C to stop the app and worker. The data services stay available between runs; stop
 them with:
 


### PR DESCRIPTION
Closes #52

## What changed

- `npm run up` now launches the existing stable `web` worker script (`tsx src/lib/search-worker.ts`) instead of `worker:dev` (`tsx watch`).
- `worker:dev` remains available as the explicit opt-in development watcher.
- Startup docs now state that artifact writes, data-directory changes, logs, caches, and Git operations do not restart the production worker, and that loading worker code requires a deliberate post-job stack restart.
- A regression test verifies the one-command startup path cannot drift back to `worker:dev` while the development script retains watch mode.

## Root cause and impact

The one-command supervisor used the development watcher for a process that executes durable, paid BullMQ jobs. An ambient filesystem event could therefore force-kill the worker mid-call; `concurrently --kill-others` then stopped the web process too. The production path now has no worker file watcher, so filesystem changes cannot interrupt an active job.

## Validation

No `up.mjs`, worker, web server, Docker, Prisma schema command, Redis client, or shared port was launched to validate this patch.

- `node --check scripts/up.mjs`
- `pnpm run build`
- `pnpm test` — 73/73 passing
- `pnpm run lint`
- `npm run build` in `web/`
- DB and Redis URLs were pinned to unreachable port 1 for executable build/test gates.

Runtime acceptance will wait for the orchestrator safe window. A proper lifecycle-aware, stale-PID-safe cross-worktree single-instance startup guard is deliberately separated into #53 rather than adding a naive lockfile here.
