### PR TITLE
Populate Airbnb stay totals

### DIFF
--- a/src/airbnb/pricing.ts
+++ b/src/airbnb/pricing.ts
@@ -7,20 +7,76 @@ import {
 } from '../search/pricing.js';
 import type { SearchPriceBasis, SearchPricing } from '../search/types.js';
 
-function getAirbnbDisplayBasis(qualifier: unknown): SearchPriceBasis {
-  if (typeof qualifier !== 'string') {
-    return 'unknown';
-  }
+function getAirbnbDisplayBasis(...labels: unknown[]): SearchPriceBasis {
+  const text = labels
+    .filter((label): label is string => typeof label === 'string')
+    .join(' ')
+    .toLowerCase();
 
-  if (qualifier.includes('total') || qualifier.includes('stay')) {
+  if (
+    /\b(?:total|stay)\b/.test(text)
+    || /\b(?:for\s+)?\d+\s+nights?\b/.test(text)
+  ) {
     return 'stay';
   }
 
-  if (qualifier.includes('night')) {
+  if (/\bnight\b/.test(text)) {
     return 'night';
   }
 
   return 'unknown';
+}
+
+function getPrimaryLineValue(
+  primaryLine: any,
+  camelCaseKey: string,
+  snakeCaseKey: string,
+): unknown {
+  const direct = primaryLine?.[camelCaseKey] ?? primaryLine?.[snakeCaseKey];
+  if (direct != null) {
+    return direct;
+  }
+
+  const orderedComponents =
+    primaryLine?.orderedComponents ?? primaryLine?.ordered_components;
+  if (!Array.isArray(orderedComponents)) {
+    return null;
+  }
+
+  for (const component of orderedComponents) {
+    const value = component?.[camelCaseKey] ?? component?.[snakeCaseKey];
+    if (value != null) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function parseAirbnbPrimaryLine(primaryLine: any): {
+  displayAmount: number | null;
+  displayBasis: SearchPriceBasis;
+} {
+  const displayText =
+    getPrimaryLineValue(primaryLine, 'discountedPrice', 'discounted_price')
+    ?? getPrimaryLineValue(primaryLine, 'price', 'price')
+    ?? getPrimaryLineValue(primaryLine, 'originalPrice', 'original_price')
+    ?? getPrimaryLineValue(primaryLine, 'accessibilityLabel', 'accessibility_label');
+  const qualifier = getPrimaryLineValue(
+    primaryLine,
+    'priceQualifier',
+    'price_qualifier',
+  ) ?? getPrimaryLineValue(primaryLine, 'qualifier', 'qualifier');
+  const accessibilityLabel = getPrimaryLineValue(
+    primaryLine,
+    'accessibilityLabel',
+    'accessibility_label',
+  );
+
+  return {
+    displayAmount: parsePriceAmount(displayText),
+    displayBasis: getAirbnbDisplayBasis(qualifier, accessibilityLabel),
+  };
 }
 
 function extractAirbnbBreakdownAmounts(
@@ -83,16 +139,7 @@ export function parseAirbnbPricingQuote(
   const priceDetails =
     structuredPrice?.explanation_data?.price_details
     ?? structuredPrice?.explanationData?.priceDetails;
-  const displayText =
-    primaryLine?.price
-    ?? primaryLine?.discountedPrice
-    ?? primaryLine?.originalPrice
-    ?? primaryLine?.accessibility_label
-    ?? primaryLine?.accessibilityLabel;
-  const displayAmount = parsePriceAmount(displayText);
-  const displayBasis = getAirbnbDisplayBasis(
-    primaryLine?.qualifier ?? primaryLine?.priceQualifier,
-  );
+  const { displayAmount, displayBasis } = parseAirbnbPrimaryLine(primaryLine);
 
   const { nightly, total } = extractAirbnbBreakdownAmounts(priceDetails, currency);
 
@@ -126,6 +173,7 @@ export function parseAirbnbPricingQuote(
 export function parseAirbnbStructuredDisplayPrice(
   structuredDisplayPrice: any,
   currency: string,
+  nights: number | null = null,
 ): SearchPricing | null {
   if (!structuredDisplayPrice) {
     return null;
@@ -133,30 +181,27 @@ export function parseAirbnbStructuredDisplayPrice(
 
   const primaryLine =
     structuredDisplayPrice?.primaryLine ?? structuredDisplayPrice?.primary_line;
-  const displayText =
-    primaryLine?.discountedPrice
-    ?? primaryLine?.originalPrice
-    ?? primaryLine?.price
-    ?? primaryLine?.accessibilityLabel
-    ?? primaryLine?.accessibility_label;
-  const displayAmount = parsePriceAmount(displayText);
-  const displayBasis = getAirbnbDisplayBasis(
-    primaryLine?.qualifier ?? primaryLine?.priceQualifier,
-  );
+  const { displayAmount, displayBasis } = parseAirbnbPrimaryLine(primaryLine);
   const priceDetails =
     structuredDisplayPrice?.explanationData?.priceDetails
     ?? structuredDisplayPrice?.explanation_data?.price_details;
   const { nightly, total } = extractAirbnbBreakdownAmounts(priceDetails, currency);
+  const displayedTotal = makePriceValue(
+    displayBasis === 'stay' ? displayAmount : null,
+    currency,
+    'displayed',
+  );
+  const derivedTotal = makePriceValue(
+    nightly && nights && nights > 0
+      ? nightly.amount * nights
+      : null,
+    currency,
+    'derived',
+  );
 
   return makeSearchPricing({
     nightly,
-    total:
-      total
-      ?? makePriceValue(
-        displayBasis === 'stay' ? displayAmount : null,
-        currency,
-        'displayed',
-      ),
+    total: total ?? displayedTotal ?? derivedTotal,
     display: makeDisplayPriceValue(displayAmount, currency, displayBasis),
   });
 }

--- a/src/airbnb/search.ts
+++ b/src/airbnb/search.ts
@@ -18,6 +18,7 @@ import {
 } from '../search/adaptive.js';
 import { bboxIntersectsCircle, subdivideBbox } from '../search/geo.js';
 import { filterSearchResults } from '../search/filters.js';
+import { getStayNights } from '../search/pricing.js';
 import type { AirbnbSearchParams, SearchResult, BoundingBox, ProgressCallback } from '../search/types.js';
 
 const AIRBNB_BASE_URL = 'https://www.airbnb.com';
@@ -154,7 +155,11 @@ async function searchAirbnbSSR(
         seenIds.add(id);
 
         const coord = listing.location?.coordinate || listing.coordinate;
-        const pricing = parseAirbnbStructuredDisplayPrice(item?.structuredDisplayPrice, params.currency);
+        const pricing = parseAirbnbStructuredDisplayPrice(
+          item?.structuredDisplayPrice,
+          params.currency,
+          getStayNights(params.checkin, params.checkout),
+        );
 
         // Check for superhost badge
         const badges = item?.badges || [];

--- a/src/booking/search.ts
+++ b/src/booking/search.ts
@@ -24,6 +24,7 @@ import {
   buildProxyUrl,
   resolveProxyProtocol,
 } from '../config.js';
+import { getStayNights } from '../search/pricing.js';
 import type {
   BookingSearchParams,
   SearchResult,
@@ -77,20 +78,6 @@ function getMatchingUnitConfigurations(result: any): any[] {
   }
 
   return configurations;
-}
-
-function getStayNights(params: BookingSearchParams): number | null {
-  if (!params.checkin || !params.checkout) {
-    return null;
-  }
-
-  const diffMs =
-    new Date(params.checkout).getTime() - new Date(params.checkin).getTime();
-  if (!Number.isFinite(diffMs) || diffMs <= 0) {
-    return null;
-  }
-
-  return Math.max(1, Math.round(diffMs / 86400000));
 }
 
 // --- Session management ---
@@ -733,7 +720,7 @@ function parseSearchResult(r: any, params: BookingSearchParams): SearchResult | 
   const pricing = parseBookingGraphQLPricing(
     priceInfo,
     params.currency,
-    getStayNights(params),
+    getStayNights(params.checkin, params.checkout),
   );
 
   const reviewScore = r?.basicPropertyData?.reviewScore;

--- a/src/search/pricing.ts
+++ b/src/search/pricing.ts
@@ -6,6 +6,26 @@ import type {
   SearchPricing,
 } from './types.js';
 
+export function getStayNights(
+  checkin?: string | null,
+  checkout?: string | null,
+): number | null {
+  if (!checkin || !checkout) {
+    return null;
+  }
+
+  const start = new Date(`${checkin}T00:00:00Z`);
+  const end = new Date(`${checkout}T00:00:00Z`);
+  const diffMs = end.getTime() - start.getTime();
+
+  if (!Number.isFinite(diffMs) || diffMs <= 0) {
+    return null;
+  }
+
+  const nights = Math.round(diffMs / 86400000);
+  return nights > 0 ? nights : null;
+}
+
 function normalizeNumberString(value: string): string | null {
   const cleaned = value.replace(/[^\d,.-]/g, '');
   if (!cleaned) {

--- a/tests/airbnb-pricing.test.ts
+++ b/tests/airbnb-pricing.test.ts
@@ -99,3 +99,106 @@ test('Airbnb SSR structured display price keeps total and nightly semantics dist
   assert.equal(pricing.display?.amount, 1414);
   assert.equal(pricing.display?.basis, 'stay');
 });
+
+test('Airbnb SSR derives a stay total from nightly pricing when dates are known', () => {
+  const pricing = parseAirbnbStructuredDisplayPrice(
+    {
+      primaryLine: {
+        accessibilityLabel: '$156 per night',
+        price: '$156',
+        qualifier: 'night',
+      },
+      explanationData: {
+        priceDetails: [
+          {
+            items: [
+              {
+                description: '12 nights x $156.46',
+                priceString: '$1,877.52',
+              },
+            ],
+          },
+        ],
+      },
+    },
+    'USD',
+    12,
+  );
+
+  assert.ok(pricing);
+  assert.equal(pricing.nightly?.amount, 156.46);
+  assert.equal(pricing.total?.amount, 1877.52);
+  assert.equal(pricing.total?.source, 'derived');
+  assert.equal(pricing.display?.basis, 'night');
+});
+
+test('Airbnb SSR treats a multi-night display qualifier as a stay total', () => {
+  const pricing = parseAirbnbStructuredDisplayPrice(
+    {
+      primaryLine: {
+        accessibilityLabel: '$1,935 for 12 nights',
+        price: '$1,935',
+        qualifier: 'for 12 nights',
+      },
+      explanationData: {
+        priceDetails: [
+          {
+            items: [
+              {
+                description: '12 nights x $156.46',
+                priceString: '$1,877.52',
+              },
+            ],
+          },
+        ],
+      },
+    },
+    'USD',
+    12,
+  );
+
+  assert.ok(pricing);
+  assert.equal(pricing.nightly?.amount, 156.46);
+  assert.equal(pricing.total?.amount, 1935);
+  assert.equal(pricing.total?.source, 'displayed');
+  assert.equal(pricing.display?.basis, 'stay');
+});
+
+test('Airbnb SSR reads totals from ordered display price components', () => {
+  const pricing = parseAirbnbStructuredDisplayPrice(
+    {
+      primaryLine: {
+        accessibilityLabel: '$638 total',
+        orderedComponents: [
+          {
+            discountedPrice: '$638',
+          },
+          {
+            qualifier: 'total',
+          },
+        ],
+      },
+      explanationData: {
+        priceDetails: [
+          {
+            items: [
+              {
+                description: '2 nights x $253.00',
+                priceString: '$506.00',
+              },
+            ],
+          },
+        ],
+      },
+    },
+    'USD',
+    2,
+  );
+
+  assert.ok(pricing);
+  assert.equal(pricing.nightly?.amount, 253);
+  assert.equal(pricing.total?.amount, 638);
+  assert.equal(pricing.total?.source, 'displayed');
+  assert.equal(pricing.display?.amount, 638);
+  assert.equal(pricing.display?.basis, 'stay');
+});

--- a/tests/airbnb-search.test.ts
+++ b/tests/airbnb-search.test.ts
@@ -29,6 +29,25 @@ function makeSsrSearchHtml(): string {
                       title: 'Midtown test stay',
                       avgRatingLocalized: '4.91 (123)',
                       contextualPictures: [{ picture: 'https://example.com/listing.jpg' }],
+                      structuredDisplayPrice: {
+                        primaryLine: {
+                          accessibilityLabel: '$447 total',
+                          price: '$447',
+                          qualifier: 'total',
+                        },
+                        explanationData: {
+                          priceDetails: [
+                            {
+                              items: [
+                                {
+                                  description: '2 nights x $203.50',
+                                  priceString: '$407.00',
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
                       structuredContent: {
                         primaryLine: [{ body: '2 bedrooms' }, { body: '3 beds' }],
                       },
@@ -134,6 +153,9 @@ test('Airbnb quick search uses SSR staysSearch directly without API-key retries'
   assert.equal(output.results[0].bedrooms, 2);
   assert.equal(output.results[0].beds, 3);
   assert.equal(output.results[0].superhost, true);
+  assert.equal(output.results[0].pricing?.nightly?.amount, 203.5);
+  assert.equal(output.results[0].pricing?.total?.amount, 447);
+  assert.equal(output.results[0].pricing?.total?.source, 'displayed');
   assert.equal(pages.length, 1);
   assert.equal(pages[0].results.length, 1);
 });

--- a/tests/review-job-persistence.test.ts
+++ b/tests/review-job-persistence.test.ts
@@ -5,6 +5,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import {
   hasPersistedReviewJobResults,
+  toReviewJobListingRecord,
   toReviewJobResponse,
 } from '../web/src/lib/reviewJobs.js';
 import { AI_JOB_BUDGET_ENV } from '../web/src/lib/aiBudget.js';
@@ -118,6 +119,42 @@ function makeListing(overrides: Record<string, unknown> = {}) {
     ...overrides,
   } as any;
 }
+
+test('Airbnb stay totals persist into the dedicated totalPrice column', () => {
+  const row = toReviewJobListingRecord('job_1', {
+    id: 'airbnb_1',
+    platform: 'airbnb',
+    name: 'Airbnb stay',
+    url: 'https://www.airbnb.com/rooms/1',
+    rating: 4.9,
+    reviewCount: 20,
+    pricing: {
+      nightly: {
+        amount: 156.46,
+        currency: 'USD',
+        source: 'upstream',
+      },
+      total: {
+        amount: 1877.52,
+        currency: 'USD',
+        source: 'derived',
+      },
+      display: {
+        amount: 156,
+        currency: 'USD',
+        source: 'displayed',
+        basis: 'night',
+      },
+    },
+    coordinates: null,
+    propertyType: 'Entire home',
+    photoUrl: null,
+  });
+
+  assert.equal(row.priceAmount, 156.46);
+  assert.equal(row.totalPrice, 1877.52);
+  assert.equal(row.priceCurrency, 'USD');
+});
 
 test('native results readiness is derived from persisted analysis state, not report files', () => {
   assert.equal(hasPersistedReviewJobResults(makeJob({ analysisStatus: 'completed' })), true);


### PR DESCRIPTION
Closes #57.

## Root cause

The Airbnb SSR search parser only recognized top-level price-line fields and only populated `pricing.total` when the breakdown contained an explicit `Total` item or the top-level qualifier was already classified as a stay. Airbnb also emits variants with nested ordered components, multi-night qualifiers, or a nightly breakdown without an explicit total. Those rows retained a nightly rate but persisted `totalPrice = NULL` even when the job had check-in and checkout dates.

## What changed

- Parse camelCase and snake_case Airbnb price lines, including nested ordered price components.
- Treat explicit multi-night qualifiers as stay totals while preserving exact breakdown totals as the first choice.
- Derive `nightly × nights` when dates are known and neither an exact nor displayed stay total exists.
- Share date-only stay-night calculation with Booking pricing so both platforms use the same primitive.
- Add SSR parser, public search-path, and `ReviewJobListing.totalPrice` persistence regressions.

The existing results workspaces already display, filter, and sort through the shared comparable-price resolver. Once `pricing.total` is populated, the dedicated database column and those UI paths receive the value without a web implementation change.

## Validation

- `pnpm run build`
- `pnpm run lint`
- `pnpm test` — 86 passing
- Existing web pricing resolver tests — 3 passing
- Current isolated Airbnb SSR replay for Warsaw — 20/20 results with nightly and total pricing; 18 exact upstream totals and 2 displayed ordered-line totals

No AI calls, live database access, stack restart, or live checkout mutation was used for this change. No `npm ci` was run in `web/`.
