### PR TITLE
Fix CLI batch artifact path resolution

### DIFF
--- a/src/batch.ts
+++ b/src/batch.ts
@@ -51,6 +51,8 @@ export interface BatchOptions {
   retryFailed: boolean;
   downloadPhotosAll: boolean;
   outputDir?: string;
+  /** Keep a normal file-backed run's manifest limited to its current input. */
+  scopeManifestToInput?: boolean;
   print: boolean;
   programmatic?: boolean;
   hooks?: BatchHooks;
@@ -164,6 +166,9 @@ export interface BatchResult {
 
 export interface BatchDependencies {
   scrapeBookingHotelReviews?: typeof bookingScraper.scrapeHotelReviews;
+  runAnalyze?: typeof runAnalyze;
+  runAnalyzePhotos?: typeof runAnalyzePhotos;
+  runTriage?: typeof runTriage;
 }
 
 // --- Helpers ---
@@ -363,6 +368,13 @@ function getManifestPath(options: BatchOptions): string {
   return path.join(baseDir, 'batch_manifest.json');
 }
 
+export function resolveBatchOutputDir(
+  options: Pick<BatchOptions, 'outputDir'>,
+  platform: ManifestEntry['platform'],
+): string {
+  return options.outputDir || path.join('data', platform, 'output');
+}
+
 function loadManifest(manifestPath: string): BatchManifest | null {
   try {
     if (fs.existsSync(manifestPath)) {
@@ -389,6 +401,15 @@ function getPhotosDir(outputDir: string): string { return path.join(outputDir, '
 function getAiReviewsDir(outputDir: string): string { return path.join(outputDir, 'ai-reviews'); }
 function getAiPhotosDir(outputDir: string): string { return path.join(outputDir, 'ai-photos'); }
 function getTriageDir(outputDir: string): string { return path.join(outputDir, 'triage'); }
+
+function hasUsableArtifact(
+  phase: ManifestPhase,
+  location: 'file' | 'dir',
+): boolean {
+  if (!phase[location]) return false;
+  if (phase.status === 'fetched' || phase.status === 'partial') return true;
+  return phase.status === 'skipped' && phase.source === 'local';
+}
 
 /**
  * Migrate v1 manifest to v2:
@@ -433,13 +454,18 @@ function migrateManifestV2(manifest: BatchManifest): BatchManifest {
  * Move files from flat layout to subdirectory layout during v1->v2 migration.
  * Silently skips if source doesn't exist or destination already exists.
  */
-function migrateFilesToSubdirs(outputDir: string, manifest: BatchManifest): void {
+function migrateFilesToSubdirs(
+  options: Pick<BatchOptions, 'outputDir'>,
+  manifest: BatchManifest,
+): void {
   for (const entry of Object.values(manifest.listings)) {
+    const entryOutputDir = resolveBatchOutputDir(options, entry.platform);
+
     // Move listing files
     if (entry.details.file) {
       const basename = path.basename(entry.details.file);
-      const oldPath = path.join(outputDir, basename);
-      const newPath = path.join(outputDir, entry.details.file);
+      const oldPath = path.join(entryOutputDir, basename);
+      const newPath = path.join(entryOutputDir, entry.details.file);
       if (fs.existsSync(oldPath) && !fs.existsSync(newPath)) {
         const dir = path.dirname(newPath);
         if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
@@ -450,8 +476,8 @@ function migrateFilesToSubdirs(outputDir: string, manifest: BatchManifest): void
     // Move review files
     if (entry.reviews.file) {
       const basename = path.basename(entry.reviews.file);
-      const oldPath = path.join(outputDir, basename);
-      const newPath = path.join(outputDir, entry.reviews.file);
+      const oldPath = path.join(entryOutputDir, basename);
+      const newPath = path.join(entryOutputDir, entry.reviews.file);
       if (fs.existsSync(oldPath) && !fs.existsSync(newPath)) {
         const dir = path.dirname(newPath);
         if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
@@ -462,8 +488,8 @@ function migrateFilesToSubdirs(outputDir: string, manifest: BatchManifest): void
     // Move photo directories: photos_ID -> photos/ID
     if (entry.photos.dir) {
       const cleanId = path.basename(entry.photos.dir);
-      const oldDir = path.join(outputDir, `photos_${cleanId}`);
-      const newDir = path.join(outputDir, entry.photos.dir);
+      const oldDir = path.join(entryOutputDir, `photos_${cleanId}`);
+      const newDir = path.join(entryOutputDir, entry.photos.dir);
       if (fs.existsSync(oldDir) && !fs.existsSync(newDir)) {
         const parent = path.dirname(newDir);
         if (!fs.existsSync(parent)) fs.mkdirSync(parent, { recursive: true });
@@ -536,7 +562,7 @@ async function persistPhaseUpdate(
   }
 
   await emitPhaseUpdate(options, {
-    outputDir: options.outputDir || 'data',
+    outputDir: resolveBatchOutputDir(options, entry.platform),
     manifestKey,
     phase,
     entry,
@@ -615,6 +641,9 @@ export async function runBatch(
   const startTime = Date.now();
   const scrapeBookingHotelReviews =
     dependencies.scrapeBookingHotelReviews || bookingScraper.scrapeHotelReviews;
+  const analyzeReviews = dependencies.runAnalyze || runAnalyze;
+  const analyzePhotos = dependencies.runAnalyzePhotos || runAnalyzePhotos;
+  const triageListing = dependencies.runTriage || runTriage;
   const manifestPath = getManifestPath(options);
   let artifactCache: ArtifactCache | null = options.artifactCache ?? null;
   if (options.artifactCache === undefined) {
@@ -639,9 +668,8 @@ export async function runBatch(
 
   // Migrate v1 manifest to v2 (add aiReviews/aiPhotos, prefix paths with subdirs)
   if (manifest.version < 2) {
-    const outputDir = options.outputDir || 'data';
     manifest = migrateManifestV2(manifest);
-    migrateFilesToSubdirs(outputDir, manifest);
+    migrateFilesToSubdirs(options, manifest);
     saveManifest(manifest, manifestPath);
     console.log('Manifest migrated to v2 (subdirectory layout)');
   }
@@ -650,6 +678,37 @@ export async function runBatch(
   const preprocessed = filePaths.length > 0
     ? preprocessFiles(filePaths)
     : { airbnb: { urls: [] as string[], count: 0, duplicatesRemoved: 0 }, booking: { urls: [] as string[], count: 0, duplicatesRemoved: 0 }, dates: { source: 'none' as const, checkIn: undefined, checkOut: undefined, adults: undefined } };
+
+  if (options.scopeManifestToInput && !options.retryFailed && filePaths.length > 0) {
+    const currentManifestKeys = new Set<string>();
+
+    for (const url of preprocessed.airbnb.urls) {
+      currentManifestKeys.add(`airbnb/${airbnbListing.parseAirbnbUrl(url).roomId}`);
+    }
+    for (const url of preprocessed.booking.urls) {
+      const hotelInfo = bookingScraper.extractHotelInfo(url);
+      if (hotelInfo) currentManifestKeys.add(`booking/${hotelInfo.hotel_name}`);
+    }
+
+    if (currentManifestKeys.size === 0) {
+      throw new Error('No valid Airbnb or Booking URLs found in the input files.');
+    }
+
+    const scopedListings = Object.fromEntries(
+      Object.entries(manifest.listings)
+        .filter(([key]) => currentManifestKeys.has(key)),
+    );
+    const removedListingCount =
+      Object.keys(manifest.listings).length - Object.keys(scopedListings).length;
+    manifest.listings = scopedListings;
+
+    if (removedListingCount > 0) {
+      console.log(
+        `Manifest: removed ${removedListingCount} listing`
+        + `${removedListingCount === 1 ? '' : 's'} outside the current input`,
+      );
+    }
+  }
 
   // 3. If --retry, merge retry URLs from manifest
   if (options.retryFailed) {
@@ -736,7 +795,7 @@ export async function runBatch(
 
   // 6. Process Airbnb listings
   if (preprocessed.airbnb.count > 0) {
-    const airbnbOutputDir = options.outputDir || 'data/airbnb/output';
+    const airbnbOutputDir = resolveBatchOutputDir(options, 'airbnb');
     let apiKey: string | null = null;
     let apiKeyAttempted = false;
     const ensureAirbnbApiKey = async (refresh = false): Promise<string | null> => {
@@ -1196,7 +1255,7 @@ export async function runBatch(
 
   // 7. Process Booking listings
   if (preprocessed.booking.count > 0) {
-    const bookingOutputDir = options.outputDir || 'data/booking/output';
+    const bookingOutputDir = resolveBatchOutputDir(options, 'booking');
     await emitBatchEvent(options, {
       phase: 'scrape',
       level: 'info',
@@ -1614,9 +1673,7 @@ export async function runBatch(
 
   // 8. AI review analysis phase (runs after all scraping)
   if (options.aiReviews) {
-    const aiOutputDir = options.outputDir || 'data';
     const aiModel = options.aiModel || process.env.LLM_MODEL || 'gemini-3-flash-preview:high';
-    const aiReviewsDir = getAiReviewsDir(aiOutputDir);
 
     // Early API key validation
     const modelConfig = parseModelConfig(aiModel);
@@ -1645,13 +1702,13 @@ export async function runBatch(
         level: 'info',
         message: `Starting AI review analysis (${modelConfig.model})`,
       });
-      if (!fs.existsSync(aiReviewsDir)) fs.mkdirSync(aiReviewsDir, { recursive: true });
-
       let aiIndex = 0;
       const aiEntries = Object.entries(manifest.listings);
       for (const [manifestKey, entry] of aiEntries) {
         aiIndex++;
         const prefix = `[${aiIndex}/${aiEntries.length}] ${manifestKey}`;
+        const aiOutputDir = resolveBatchOutputDir(options, entry.platform);
+        const aiReviewsDir = getAiReviewsDir(aiOutputDir);
 
         // Determine platform-specific result tracker
         const platformResult = entry.platform === 'airbnb' ? airbnbResult : bookingResult;
@@ -1693,7 +1750,7 @@ export async function runBatch(
         }
 
         // Skip if no reviews available or review count is 0
-        if (!entry.reviews.file || (entry.reviews.status !== 'fetched' && entry.reviews.status !== 'partial') || entry.reviews.count === 0) {
+        if (!hasUsableArtifact(entry.reviews, 'file') || entry.reviews.count === 0) {
           console.log(`${prefix} \u2014 ai-reviews \u2298 skip (no reviews)`);
           platformResult.aiReviews.skipped++;
           entry.aiReviews = { status: 'skipped', reason: 'no reviews' };
@@ -1730,6 +1787,7 @@ export async function runBatch(
         }
 
         const t = Date.now();
+        if (!fs.existsSync(aiReviewsDir)) fs.mkdirSync(aiReviewsDir, { recursive: true });
         await emitBeforeAiCall(options, {
           outputDir: aiOutputDir,
           manifestKey,
@@ -1737,7 +1795,7 @@ export async function runBatch(
           entry,
         });
         try {
-          const result: AnalysisResult = await runAnalyze({
+          const result: AnalysisResult = await analyzeReviews({
             reviewsFile: reviewsPath,
             listingFile: listingPath && fs.existsSync(listingPath) ? listingPath : undefined,
             model: aiModel,
@@ -1798,9 +1856,7 @@ export async function runBatch(
 
   // 9. AI photo analysis phase (runs after all scraping)
   if (options.aiPhotos) {
-    const aiOutputDir = options.outputDir || 'data';
     const aiModel = options.aiModel || process.env.LLM_MODEL || 'gemini-3-flash-preview:high';
-    const aiPhotosOutputDir = getAiPhotosDir(aiOutputDir);
 
     // Early API key validation
     const modelConfig = parseModelConfig(aiModel);
@@ -1829,13 +1885,13 @@ export async function runBatch(
         level: 'info',
         message: `Starting AI photo analysis (${modelConfig.model})`,
       });
-      if (!fs.existsSync(aiPhotosOutputDir)) fs.mkdirSync(aiPhotosOutputDir, { recursive: true });
-
       let aiIndex = 0;
       const aiEntries = Object.entries(manifest.listings);
       for (const [manifestKey, entry] of aiEntries) {
         aiIndex++;
         const prefix = `[${aiIndex}/${aiEntries.length}] ${manifestKey}`;
+        const aiOutputDir = resolveBatchOutputDir(options, entry.platform);
+        const aiPhotosOutputDir = getAiPhotosDir(aiOutputDir);
 
         const platformResult = entry.platform === 'airbnb' ? airbnbResult : bookingResult;
 
@@ -1875,7 +1931,7 @@ export async function runBatch(
         }
 
         // Skip if no photos available
-        if (!entry.photos.dir || (entry.photos.status !== 'fetched' && entry.photos.status !== 'partial' && entry.photos.status !== 'skipped')) {
+        if (!hasUsableArtifact(entry.photos, 'dir')) {
           console.log(`${prefix} — ai-photos ⊘ skip (no photos)`);
           platformResult.aiPhotos.skipped++;
           entry.aiPhotos = { status: 'skipped', reason: 'no photos' };
@@ -1912,6 +1968,7 @@ export async function runBatch(
         const listingPath = entry.details.file ? path.join(aiOutputDir, entry.details.file) : undefined;
 
         const t = Date.now();
+        if (!fs.existsSync(aiPhotosOutputDir)) fs.mkdirSync(aiPhotosOutputDir, { recursive: true });
         await emitBeforeAiCall(options, {
           outputDir: aiOutputDir,
           manifestKey,
@@ -1919,7 +1976,7 @@ export async function runBatch(
           entry,
         });
         try {
-          const result: PhotoAnalysisResult = await runAnalyzePhotos({
+          const result: PhotoAnalysisResult = await analyzePhotos({
             photosDir: photosPath,
             listingFile: listingPath && fs.existsSync(listingPath) ? listingPath : undefined,
             model: aiModel,
@@ -1969,9 +2026,7 @@ export async function runBatch(
 
   // 10. AI triage phase (runs after all AI analysis)
   if (options.triage) {
-    const aiOutputDir = options.outputDir || 'data';
     const aiModel = options.aiModel || process.env.LLM_MODEL || 'gemini-3-flash-preview:high';
-    const triageOutputDir = getTriageDir(aiOutputDir);
 
     // Early API key validation
     const modelConfig = parseModelConfig(aiModel);
@@ -2000,13 +2055,13 @@ export async function runBatch(
         level: 'info',
         message: `Starting AI triage (${modelConfig.model})`,
       });
-      if (!fs.existsSync(triageOutputDir)) fs.mkdirSync(triageOutputDir, { recursive: true });
-
       let triageIndex = 0;
       const triageEntries = Object.entries(manifest.listings);
       for (const [manifestKey, entry] of triageEntries) {
         triageIndex++;
         const prefix = `[${triageIndex}/${triageEntries.length}] ${manifestKey}`;
+        const aiOutputDir = resolveBatchOutputDir(options, entry.platform);
+        const triageOutputDir = getTriageDir(aiOutputDir);
 
         const platformResult = entry.platform === 'airbnb' ? airbnbResult : bookingResult;
 
@@ -2046,7 +2101,7 @@ export async function runBatch(
         }
 
         // Skip if no listing details available (required for triage)
-        if (!entry.details.file || (entry.details.status !== 'fetched' && entry.details.status !== 'skipped')) {
+        if (!hasUsableArtifact(entry.details, 'file')) {
           console.log(`${prefix} — triage ⊘ skip (no listing details)`);
           platformResult.triage.skipped++;
           entry.triage = { status: 'skipped', reason: 'no listing details' };
@@ -2084,6 +2139,7 @@ export async function runBatch(
         const aiPhotosPath = entry.aiPhotos?.file ? path.join(aiOutputDir, entry.aiPhotos.file) : undefined;
 
         const t = Date.now();
+        if (!fs.existsSync(triageOutputDir)) fs.mkdirSync(triageOutputDir, { recursive: true });
         await emitBeforeAiCall(options, {
           outputDir: aiOutputDir,
           manifestKey,
@@ -2091,7 +2147,7 @@ export async function runBatch(
           entry,
         });
         try {
-          const result: TriageResult = await runTriage({
+          const result: TriageResult = await triageListing({
             listingFile: listingPath,
             aiReviewsFile: aiReviewsPath && fs.existsSync(aiReviewsPath) ? aiReviewsPath : undefined,
             aiPhotosFile: aiPhotosPath && fs.existsSync(aiPhotosPath) ? aiPhotosPath : undefined,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -411,6 +411,7 @@ program
   .option('--force', 'Re-fetch even if output exists')
   .option('--retry', 'Retry failed/partial listings from manifest')
   .option('--download-photos-all', 'Download ALL room photos (Booking.com)')
+  .option('--output <dir>', 'Write batch artifacts to this directory')
   .action(async (files: string[], cmdOpts: any, command: Command) => {
     const opts = command.optsWithGlobals();
     setupProxy(opts);
@@ -446,7 +447,8 @@ program
       force: !!cmdOpts.force,
       retryFailed: !!cmdOpts.retry,
       downloadPhotosAll: !!(cmdOpts.downloadPhotosAll || opts.downloadPhotosAll),
-      outputDir: opts.outputDir || undefined,
+      outputDir: cmdOpts.output || opts.outputDir || undefined,
+      scopeManifestToInput: true,
       print: !!opts.print,
     });
   });

--- a/tests/batch-output-paths.test.ts
+++ b/tests/batch-output-paths.test.ts
@@ -1,0 +1,322 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { resolveBatchOutputDir, runBatch } from '../src/batch.js';
+
+const repositoryRoot = process.cwd();
+const bookingUrl =
+  'https://www.booking.com/hotel/us/example-hotel.en-gb.html';
+
+function canonicalPath(filePath: string): string {
+  return fs.realpathSync(filePath);
+}
+
+function writeBookingFixture(rootDir: string): {
+  listingFile: string;
+  reviewsFile: string;
+  photosDir: string;
+} {
+  const listingFile = path.join(
+    rootDir,
+    'listings',
+    'listing_example-hotel.json',
+  );
+  const reviewsFile = path.join(
+    rootDir,
+    'reviews',
+    'example-hotel_reviews.json',
+  );
+  const photosDir = path.join(rootDir, 'photos', 'example-hotel');
+
+  fs.mkdirSync(path.dirname(listingFile), { recursive: true });
+  fs.mkdirSync(path.dirname(reviewsFile), { recursive: true });
+  fs.mkdirSync(photosDir, { recursive: true });
+  fs.writeFileSync(
+    listingFile,
+    JSON.stringify({
+      id: 'example-hotel',
+      url: bookingUrl,
+      linkedRoomId: null,
+      reviewCount: 1,
+      photos: [{ associatedRooms: [] }],
+    }),
+  );
+  fs.writeFileSync(
+    reviewsFile,
+    JSON.stringify({
+      scraped_at: '2026-07-24T00:00:00.000Z',
+      total_reviews: 1,
+      hotels_processed: ['example-hotel'],
+      reviews: [{ review_id: 'one' }],
+    }),
+  );
+  fs.writeFileSync(path.join(photosDir, 'one.jpg'), 'fixture');
+
+  return { listingFile, reviewsFile, photosDir };
+}
+
+test('default batch output directories are platform-specific', () => {
+  assert.equal(
+    resolveBatchOutputDir({}, 'booking'),
+    path.join('data', 'booking', 'output'),
+  );
+  assert.equal(
+    resolveBatchOutputDir({}, 'airbnb'),
+    path.join('data', 'airbnb', 'output'),
+  );
+  assert.equal(
+    resolveBatchOutputDir({ outputDir: '/tmp/reviewr-output' }, 'booking'),
+    '/tmp/reviewr-output',
+  );
+});
+
+test('default-dir resumed Booking artifacts remain eligible for every AI phase', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reviewr-batch-paths-'));
+  const originalCwd = process.cwd();
+  const originalGeminiApiKey = process.env.GEMINI_API_KEY;
+  const platformOutputDir = path.join(
+    tempDir,
+    'data',
+    'booking',
+    'output',
+  );
+  const fixture = writeBookingFixture(platformOutputDir);
+  const urlsFile = path.join(tempDir, 'urls.txt');
+  fs.writeFileSync(urlsFile, `${bookingUrl}\n`);
+
+  const manifestPath = path.join(tempDir, 'data', 'batch_manifest.json');
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      version: 2,
+      createdAt: '2026-02-01T00:00:00.000Z',
+      updatedAt: '2026-02-01T00:00:00.000Z',
+      dates: {},
+      listings: {
+        'booking/unrelated-hotel': {
+          platform: 'booking',
+          id: 'unrelated-hotel',
+          url: 'https://www.booking.com/hotel/it/unrelated-hotel.en-gb.html',
+          details: { status: 'not_requested' },
+          reviews: { status: 'not_requested' },
+          photos: { status: 'not_requested' },
+          aiReviews: { status: 'not_requested' },
+          aiPhotos: { status: 'not_requested' },
+          triage: { status: 'not_requested' },
+        },
+      },
+    }),
+  );
+
+  const analyzerInputs: string[] = [];
+  const checkpointOutputDirs: string[] = [];
+
+  try {
+    process.chdir(tempDir);
+    process.env.GEMINI_API_KEY = 'fixture-key';
+
+    const result = await runBatch(
+      [urlsFile],
+      {
+        fetchDetails: true,
+        fetchReviews: true,
+        fetchPhotos: true,
+        aiReviews: true,
+        aiPhotos: true,
+        triage: true,
+        aiReviewsExplicit: true,
+        aiPhotosExplicit: true,
+        triageExplicit: true,
+        force: false,
+        retryFailed: false,
+        downloadPhotosAll: false,
+        scopeManifestToInput: true,
+        print: false,
+        artifactCache: null,
+        hooks: {
+          onBeforeAiCall: ({ outputDir }) => {
+            checkpointOutputDirs.push(canonicalPath(outputDir));
+          },
+        },
+      },
+      {
+        runAnalyze: async (options) => {
+          analyzerInputs.push(canonicalPath(options.reviewsFile));
+          assert.equal(
+            canonicalPath(options.listingFile!),
+            canonicalPath(fixture.listingFile),
+          );
+          return {
+            data: { summary: 'fixture' },
+            model: 'fixture-model',
+            provider: 'gemini',
+            multiYear: false,
+            reviewSelection: {
+              eligibleCount: 1,
+              includedCount: 1,
+              limit: 250,
+              capped: false,
+            },
+          };
+        },
+        runAnalyzePhotos: async (options) => {
+          analyzerInputs.push(canonicalPath(options.photosDir));
+          assert.equal(
+            canonicalPath(options.listingFile!),
+            canonicalPath(fixture.listingFile),
+          );
+          return {
+            data: { highlights: ['fixture'] },
+            model: 'fixture-model',
+            provider: 'gemini',
+            photoCount: 1,
+          };
+        },
+        runTriage: async (options) => {
+          analyzerInputs.push(canonicalPath(options.listingFile));
+          assert.equal(
+            canonicalPath(options.aiReviewsFile!),
+            canonicalPath(
+              path.join(
+                platformOutputDir,
+                'ai-reviews',
+                'example-hotel.json',
+              ),
+            ),
+          );
+          assert.equal(
+            canonicalPath(options.aiPhotosFile!),
+            canonicalPath(
+              path.join(
+                platformOutputDir,
+                'ai-photos',
+                'example-hotel.json',
+              ),
+            ),
+          );
+          return {
+            data: { tier: 'shortlist', fitScore: 75 },
+            model: 'fixture-model',
+            provider: 'gemini',
+          };
+        },
+      },
+    );
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    assert.deepEqual(Object.keys(manifest.listings), ['booking/example-hotel']);
+
+    const entry = manifest.listings['booking/example-hotel'];
+    assert.deepEqual(
+      [entry.details.status, entry.details.source],
+      ['skipped', 'local'],
+    );
+    assert.deepEqual(
+      [entry.reviews.status, entry.reviews.source],
+      ['skipped', 'local'],
+    );
+    assert.deepEqual(
+      [entry.photos.status, entry.photos.source],
+      ['skipped', 'local'],
+    );
+    assert.equal(entry.aiReviews.status, 'fetched');
+    assert.equal(entry.aiPhotos.status, 'fetched');
+    assert.equal(entry.triage.status, 'fetched');
+
+    assert.deepEqual(analyzerInputs, [
+      canonicalPath(fixture.reviewsFile),
+      canonicalPath(fixture.photosDir),
+      canonicalPath(fixture.listingFile),
+    ]);
+    assert.deepEqual(checkpointOutputDirs, [
+      canonicalPath(platformOutputDir),
+      canonicalPath(platformOutputDir),
+      canonicalPath(platformOutputDir),
+    ]);
+    assert.equal(result.booking.aiReviews.fetched, 1);
+    assert.equal(result.booking.aiPhotos.fetched, 1);
+    assert.equal(result.booking.triage.fetched, 1);
+    assert.equal(
+      fs.existsSync(
+        path.join(platformOutputDir, 'ai-reviews', 'example-hotel.json'),
+      ),
+      true,
+    );
+    assert.equal(
+      fs.existsSync(
+        path.join(platformOutputDir, 'ai-photos', 'example-hotel.json'),
+      ),
+      true,
+    );
+    assert.equal(
+      fs.existsSync(
+        path.join(platformOutputDir, 'triage', 'example-hotel.json'),
+      ),
+      true,
+    );
+    assert.equal(
+      fs.existsSync(
+        path.join(tempDir, 'data', 'ai-reviews', 'example-hotel.json'),
+      ),
+      false,
+    );
+  } finally {
+    process.chdir(originalCwd);
+    if (originalGeminiApiKey === undefined) {
+      delete process.env.GEMINI_API_KEY;
+    } else {
+      process.env.GEMINI_API_KEY = originalGeminiApiKey;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('batch CLI accepts --output after the subcommand', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reviewr-cli-output-'));
+  const outputDir = path.join(tempDir, 'custom-output');
+  const urlsFile = path.join(tempDir, 'urls.txt');
+  const cacheDir = path.join(tempDir, 'cache');
+  writeBookingFixture(outputDir);
+  fs.writeFileSync(urlsFile, `${bookingUrl}\n`);
+
+  const cliPath = path.join(repositoryRoot, 'src', 'cli.ts');
+  const tsxPath = path.join(repositoryRoot, 'node_modules', '.bin', 'tsx');
+
+  try {
+    const cliResult = spawnSync(
+      tsxPath,
+      [cliPath, 'batch', urlsFile, '--details', '--output', outputDir],
+      {
+        cwd: tempDir,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          REVIEWR_CACHE_DIR: cacheDir,
+        },
+      },
+    );
+
+    assert.equal(
+      cliResult.status,
+      0,
+      `${cliResult.stdout}\n${cliResult.stderr}`,
+    );
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(outputDir, 'batch_manifest.json'), 'utf-8'),
+    );
+    assert.equal(
+      manifest.listings['booking/example-hotel'].details.source,
+      'local',
+    );
+    assert.equal(
+      fs.existsSync(path.join(tempDir, 'data', 'batch_manifest.json')),
+      false,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #58

## Summary

- Resolve every AI phase against the same platform-specific artifact root used by scraping when no explicit output directory is supplied.
- Treat skipped local details, reviews, and photos with an existing manifest path as usable AI inputs.
- Expose reviewr batch --output <dir> and scope normal CLI manifests to the current input while preserving full-manifest retry behavior.
- Make AI runners injectable so the default-directory regression covers review analysis, photo analysis, and triage without external API calls.

## Validation

- pnpm run build
- pnpm test (76 passing)
- pnpm exec eslint src/batch.ts src/cli.ts tests/batch-output-paths.test.ts
- cd web and npm run build
- cd web and npm run lint
- cd web and npm run test:pricing
- cd web and npm run test:ui
- reviewr batch --help exposes --output <dir>