### PR TITLE
Surface incomplete triage evidence

### DIFF
--- a/src/batch.ts
+++ b/src/batch.ts
@@ -14,7 +14,12 @@ import * as bookingListing from './booking/listing.js';
 import * as bookingScraper from './booking/scraper.js';
 import { runAnalyze, parseModelConfig, getProviderApiKey, PROVIDER_KEY_NAMES, type AnalysisResult } from './analyze.js';
 import { runAnalyzePhotos, type PhotoAnalysisResult } from './analyze-photos.js';
-import { runTriage, type TriageResult } from './triage.js';
+import {
+  normalizeTriageEvidenceGaps,
+  runTriage,
+  type TriageEvidenceGap,
+  type TriageResult,
+} from './triage.js';
 import {
   buildDetailsCacheVariant,
   buildPhotosCacheVariant,
@@ -74,6 +79,7 @@ export interface ManifestPhase {
   source?: 'network' | 'cache' | 'local';
   cachedAt?: string;
   cacheAgeMs?: number;
+  evidenceGaps?: TriageEvidenceGap[];
 }
 
 export interface ManifestEntry {
@@ -2104,7 +2110,11 @@ export async function runBatch(
         if (!hasUsableArtifact(entry.details, 'file')) {
           console.log(`${prefix} — triage ⊘ skip (no listing details)`);
           platformResult.triage.skipped++;
-          entry.triage = { status: 'skipped', reason: 'no listing details' };
+          entry.triage = {
+            status: 'skipped',
+            reason: 'no listing details',
+            evidenceGaps: ['details'],
+          };
           await persistPhaseUpdate(options, manifest, manifestPath, manifestKey, 'triage');
           await emitBatchEvent(options, {
             phase: 'triage',
@@ -2121,7 +2131,11 @@ export async function runBatch(
         if (!fs.existsSync(listingPath)) {
           console.log(`${prefix} — triage ⊘ skip (listing file missing)`);
           platformResult.triage.skipped++;
-          entry.triage = { status: 'skipped', reason: 'listing file missing' };
+          entry.triage = {
+            status: 'skipped',
+            reason: 'listing file missing',
+            evidenceGaps: ['details'],
+          };
           await persistPhaseUpdate(options, manifest, manifestPath, manifestKey, 'triage');
           await emitBatchEvent(options, {
             phase: 'triage',
@@ -2137,6 +2151,14 @@ export async function runBatch(
         // Resolve optional AI analysis files
         const aiReviewsPath = entry.aiReviews?.file ? path.join(aiOutputDir, entry.aiReviews.file) : undefined;
         const aiPhotosPath = entry.aiPhotos?.file ? path.join(aiOutputDir, entry.aiPhotos.file) : undefined;
+        const availableAiReviewsPath =
+          aiReviewsPath && fs.existsSync(aiReviewsPath) ? aiReviewsPath : undefined;
+        const availableAiPhotosPath =
+          aiPhotosPath && fs.existsSync(aiPhotosPath) ? aiPhotosPath : undefined;
+        const missingInputEvidence = normalizeTriageEvidenceGaps([
+          ...(availableAiReviewsPath ? [] : ['reviews']),
+          ...(availableAiPhotosPath ? [] : ['photos']),
+        ]);
 
         const t = Date.now();
         if (!fs.existsSync(triageOutputDir)) fs.mkdirSync(triageOutputDir, { recursive: true });
@@ -2149,28 +2171,54 @@ export async function runBatch(
         try {
           const result: TriageResult = await triageListing({
             listingFile: listingPath,
-            aiReviewsFile: aiReviewsPath && fs.existsSync(aiReviewsPath) ? aiReviewsPath : undefined,
-            aiPhotosFile: aiPhotosPath && fs.existsSync(aiPhotosPath) ? aiPhotosPath : undefined,
+            aiReviewsFile: availableAiReviewsPath,
+            aiPhotosFile: availableAiPhotosPath,
             model: aiModel,
             priorities: options.aiPriorities,
           });
 
-          // Write result to triage dir
-          fs.writeFileSync(triageFile, JSON.stringify(result.data, null, 2));
+          if (!result.data || typeof result.data !== 'object' || Array.isArray(result.data)) {
+            throw new Error('Triage result data must be a JSON object.');
+          }
+          const evidenceGaps = normalizeTriageEvidenceGaps([
+            ...missingInputEvidence,
+            ...result.evidenceGaps,
+          ]);
+          const triageData = {
+            ...result.data,
+            evidenceGaps,
+          };
 
-          const tier = result.data?.tier || '?';
-          const fitScore = result.data?.fitScore ?? '?';
-          console.log(`${prefix} — triage ✓ ${tier} (${fitScore}) (${formatDuration(Date.now() - t)})`);
+          // Write result to triage dir
+          fs.writeFileSync(triageFile, JSON.stringify(triageData, null, 2));
+
+          const tier = triageData.tier || '?';
+          const fitScore = triageData.fitScore ?? '?';
+          const evidenceLabel =
+            evidenceGaps.length > 0
+              ? `; graded without ${evidenceGaps.join(' + ')}`
+              : '';
+          const triageMessage =
+            `triage ✓ ${tier} (${fitScore})`
+            + ` (${formatDuration(Date.now() - t)})${evidenceLabel}`;
+          console.log(`${prefix} — ${triageMessage}`);
           platformResult.triage.fetched++;
-          entry.triage = { status: 'fetched', file: `triage/${entry.id}.json`, model: result.model, cost: result.usage?.cost };
+          entry.triage = {
+            status: 'fetched',
+            file: `triage/${entry.id}.json`,
+            model: result.model,
+            cost: result.usage?.cost,
+            evidenceGaps,
+          };
           await persistPhaseUpdate(options, manifest, manifestPath, manifestKey, 'triage');
           await emitBatchEvent(options, {
             phase: 'triage',
-            level: 'info',
-            message: `triage ✓ ${tier} (${fitScore}) (${formatDuration(Date.now() - t)})`,
+            level: evidenceGaps.length > 0 ? 'warning' : 'info',
+            message: triageMessage,
             manifestKey,
             platform: entry.platform,
             listingId: entry.id,
+            payload: { evidenceGaps },
           });
         } catch (err: any) {
           console.log(`${prefix} — triage ✗ ${err.message}`);

--- a/src/triage.ts
+++ b/src/triage.ts
@@ -18,10 +18,26 @@ export interface TriageOptions {
   priorities?: string;       // Guest requirements (free text)
 }
 
+export const TRIAGE_EVIDENCE_GAP_ORDER = [
+  'details',
+  'reviews',
+  'photos',
+] as const;
+
+export type TriageEvidenceGap = typeof TRIAGE_EVIDENCE_GAP_ORDER[number];
+
+export function normalizeTriageEvidenceGaps(
+  values: Iterable<unknown>,
+): TriageEvidenceGap[] {
+  const provided = new Set(values);
+  return TRIAGE_EVIDENCE_GAP_ORDER.filter((gap) => provided.has(gap));
+}
+
 export interface TriageResult {
   data: any;                 // Parsed triage JSON
   model: string;
   provider: LLMProvider;
+  evidenceGaps: TriageEvidenceGap[];
   tokensUsed?: number;
   usage?: UsageSummary;
 }
@@ -52,6 +68,8 @@ const TRIAGE_SYSTEM_PROMPT = `You are a property evaluator helping a specific gu
 - Photo analysis is supplementary. Photos can be outdated, selectively chosen, or misleading.
 - **Absence in photos does NOT mean absence in reality.** Only flag what's clearly visible as a concern.
 - Never assign no_go tier based on photo evidence alone — only from listing details or reviews.
+- The user message names any missing evidence layers. Never infer facts from a missing layer.
+- Mark requirements that depend only on missing evidence as unknown, and state the limitation in the tier reason and summary.
 
 ## Requirement Evaluation Rules
 1. Parse the guest's requirements from their free text.
@@ -302,6 +320,7 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
   }
   const listingData = JSON.parse(fs.readFileSync(listingPath, 'utf-8'));
   const trimmedListing = trimListingData(listingData);
+  const evidenceGaps: TriageEvidenceGap[] = [];
 
   // 3. Read AI reviews (optional)
   let aiReviewsData: any = null;
@@ -314,6 +333,9 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
         console.warn(`  Warning: could not parse AI reviews file: ${err.message}`);
       }
     }
+  }
+  if (!aiReviewsData) {
+    evidenceGaps.push('reviews');
   }
 
   // 4. Read AI photos (optional)
@@ -328,12 +350,25 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
       }
     }
   }
+  if (!aiPhotosData) {
+    evidenceGaps.push('photos');
+  }
+
+  const normalizedEvidenceGaps = normalizeTriageEvidenceGaps(evidenceGaps);
 
   // 5. Build user message
   const sections: string[] = [];
 
   sections.push('## Guest Requirements');
   sections.push(priorities || 'No specific requirements provided. Evaluate for a general traveler.');
+  sections.push('');
+
+  sections.push('## Evidence Availability');
+  sections.push(
+    normalizedEvidenceGaps.length > 0
+      ? `Missing evidence layers: ${normalizedEvidenceGaps.join(', ')}. Do not infer facts from these layers.`
+      : 'All evidence layers are available.',
+  );
   sections.push('');
 
   sections.push('## Listing Details');
@@ -377,6 +412,10 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
   } catch {
     throw new Error(`Failed to parse Gemini response as JSON:\n${result.text.slice(0, 500)}`);
   }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Gemini triage response must be a JSON object.');
+  }
+  parsed.evidenceGaps = normalizedEvidenceGaps;
 
   // 8. Log usage
   console.error(`\nUsage:`);
@@ -392,6 +431,7 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
     data: parsed,
     model: modelConfig.model,
     provider: modelConfig.provider,
+    evidenceGaps: normalizedEvidenceGaps,
     tokensUsed: prompt,
     usage: { inputTokens: prompt, outputTokens: response, thinkingTokens: thinking || undefined, cost },
   };

--- a/tests/batch-output-paths.test.ts
+++ b/tests/batch-output-paths.test.ts
@@ -202,6 +202,7 @@ test('default-dir resumed Booking artifacts remain eligible for every AI phase',
             data: { tier: 'shortlist', fitScore: 75 },
             model: 'fixture-model',
             provider: 'gemini',
+            evidenceGaps: [],
           };
         },
       },
@@ -226,6 +227,7 @@ test('default-dir resumed Booking artifacts remain eligible for every AI phase',
     assert.equal(entry.aiReviews.status, 'fetched');
     assert.equal(entry.aiPhotos.status, 'fetched');
     assert.equal(entry.triage.status, 'fetched');
+    assert.deepEqual(entry.triage.evidenceGaps, []);
 
     assert.deepEqual(analyzerInputs, [
       canonicalPath(fixture.reviewsFile),
@@ -266,6 +268,243 @@ test('default-dir resumed Booking artifacts remain eligible for every AI phase',
     );
   } finally {
     process.chdir(originalCwd);
+    if (originalGeminiApiKey === undefined) {
+      delete process.env.GEMINI_API_KEY;
+    } else {
+      process.env.GEMINI_API_KEY = originalGeminiApiKey;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('triage records missing review evidence in its artifact and manifest', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reviewr-triage-gaps-'));
+  const outputDir = path.join(tempDir, 'output');
+  const fixture = writeBookingFixture(outputDir);
+  const urlsFile = path.join(tempDir, 'urls.txt');
+  const manifestPath = path.join(outputDir, 'batch_manifest.json');
+  const aiPhotosFile = path.join(
+    outputDir,
+    'ai-photos',
+    'example-hotel.json',
+  );
+  const originalGeminiApiKey = process.env.GEMINI_API_KEY;
+  fs.rmSync(fixture.reviewsFile);
+  fs.mkdirSync(path.dirname(aiPhotosFile), { recursive: true });
+  fs.writeFileSync(aiPhotosFile, JSON.stringify({ highlights: ['fixture'] }));
+  fs.writeFileSync(urlsFile, `${bookingUrl}\n`);
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      version: 2,
+      createdAt: '2026-07-24T00:00:00.000Z',
+      updatedAt: '2026-07-24T00:00:00.000Z',
+      dates: {},
+      listings: {
+        'booking/example-hotel': {
+          platform: 'booking',
+          id: 'example-hotel',
+          url: bookingUrl,
+          details: {
+            status: 'fetched',
+            file: 'listings/listing_example-hotel.json',
+          },
+          reviews: { status: 'skipped', reason: 'no reviews' },
+          photos: {
+            status: 'fetched',
+            dir: 'photos/example-hotel',
+          },
+          aiReviews: {
+            status: 'skipped',
+            reason: 'no reviews',
+          },
+          aiPhotos: {
+            status: 'fetched',
+            file: 'ai-photos/example-hotel.json',
+          },
+          triage: { status: 'not_requested' },
+        },
+      },
+    }),
+  );
+
+  const triageEvents: Array<{ level: string; message: string; payload?: Record<string, unknown> }> = [];
+
+  try {
+    process.env.GEMINI_API_KEY = 'fixture-key';
+    const result = await runBatch(
+      [urlsFile],
+      {
+        fetchDetails: false,
+        fetchReviews: false,
+        fetchPhotos: false,
+        aiReviews: false,
+        aiPhotos: false,
+        triage: true,
+        aiReviewsExplicit: false,
+        aiPhotosExplicit: false,
+        triageExplicit: true,
+        force: false,
+        retryFailed: false,
+        downloadPhotosAll: false,
+        outputDir,
+        scopeManifestToInput: true,
+        print: false,
+        artifactCache: null,
+        hooks: {
+          onEvent: (event) => {
+            if (event.phase === 'triage') triageEvents.push(event);
+          },
+        },
+      },
+      {
+        runTriage: async (options) => {
+          assert.equal(options.aiReviewsFile, undefined);
+          assert.equal(
+            canonicalPath(options.aiPhotosFile!),
+            canonicalPath(aiPhotosFile),
+          );
+          return {
+            data: { tier: 'consider', fitScore: 55 },
+            model: 'fixture-model',
+            provider: 'gemini',
+            evidenceGaps: [],
+          };
+        },
+      },
+    );
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    assert.deepEqual(
+      manifest.listings['booking/example-hotel'].triage.evidenceGaps,
+      ['reviews'],
+    );
+
+    const triageJson = JSON.parse(
+      fs.readFileSync(
+        path.join(outputDir, 'triage', 'example-hotel.json'),
+        'utf-8',
+      ),
+    );
+    assert.deepEqual(triageJson.evidenceGaps, ['reviews']);
+    assert.equal(result.booking.triage.fetched, 1);
+
+    const completedEvent = triageEvents.find((event) =>
+      event.message.startsWith('triage ✓'));
+    assert.ok(completedEvent);
+    assert.equal(completedEvent.level, 'warning');
+    assert.deepEqual(completedEvent.payload?.evidenceGaps, ['reviews']);
+    assert.match(completedEvent.message, /graded without reviews/);
+  } finally {
+    if (originalGeminiApiKey === undefined) {
+      delete process.env.GEMINI_API_KEY;
+    } else {
+      process.env.GEMINI_API_KEY = originalGeminiApiKey;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('triage records missing photo evidence in its artifact and manifest', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reviewr-triage-photo-gap-'));
+  const outputDir = path.join(tempDir, 'output');
+  const fixture = writeBookingFixture(outputDir);
+  const urlsFile = path.join(tempDir, 'urls.txt');
+  const manifestPath = path.join(outputDir, 'batch_manifest.json');
+  const aiReviewsFile = path.join(
+    outputDir,
+    'ai-reviews',
+    'example-hotel.json',
+  );
+  const originalGeminiApiKey = process.env.GEMINI_API_KEY;
+  fs.mkdirSync(path.dirname(aiReviewsFile), { recursive: true });
+  fs.writeFileSync(aiReviewsFile, JSON.stringify({ summary: 'fixture' }));
+  fs.writeFileSync(urlsFile, `${bookingUrl}\n`);
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      version: 2,
+      createdAt: '2026-07-24T00:00:00.000Z',
+      updatedAt: '2026-07-24T00:00:00.000Z',
+      dates: {},
+      listings: {
+        'booking/example-hotel': {
+          platform: 'booking',
+          id: 'example-hotel',
+          url: bookingUrl,
+          details: {
+            status: 'fetched',
+            file: 'listings/listing_example-hotel.json',
+          },
+          reviews: {
+            status: 'fetched',
+            file: 'reviews/example-hotel_reviews.json',
+          },
+          photos: { status: 'skipped', reason: 'no photos' },
+          aiReviews: {
+            status: 'fetched',
+            file: 'ai-reviews/example-hotel.json',
+          },
+          aiPhotos: { status: 'skipped', reason: 'no photos' },
+          triage: { status: 'not_requested' },
+        },
+      },
+    }),
+  );
+
+  try {
+    process.env.GEMINI_API_KEY = 'fixture-key';
+    await runBatch(
+      [urlsFile],
+      {
+        fetchDetails: false,
+        fetchReviews: false,
+        fetchPhotos: false,
+        aiReviews: false,
+        aiPhotos: false,
+        triage: true,
+        aiReviewsExplicit: false,
+        aiPhotosExplicit: false,
+        triageExplicit: true,
+        force: false,
+        retryFailed: false,
+        downloadPhotosAll: false,
+        outputDir,
+        scopeManifestToInput: true,
+        print: false,
+        artifactCache: null,
+      },
+      {
+        runTriage: async (options) => {
+          assert.equal(
+            canonicalPath(options.aiReviewsFile!),
+            canonicalPath(aiReviewsFile),
+          );
+          assert.equal(options.aiPhotosFile, undefined);
+          return {
+            data: { tier: 'consider', fitScore: 55 },
+            model: 'fixture-model',
+            provider: 'gemini',
+            evidenceGaps: [],
+          };
+        },
+      },
+    );
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    assert.deepEqual(
+      manifest.listings['booking/example-hotel'].triage.evidenceGaps,
+      ['photos'],
+    );
+    const triageJson = JSON.parse(
+      fs.readFileSync(
+        path.join(outputDir, 'triage', 'example-hotel.json'),
+        'utf-8',
+      ),
+    );
+    assert.deepEqual(triageJson.evidenceGaps, ['photos']);
+    assert.equal(fs.existsSync(fixture.listingFile), true);
+  } finally {
     if (originalGeminiApiKey === undefined) {
       delete process.env.GEMINI_API_KEY;
     } else {

--- a/tests/results-evidence-gaps.test.ts
+++ b/tests/results-evidence-gaps.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getListingResultsSnapshot } from '../web/src/lib/results.js';
+import type { ReviewJobListing } from '../web/src/types.js';
+
+function listingWithAnalysis(input: {
+  triage: Record<string, unknown>;
+  aiReviews: Record<string, unknown> | null;
+  aiPhotos: Record<string, unknown> | null;
+}): ReviewJobListing {
+  return {
+    id: 'example',
+    platform: 'booking',
+    name: 'Example',
+    url: 'https://www.booking.com/hotel/us/example.en-gb.html',
+    rating: null,
+    reviewCount: 0,
+    pricing: null,
+    coordinates: null,
+    propertyType: null,
+    photoUrl: null,
+    selected: true,
+    liked: false,
+    hidden: false,
+    poiDistanceMeters: null,
+    analysis: {
+      triage: input.triage,
+      aiReviews: input.aiReviews,
+      aiPhotos: input.aiPhotos,
+    },
+  } as unknown as ReviewJobListing;
+}
+
+test('results parser preserves explicit triage evidence gaps', () => {
+  const snapshot = getListingResultsSnapshot(
+    listingWithAnalysis({
+      triage: {
+        tier: 'consider',
+        fitScore: 55,
+        evidenceGaps: ['photos', 'reviews', 'photos', 'invalid'],
+      },
+      aiReviews: {},
+      aiPhotos: {},
+    }),
+  );
+
+  assert.deepEqual(snapshot.triage?.evidenceGaps, ['reviews', 'photos']);
+});
+
+test('results parser derives legacy gaps from missing stored AI artifacts', () => {
+  const snapshot = getListingResultsSnapshot(
+    listingWithAnalysis({
+      triage: { tier: 'shortlist', fitScore: 70 },
+      aiReviews: null,
+      aiPhotos: {},
+    }),
+  );
+
+  assert.deepEqual(snapshot.triage?.evidenceGaps, ['reviews']);
+});
+
+test('an explicit empty gap list remains authoritative', () => {
+  const snapshot = getListingResultsSnapshot(
+    listingWithAnalysis({
+      triage: { tier: 'shortlist', fitScore: 70, evidenceGaps: [] },
+      aiReviews: null,
+      aiPhotos: null,
+    }),
+  );
+
+  assert.deepEqual(snapshot.triage?.evidenceGaps, []);
+});

--- a/tests/review-job-analysis.test.ts
+++ b/tests/review-job-analysis.test.ts
@@ -13,6 +13,7 @@ import {
   pruneAnalysisManifestToListings,
   readJsonFile,
   summarizeAnalysisStatus,
+  summarizeManifestEntryStatus,
   type AnalysisManifest,
 } from '../web/src/lib/review-job-analysis.js';
 import { REVIEW_JOB_ARTIFACT_DIR_ENV } from '../web/src/lib/reviewJobArtifacts.js';
@@ -161,6 +162,28 @@ test('summarizeAnalysisStatus treats pending listings as partial results', () =>
     summarizeAnalysisStatus([{ status: 'running' }] as any),
     'partial',
   );
+});
+
+test('triage evidence gaps make an otherwise completed listing partial', () => {
+  const entry: AnalysisManifest['listings'][string] = {
+    platform: 'booking',
+    id: 'example',
+    url: 'https://www.booking.com/hotel/us/example.en-gb.html',
+    details: { status: 'fetched', file: 'listings/listing_example.json' },
+    reviews: { status: 'fetched', file: 'reviews/example_reviews.json' },
+    photos: { status: 'fetched', dir: 'photos/example' },
+    aiReviews: { status: 'fetched', file: 'ai-reviews/example.json' },
+    aiPhotos: { status: 'fetched', file: 'ai-photos/example.json' },
+    triage: {
+      status: 'fetched',
+      file: 'triage/example.json',
+      evidenceGaps: ['reviews'],
+    },
+  };
+
+  assert.equal(summarizeManifestEntryStatus(entry), 'partial');
+  entry.triage.evidenceGaps = [];
+  assert.equal(summarizeManifestEntryStatus(entry), 'completed');
 });
 
 test('prepareReviewJobRunWorkspace stages a fresh rerun with AI outputs invalidated', () => {

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "backfill:ai-costs": "dotenv -e ../.env -e .env.local -- tsx scripts/backfill-ai-costs.ts",
     "cleanup:artifacts": "dotenv -e ../.env -e .env.local -- tsx scripts/cleanup-artifacts.ts",
     "test:pricing": "tsx --test src/lib/pricing.test.ts",
-    "test:ui": "tsx --test src/components/AiBudgetNotice.test.tsx",
+    "test:ui": "tsx --test src/components/*.test.tsx",
     "lint": "eslint .",
     "db:generate": "dotenv -e ../.env -e .env.local -- prisma generate",
     "db:push": "dotenv -e ../.env -e .env.local -- prisma db push",

--- a/web/src/components/EvidenceGapBadge.test.tsx
+++ b/web/src/components/EvidenceGapBadge.test.tsx
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import EvidenceGapBadge from './EvidenceGapBadge.js';
+
+test('evidence gap badge names the missing review layer', () => {
+  const html = renderToStaticMarkup(
+    <EvidenceGapBadge gaps={['reviews']} />,
+  );
+
+  assert.match(html, /Graded without reviews/);
+  assert.match(html, /Treat this verdict as partial/);
+});
+
+test('evidence gap badge normalizes combined gaps into a stable label', () => {
+  const html = renderToStaticMarkup(
+    <EvidenceGapBadge gaps={['photos', 'reviews', 'photos']} />,
+  );
+
+  assert.match(html, /Graded without reviews \+ photos/);
+});
+
+test('evidence gap badge stays hidden for a complete verdict', () => {
+  const html = renderToStaticMarkup(
+    <EvidenceGapBadge gaps={[]} />,
+  );
+
+  assert.equal(html, '');
+});

--- a/web/src/components/EvidenceGapBadge.tsx
+++ b/web/src/components/EvidenceGapBadge.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import type { TriageEvidenceGap } from '@/types';
+
+const GAP_ORDER: TriageEvidenceGap[] = ['details', 'reviews', 'photos'];
+
+interface EvidenceGapBadgeProps {
+  gaps: readonly TriageEvidenceGap[] | null | undefined;
+  className?: string;
+}
+
+export function formatEvidenceGapLabel(
+  gaps: readonly TriageEvidenceGap[] | null | undefined,
+): string | null {
+  const provided = new Set(gaps ?? []);
+  const normalized = GAP_ORDER.filter((gap) => provided.has(gap));
+
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  return `Graded without ${normalized.join(' + ')}`;
+}
+
+export default function EvidenceGapBadge({
+  gaps,
+  className = '',
+}: EvidenceGapBadgeProps) {
+  const label = formatEvidenceGapLabel(gaps);
+  if (!label) {
+    return null;
+  }
+
+  return (
+    <span
+      className={`${className} inline-flex rounded-full border border-amber-300/30 bg-amber-300/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-amber-100`.trim()}
+      title={`${label}. Treat this verdict as partial.`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/web/src/components/JobWorkspace.tsx
+++ b/web/src/components/JobWorkspace.tsx
@@ -9,12 +9,14 @@ import type {
 } from '@/types';
 import { resolveComparablePrice } from '@/lib/pricing';
 import { formatUsdCost, hasAiCosts } from '@/lib/aiCosts';
+import { getListingResultsSnapshot } from '@/lib/results';
 import {
   fetchReviewJobResponse,
   getStoredReviewJobPriceDisplay,
 } from '@/lib/reviewJobClient';
 import { useReviewJobPolling } from '@/hooks/useReviewJobPolling';
 import AiBudgetNotice from './AiBudgetNotice';
+import EvidenceGapBadge from './EvidenceGapBadge';
 import ResultCard from './ResultCard';
 
 const JobMap = dynamic(() => import('./JobMap'), {
@@ -63,13 +65,6 @@ function phaseStatusLabel(status: ReviewJobResponse['job']['analysisStatus']) {
   return 'Skipped';
 }
 
-function asStringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return value.filter((item): item is string => typeof item === 'string');
-}
-
 function getEventDetailLine(
   event: ReviewJobResponse['events'][number],
 ): string | null {
@@ -105,22 +100,19 @@ function getEventDetailLine(
 }
 
 function getSelectedAnalysisSummary(result: ReviewJobResponse['listings'][number] | null) {
-  const triage =
-    result?.analysis?.triage && typeof result.analysis.triage === 'object'
-      ? result.analysis.triage
-      : null;
-
+  const triage = result ? getListingResultsSnapshot(result).triage : null;
   if (!triage) {
     return null;
   }
 
   return {
-    tier: typeof triage.tier === 'string' ? triage.tier : null,
-    fitScore: typeof triage.fitScore === 'number' ? triage.fitScore : null,
-    summary: typeof triage.summary === 'string' ? triage.summary : null,
-    highlights: asStringArray(triage.highlights),
-    concerns: asStringArray(triage.concerns),
-    dealBreakers: asStringArray(triage.dealBreakers),
+    tier: triage.tier,
+    fitScore: triage.fitScore,
+    summary: triage.summary,
+    highlights: triage.highlights,
+    concerns: triage.concerns,
+    dealBreakers: triage.dealBreakers,
+    evidenceGaps: triage.evidenceGaps,
   };
 }
 
@@ -809,6 +801,7 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
                           {selectedAnalysisSummary.tier.replace(/_/g, ' ')}
                         </span>
                       )}
+                      <EvidenceGapBadge gaps={selectedAnalysisSummary.evidenceGaps} />
                       {selectedAnalysisSummary.fitScore != null && (
                         <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 font-medium text-stone-300">
                           Fit {selectedAnalysisSummary.fitScore}

--- a/web/src/components/ResultsWorkspace.tsx
+++ b/web/src/components/ResultsWorkspace.tsx
@@ -29,6 +29,7 @@ import { useReviewJobPolling } from '@/hooks/useReviewJobPolling';
 import PlatformBadge from './PlatformBadge';
 import ResultsJobMap from './ResultsJobMap';
 import AiBudgetNotice from './AiBudgetNotice';
+import EvidenceGapBadge from './EvidenceGapBadge';
 
 const MIN_MAP_HEIGHT = 280;
 const TIER_ORDER = ['top_pick', 'shortlist', 'consider', 'unlikely', 'no_go'] as const;
@@ -152,6 +153,7 @@ function buildExportPayload(
       title: listing.name,
       fitScore: snapshot.triage?.fitScore ?? null,
       tier: snapshot.triage?.tier ?? null,
+      evidenceGaps: snapshot.triage?.evidenceGaps ?? [],
       priceTotal: snapshot.triage?.priceTotal ?? null,
       pricePerNight: snapshot.triage?.pricePerNight ?? null,
     };
@@ -445,7 +447,7 @@ function HeroCard({
         <div className="h-44 w-full bg-white/5" />
       )}
       <div className="space-y-3 p-4">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <span className="rounded-lg bg-white text-black px-2 py-1 text-xs font-bold">
             {snapshot.triage?.fitScore ?? '—'}
           </span>
@@ -456,6 +458,7 @@ function HeroCard({
           >
             {tierLabel(snapshot.triage?.tier ?? null)}
           </span>
+          <EvidenceGapBadge gaps={snapshot.triage?.evidenceGaps} />
         </div>
 
         <div>
@@ -593,6 +596,20 @@ function ListingDetailPanel({
 
           {activeTab === 'triage' && (
             <div className="space-y-4 pt-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-lg bg-white px-2.5 py-1.5 text-xs font-bold text-black">
+                  Fit {triage?.fitScore ?? '—'}
+                </span>
+                <span
+                  className={`rounded-lg border px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] ${tierClassName(
+                    triage?.tier ?? null,
+                  )}`}
+                >
+                  {tierLabel(triage?.tier ?? null)}
+                </span>
+                <EvidenceGapBadge gaps={triage?.evidenceGaps} />
+              </div>
+
               <div className="flex flex-wrap gap-2 text-xs text-stone-300">
                 <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5">
                   {priceInfo.primary}
@@ -1597,13 +1614,16 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
                 </div>
               </td>
               <td className="px-3 py-3 align-top">
-                <span
-                  className={`inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] ${tierClassName(
-                    snapshot.triage?.tier ?? null,
-                  )}`}
-                >
-                  {tierLabel(snapshot.triage?.tier ?? null)}
-                </span>
+                <div className="flex flex-col items-start gap-1.5">
+                  <span
+                    className={`inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] ${tierClassName(
+                      snapshot.triage?.tier ?? null,
+                    )}`}
+                  >
+                    {tierLabel(snapshot.triage?.tier ?? null)}
+                  </span>
+                  <EvidenceGapBadge gaps={snapshot.triage?.evidenceGaps} />
+                </div>
               </td>
               <td className="px-3 py-3 align-top text-sm font-semibold text-white">
                 {snapshot.triage?.fitScore ?? '—'}

--- a/web/src/lib/results.ts
+++ b/web/src/lib/results.ts
@@ -1,4 +1,13 @@
-import type { ReviewJobListing } from '@/types';
+import type {
+  ReviewJobListing,
+  TriageEvidenceGap,
+} from '../types.js';
+
+const TRIAGE_EVIDENCE_GAP_ORDER: TriageEvidenceGap[] = [
+  'details',
+  'reviews',
+  'photos',
+];
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -20,6 +29,25 @@ function asStringArray(value: unknown): string[] {
     return [];
   }
   return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
+function normalizeEvidenceGaps(value: unknown[]): TriageEvidenceGap[] {
+  const provided = new Set(value);
+  return TRIAGE_EVIDENCE_GAP_ORDER.filter((gap) => provided.has(gap));
+}
+
+function getTriageEvidenceGaps(
+  listing: ReviewJobListing,
+  triage: Record<string, unknown>,
+): TriageEvidenceGap[] {
+  if (Array.isArray(triage.evidenceGaps)) {
+    return normalizeEvidenceGaps(triage.evidenceGaps);
+  }
+
+  return normalizeEvidenceGaps([
+    ...(asRecord(listing.analysis?.aiReviews) ? [] : ['reviews']),
+    ...(asRecord(listing.analysis?.aiPhotos) ? [] : ['photos']),
+  ]);
 }
 
 function getPhotoUrl(photo: unknown): string | null {
@@ -69,6 +97,7 @@ export interface ParsedTriage {
   highlights: string[];
   concerns: string[];
   dealBreakers: string[];
+  evidenceGaps: TriageEvidenceGap[];
   requirements: ParsedRequirement[];
   scores: Array<{ key: string; value: number }>;
 }
@@ -196,6 +225,7 @@ function parseTriage(listing: ReviewJobListing): ParsedTriage | null {
     highlights: asStringArray(triage.highlights),
     concerns: asStringArray(triage.concerns),
     dealBreakers: asStringArray(triage.dealBreakers),
+    evidenceGaps: getTriageEvidenceGaps(listing, triage),
     requirements,
     scores,
   };

--- a/web/src/lib/review-job-analysis.ts
+++ b/web/src/lib/review-job-analysis.ts
@@ -1,7 +1,12 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { Prisma, ReviewJobListing, ReviewJobListingAnalysis } from '@prisma/client';
-import type { MapPoint, PhaseStatus, Platform } from '../types.js';
+import type {
+  MapPoint,
+  PhaseStatus,
+  Platform,
+  TriageEvidenceGap,
+} from '../types.js';
 import {
   ensureReviewJobArtifactWorkspace,
   getReviewJobArtifactRunDir,
@@ -139,6 +144,7 @@ export interface AnalysisManifestPhase {
   source?: 'network' | 'cache' | 'local';
   cachedAt?: string;
   cacheAgeMs?: number;
+  evidenceGaps?: TriageEvidenceGap[];
 }
 
 export interface AnalysisManifestEntry {
@@ -192,7 +198,11 @@ export function summarizeManifestEntryStatus(
   ];
 
   if (entry.triage.status === 'fetched') {
-    if (phaseStatuses.includes('failed') || phaseStatuses.includes('partial')) {
+    if (
+      phaseStatuses.includes('failed')
+      || phaseStatuses.includes('partial')
+      || (entry.triage.evidenceGaps?.length ?? 0) > 0
+    ) {
       return 'partial';
     }
     return 'completed';

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -64,6 +64,8 @@ export type PhaseStatus =
   | 'skipped'
   | 'partial';
 
+export type TriageEvidenceGap = 'details' | 'reviews' | 'photos';
+
 export interface SearchResult {
   id: string;
   platform: Platform;


### PR DESCRIPTION
Closes #59

## Contract implemented

- Canonical evidence gaps are details, reviews, and photos in fixed order.
- Missing details hard-skips triage and records a details gap in the manifest.
- Missing or unreadable review and photo analysis remains a usable partial verdict, but the actual missing layers are attached deterministically rather than authored by the model.
- Every new completed triage writes evidenceGaps to both the triage JSON artifact and manifest phase, including an empty array for complete evidence.
- The existing ReviewJobListingAnalysis.triage JSON persistence path carries the field without a Prisma migration.
- A completed triage with gaps makes the overall listing analysis partial and emits a warning-qualified event.
- Legacy triage JSON without the field derives gaps from missing stored review and photo analysis artifacts.

## UI

- Adds a shared amber Graded without ... badge.
- JobWorkspace shows it beside the selected listing tier.
- ResultsWorkspace shows it beside tiers on hero cards, table rows, and the detail triage header.
- Curated JSON exports include evidenceGaps.

## Validation

- pnpm run build
- pnpm test: 82 passing
- pnpm run lint
- cd web and npm run build
- cd web and npm run lint
- cd web and npm run test:pricing
- cd web and npm run test:ui: 5 passing

Regression coverage proves separate missing-review and missing-photo persistence, warning events, clean empty gaps, partial status, legacy fallback, stable combined labels, and clean no-render behavior. No external AI calls, live checkout changes, stack restarts, or DB access were used.