### PR TITLE
stabilize triage scoring with a deterministic rubric

### DIFF
--- a/docs/triage-rubric.md
+++ b/docs/triage-rubric.md
@@ -1,0 +1,353 @@
+# Deterministic triage rubric v1
+
+This document defines what a StayReviewr quality score and tier mean. It is a product contract:
+the model classifies evidence, while code alone computes the score, hard caps, ranking eligibility,
+and tier.
+
+## Verdict fields and scope
+
+New verdicts carry:
+
+```json
+{
+  "scoreSource": "deterministic_rubric",
+  "rubricVersion": "1",
+  "requirementSetId": "reqset_...",
+  "rawFitScore": 70,
+  "fitScore": 44,
+  "tier": "unlikely",
+  "capReasons": ["weight_gte_3_unmet_high:req-01-quiet-sleep"],
+  "coverage": 1,
+  "rankingStatus": "ranked"
+}
+```
+
+`fitScore` and `tier` measure only quality fit against one canonical requirement set. Price,
+budget, price freshness, and availability do not contribute to the score and never cap it.
+Affordability is a separate structured axis.
+
+`rawFitScore` is the weighted result. `fitScore` is the raw result after every deterministic cap.
+`tier` is derived from `fitScore`. `coverage` and `rankingStatus` decide whether the verdict may be
+ranked alongside its peers.
+
+## Canonical requirement set
+
+The guest brief is parsed once per job or batch at temperature 0. The resulting definitions are
+persisted and reused verbatim for every listing. The direct single-listing CLI performs the same
+parse for that invocation.
+
+Code creates IDs from persisted order and a normalized label slug, for example
+`req-01-quiet-sleep`. The model never creates IDs. `requirementSetId` hashes:
+
+- the requirement schema version;
+- the parser/model version;
+- every normalized definition, including order, type, rank, weight, source text, and criteria.
+
+The prose brief and parsed budget are not themselves hashed. Equivalent canonical definitions
+therefore remain comparable, while any material definition or parser-version change creates a new
+set.
+
+These IDs are also the column keys for the priorities matrix planned in #61. Each listing must
+classify the same IDs in the same order. A future matrix cell can display status, confidence,
+evidence, frequency/year metadata, and evidence gaps without attempting to align model-invented
+labels.
+
+### Splitting
+
+Split compound prose only when its parts are independently evaluable. Keep close synonyms as
+criteria within one definition. For example, street noise, HVAC noise, and soundproofing can remain
+criteria for quiet sleep; bed comfort, blackout conditions, workspace, and walkability are separate
+decisions.
+
+When a ranked umbrella is split, its type and rank propagate to every independently evaluable
+child. This makes the scoring consequence explicit.
+
+Budget language is extracted separately and is never a quality requirement.
+
+### Types and weights
+
+| Display type | Meaning | Resolved weight |
+|---|---|---:|
+| `deal_breaker` | Explicit cannot-accept condition or objective safety/accessibility constraint | 4 |
+| `must_have` | Explicit must/need/require or objective occupancy/accessibility need | 3 |
+| `priority` | Strong or ranked preference that is not non-negotiable | 2 |
+| `nice_to_have` | Preference or bonus | 1 |
+
+An explicitly rank-1 or “by far” `priority` resolves to weight 3. Other priority ranks remain weight
+2. The type remains `priority` for display, but cap behavior uses the resolved numeric weight.
+
+With no quality brief, v1 uses:
+
+1. Clean and well maintained — `priority`, weight 2
+2. Comfortable sleep — `priority`, weight 2
+3. Accurate and functional listing — `priority`, weight 2
+4. Convenient location — `nice_to_have`, weight 1
+
+## Evidence classification
+
+The listing classifier receives frozen definitions and returns one outcome for every ID:
+
+```json
+{
+  "requirementId": "req-01-quiet-sleep",
+  "status": "unmet",
+  "confidence": "high",
+  "note": "Repeated HVAC noise conflicts with quiet sleep.",
+  "evidence": [
+    {
+      "layer": "reviews",
+      "polarity": "contradicts",
+      "text": "The HVAC sounded like a freight train.",
+      "frequency": "repeated",
+      "years": [2025, 2026]
+    }
+  ]
+}
+```
+
+Statuses are `met`, `partial`, `unmet`, and `unknown`. Confidence is `high`, `medium`, or `low`.
+Missing evidence must produce `unknown`; absence in photos is not evidence of absence. The model
+does not output the quality score, tier, definitions, weights, or caps.
+
+## Scoring math
+
+Status values:
+
+| Status | Value |
+|---|---:|
+| `met` | 1.0 |
+| `partial` | 0.5 |
+| `unmet` | 0.0 |
+| `unknown` | 0.5 |
+
+Confidence factors:
+
+| Confidence | Factor |
+|---|---:|
+| `high` | 1.0 |
+| `medium` | 0.75 |
+| `low` | 0.5 |
+
+For a non-unknown outcome:
+
+```text
+effective = 0.5 + confidenceFactor × (statusValue - 0.5)
+```
+
+Low-confidence `met` is therefore 0.75 and low-confidence `unmet` is 0.25. Every `partial` is 0.5
+regardless of confidence. `unknown` is always 0.5.
+
+```text
+rawFitScore =
+  integerHalfUpRound(
+    100 × sum(requirementWeight × effective) / sum(requirementWeight)
+  )
+```
+
+Evidence gaps do not impose a second hidden penalty. They affect the outcome through explicit
+`unknown` classifications and coverage.
+
+## Hard caps
+
+Apply every matching rule and use the lowest cap. Persist every triggering rule in `capReasons`.
+“Weight” below means the resolved stored weight after the rank-1 modifier.
+
+| Condition | Maximum |
+|---|---:|
+| One weight ≥ 4 requirement is `unmet/high` | 24 |
+| Two or more weight ≥ 3 requirements are `unmet/high` | 24 |
+| One weight ≥ 3 requirement is `unmet/high` | 44 |
+| One weight ≥ 4 requirement is `unmet/medium` | 44 |
+| A weight ≥ 4 requirement is `unmet/low`, `partial`, or `unknown` | 64 |
+| A weight ≥ 3 requirement is `unmet/medium`, `unmet/low`, or `unknown` | 64 |
+| A weight ≥ 3 requirement is `met/low` | 79 |
+| A weight ≥ 3 requirement is `partial` | 79 |
+
+Weight-based caps protect a rank-1 priority exactly like a base `must_have`. A weight-4
+`deal_breaker` also matches weight-3 rules, but lowest-cap-wins makes the stronger critical rule
+authoritative.
+
+Price and availability never create a quality cap.
+
+## Tier thresholds
+
+| Tier | Score | Meaning |
+|---|---:|---|
+| `top_pick` | 80–100 | Strong quality fit; every weight-3-or-higher requirement is confirmed met at medium/high confidence |
+| `shortlist` | 65–79 | Good fit with bounded caveats and no confirmed major failure |
+| `consider` | 45–64 | Meaningful uncertainty or compromise |
+| `unlikely` | 25–44 | A confirmed major failure or poor weighted fit |
+| `no_go` | 0–24 | A confirmed critical failure, multiple major failures, or extremely poor fit |
+
+## Coverage and ranking eligibility
+
+```text
+coverage = known requirement weight / total requirement weight
+```
+
+`met`, `partial`, and `unmet` are known; `unknown` is not.
+
+If coverage is below 0.50, the result gets `rankingStatus: "insufficient_evidence"`. Its calculated
+score, tier, cap reasons, and cells remain available for audit, but the UI presents
+**Insufficient evidence** and groups the listing outside the peer ranking. Coverage of exactly 0.50
+or greater may rank normally.
+
+This prevents an evidence-empty listing with a neutral score from outranking a well-evaluated
+listing with documented problems.
+
+## Affordability
+
+The quality verdict and affordability are independent:
+
+```json
+{
+  "status": "over",
+  "budgetAmount": 4500,
+  "priceAmount": 4950,
+  "currency": "USD",
+  "budgetCurrency": "USD",
+  "priceCurrency": "USD",
+  "basis": "stay",
+  "priceBasis": "stay",
+  "overByAmount": 450,
+  "overByPercent": 10,
+  "budgetSource": "explicit",
+  "priceSource": "upstream",
+  "priceCapturedAt": "2026-07-25T12:00:00Z",
+  "freshness": "fresh",
+  "rateType": "public",
+  "mandatoryChargesResolved": true,
+  "comparablePrice": {
+    "amount": 4950,
+    "currency": "USD",
+    "basis": "stay",
+    "source": "upstream",
+    "capturedAt": "2026-07-25T12:00:00Z",
+    "freshness": "fresh",
+    "rateType": "public",
+    "mandatoryChargesResolved": true
+  }
+}
+```
+
+An explicit structured budget wins over a budget parsed from the brief. Search `priceMax` is not
+silently treated as the analysis budget. A range uses its upper bound. “Slightly over is
+acceptable” does not inflate the bound; the result remains visibly over by the computed percentage.
+
+V1 compares exact currency minor units and performs no FX conversion:
+
+```text
+within when priceAmount ≤ budgetAmount
+overByAmount = priceAmount - budgetAmount
+overByPercent =
+  halfUpRound(100 × overByAmount / budgetAmount, 2 decimal places)
+```
+
+A comparable price must be a public-rate total for the same stay dates and occupancy, in the same
+currency and stay basis, with mandatory charges resolved. Fresh/stale is consumed from price
+provenance; this rubric does not invent a second TTL.
+
+Unknown affordability always carries a machine code and user-facing reason. Required examples:
+
+| Code | User-facing reason |
+|---|---|
+| `no_budget_given` | No analysis budget was given. |
+| `price_missing` | Price is missing for the selected stay. |
+| `price_stale` | Price is stale (12 days old). |
+| `currency_mismatch` | Price currency PLN does not match budget currency USD. |
+| `mandatory_charges_unresolved` | Mandatory charges are unresolved in this price. |
+
+Basis, freshness, invalid-price, and non-public-rate failures have equally specific reasons. The UI
+shows the reason after “Budget unknown”; it does not show a bare unknown state.
+
+The default ranking remains quality-first. A future explicit budget-aware sort may group `within`,
+then `over` by ascending percentage, then `unknown`, with quality score as a tie-breaker. It must not
+create a hidden composite score.
+
+Changing only a structured budget or refreshing a price can recompute affordability without an LLM
+call. New rubric results persist the complete comparable-price input used for that calculation.
+Budget edits transactionally replace only the `affordability` object; quality classifications,
+scores, caps, and tiers stay unchanged. Pre-snapshot and legacy JSON are preserved rather than
+reconstructed from guesses. Changing the quality definitions requires a new classification set.
+
+## Legacy and mixed verdicts
+
+Stored JSON without `scoreSource`, `rubricVersion`, and `requirementSetId` is
+`scoreSource: "model_legacy"`.
+
+- Preserve legacy JSON; do not silently mutate it or pay to recompute it.
+- Display `Legacy AI score`.
+- If every result is legacy, preserve the prior score-based display behavior.
+- In a mixed job, only deterministic verdicts for the active requirement set rank together.
+- Insufficient-evidence, legacy, and stale/mismatched-set verdicts appear in labeled unranked
+  groups.
+- Regrading is an explicit whole-job analysis rerun. Never interleave old model-authored scores with
+  rubric scores.
+
+CLI/report output follows the same source/version and grouping rules.
+
+## Worked examples
+
+### 1. Clean `top_pick`
+
+| Requirement | Weight | Outcome | Effective | Weighted value |
+|---|---:|---|---:|---:|
+| Quiet sleep, rank 1 | 3 | `met/high` | 1.0 | 3.00 |
+| Comfortable bed, must-have | 3 | `met/high` | 1.0 | 3.00 |
+| Blackout conditions | 2 | `met/medium` | 0.875 | 1.75 |
+| Workspace | 2 | `met/high` | 1.0 | 2.00 |
+| Walkability | 1 | `partial/high` | 0.5 | 0.50 |
+
+Total weighted value is 10.25 of 11. `round(100 × 10.25 / 11) = 93`. Coverage is 11/11 = 1.00.
+No cap matches. The final result is **93 / `top_pick` / ranked**.
+
+### 2. Rank-1 priority failure is capped
+
+Sleep quality is explicitly “#1 by far”, so its display type is `priority` but resolved weight is 3.
+It is `unmet/high`. Five other satisfied requirements have weights 2, 2, 1, 1, and 1.
+
+```text
+rawFitScore = round(100 × 7 / 10) = 70
+```
+
+Without the numeric-weight cap, this would be a misleading shortlist. The weight-3 `unmet/high`
+rule caps it to 44. Coverage is 1.00. The final result is
+**raw 70 → capped 44 / `unlikely` / ranked**.
+
+### 3. Insufficient evidence
+
+| Requirement | Weight | Outcome | Effective | Weighted value |
+|---|---:|---|---:|---:|
+| Quiet sleep | 3 | `unknown` | 0.5 | 1.50 |
+| Comfortable bed | 3 | `unknown` | 0.5 | 1.50 |
+| Workspace | 2 | `met/high` | 1.0 | 2.00 |
+| Walkability | 2 | `unknown` | 0.5 | 1.00 |
+
+The calculated score is `round(100 × 6 / 10) = 60`, and the calculated tier is `consider`.
+Known weight is only 2 of 10, so coverage is 0.20. The final actionable verdict is
+**Insufficient evidence / unranked**. The calculated 60 and all cells remain visible for audit.
+
+## Stability acceptance
+
+The issue #62 frozen inputs use the same three listings and one frozen canonical set:
+
+- temperature 0: 3 listings × 5 classifier runs;
+- temperature 1.0: 3 listings × 5 classifier runs.
+
+For each listing, requirement ID, and temperature, report the five statuses/confidences, status
+distribution, pairwise status flip rate, pairwise confidence flip rate, and modal disagreement.
+Report weighted aggregate flips by requirement type.
+
+For every weight-3-or-higher requirement, separately report the
+`unmet/high` ↔ `partial/high` pairwise flip rate. This specifically exposes the Candlewood
+quiet-sleep drift that can move a verdict across a cap.
+
+Production acceptance at temperature 0 requires:
+
+- all 15 calls succeed on identical frozen inputs and definitions;
+- each score remains within 5 points of that listing’s five-run mean;
+- the tier is stable across all five runs;
+- identical classifications always produce identical code-computed score, caps, and tier;
+- residual semantic flips are reported, not hidden with retries, voting, or self-consistency.
+
+Temperature 1.0 is diagnostic only.

--- a/docs/triage-stability-issue-62.md
+++ b/docs/triage-stability-issue-62.md
@@ -1,0 +1,141 @@
+# Issue #62 deterministic-rubric stability measurement
+
+- Run date: 2026-07-25
+- Model: `gemini-3-flash-preview:high`
+- Classifier calls: 30/30 completed (3 listings × 5 runs × 2 temperatures)
+- Requirement-parser calls: 1, at temperature 0
+- Observed retries: 0
+- Measured cost: $0.2197
+
+Raw local evidence: `data/experiments/issue-62/rubric-summary.json` and
+`data/experiments/issue-62/rubric-runs/` (gitignored working data)
+
+## Acceptance result
+
+**PASS for production temperature 0.**
+
+| Listing | Five final scores | Mean | Maximum absolute deviation | Tiers |
+|---|---|---:|---:|---|
+| Club Quarters Midtown | 44, 44, 44, 44, 44 | 44 | 0 | `unlikely` ×5 |
+| Candlewood Suites | 79, 79, 79, 79, 79 | 79 | 0 | `shortlist` ×5 |
+| The Michelangelo | 77, 77, 77, 77, 77 | 77 | 0 | `shortlist` ×5 |
+
+All 15 temperature-0 calls used identical frozen inputs and definitions. Every listing stayed
+within five points of its five-run mean and retained one tier. Repeated classification signatures
+always produced the same raw score, capped score, cap reasons, coverage, ranking status, and tier;
+the invariant-violation count was zero.
+
+Temperature 1 was diagnostic only. It also retained the same final scores and tiers, but it exposed
+two underlying outcome variations documented below.
+
+## Frozen requirement set
+
+- Requirement-set ID: `reqset_6b9344b3d4089e4bcad6`
+
+Parser version: `triage-requirements-v1:gemini:gemini-3-flash-preview:high`
+
+| ID | Definition | Type/rank | Weight |
+|---|---|---|---:|
+| `req-01-quiet-environment` | Quiet Environment | `priority`, rank 1 | 3 |
+| `req-02-bed-comfort` | Bed Comfort | `priority`, rank 1 | 3 |
+| `req-03-blackout-conditions` | Blackout Conditions | `priority`, rank 1 | 3 |
+| `req-04-walkable-location` | Walkable Location | `priority`, rank 3 | 2 |
+| `req-05-in-room-workspace` | In-room Workspace | `priority`, rank 3 | 2 |
+
+The separate parsed budget was 3,000–4,500 USD for the full stay. It was not emitted as a quality
+requirement and did not contribute to the scores.
+
+## Per-requirement outcomes
+
+Each five-run group has 10 unordered run pairs. `S flips` and `C flips` are status and confidence
+pairwise flips. `S modal` and `C modal` are runs disagreeing with the modal status and confidence,
+out of five. `UH↔PH` is the specifically requested `unmet/high` ↔ `partial/high` pairwise count;
+it applies only to weight-3-or-higher rows.
+
+### Temperature 0
+
+| Listing | Requirement (weight) | Five status/confidence outcomes | Status distribution | Confidence distribution | S flips | C flips | S modal | C modal | UH↔PH |
+|---|---|---|---|---|---:|---:|---:|---:|---:|
+| Club Quarters | Quiet (3) | `unmet/high` ×5 | unmet 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Club Quarters | Bed (3) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Club Quarters | Blackout (3) | `partial/medium` ×5 | partial 5 | medium 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Club Quarters | Walkability (2) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | — |
+| Club Quarters | Workspace (2) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | — |
+| Candlewood | Quiet (3) | `partial/high` ×5 | partial 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Candlewood | Bed (3) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Candlewood | Blackout (3) | `met/medium` ×5 | met 5 | medium 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Candlewood | Walkability (2) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | — |
+| Candlewood | Workspace (2) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | — |
+| Michelangelo | Quiet (3) | `partial/high` ×5 | partial 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Michelangelo | Bed (3) | `partial/high` ×5 | partial 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Michelangelo | Blackout (3) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Michelangelo | Walkability (2) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | — |
+| Michelangelo | Workspace (2) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | — |
+
+Temperature 0 therefore had zero status flips, zero confidence flips, and zero modal
+disagreements across all 15 listing/requirement groups.
+
+### Temperature 1
+
+| Listing | Requirement (weight) | Five status/confidence outcomes | Status distribution | Confidence distribution | S flips | C flips | S modal | C modal | UH↔PH |
+|---|---|---|---|---|---:|---:|---:|---:|---:|
+| Club Quarters | Quiet (3) | `unmet/high` ×5 | unmet 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Club Quarters | Bed (3) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Club Quarters | Blackout (3) | `unknown/low`, then `partial/medium` ×4 | unknown 1; partial 4 | low 1; medium 4 | 4/10 | 4/10 | 1/5 | 1/5 | 0/10 |
+| Club Quarters | Walkability (2) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | — |
+| Club Quarters | Workspace (2) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | — |
+| Candlewood | Quiet (3) | `partial/high` ×5 | partial 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Candlewood | Bed (3) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Candlewood | Blackout (3) | `met/medium` ×5 | met 5 | medium 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Candlewood | Walkability (2) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | — |
+| Candlewood | Workspace (2) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | — |
+| Michelangelo | Quiet (3) | `partial/high` ×5 | partial 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Michelangelo | Bed (3) | `partial/medium`, `partial/high`, then `partial/medium` ×3 | partial 5 | medium 4; high 1 | 0/10 | 4/10 | 0/5 | 1/5 | 0/10 |
+| Michelangelo | Blackout (3) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | 0/10 |
+| Michelangelo | Walkability (2) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | — |
+| Michelangelo | Workspace (2) | `met/high` ×5 | met 5 | high 5 | 0/10 | 0/10 | 0/5 | 0/5 | — |
+
+## Aggregate flips
+
+All frozen definitions happened to retain display type `priority`, so this run has one type bucket.
+Weighting each pairwise observation by the definition's resolved numeric weight gives:
+
+| Temperature | Weighted pair denominator | Weighted status flips | Weighted status flip rate | Weighted confidence flips | Weighted confidence flip rate |
+|---|---:|---:|---:|---:|---:|
+| 0 | 390 | 0 | 0% | 0 | 0% |
+| 1 | 390 | 12 | 3.08% | 24 | 6.15% |
+
+At temperature 1, the 12 weighted status-flip units are the four Club Quarters blackout pair
+flips multiplied by weight 3. The 24 weighted confidence-flip units add four Michelangelo bed
+confidence flips, also at weight 3.
+
+## Explicit major-cap transition audit
+
+There were nine weight-3 listing/requirement groups per temperature, or 90 unordered pairs.
+The requested `unmet/high` ↔ `partial/high` count was:
+
+| Temperature | Special flips |
+|---|---:|
+| 0 | 0/90 (0%) |
+| 1 | 0/90 (0%) |
+
+In particular, Candlewood Quiet remained `partial/high` in all 10 classifications across both
+temperatures: 0/10 special flips at temperature 0 and 0/10 at temperature 1. The previously
+observed cap-crossing semantic drift did not recur under the frozen-set classifier.
+
+## Input identity
+
+Brief SHA-256:
+`73eb169ca67f82d8610d77ca50e2a8e8d71d76342308c39501b5423e16627263`
+
+| Input | SHA-256 |
+|---|---|
+| Candlewood listing | `9a42c0a2fc34309e9b153163f37eacaa29cd651dc8ff748027e440f5814f21b1` |
+| Candlewood photos | `0b4572f4718fab6897bad4ac44770d803a02e65b3d9a371cc575693417cab296` |
+| Candlewood reviews | `d59049edc43c1e2da8b786b868504ef6f2990c125d8e1eb533b8a6628cb1b0dd` |
+| Club Quarters listing | `11b8291a020f52b4a1ad1f5cfcd9f341432d2c040e6407cd3cb7de3c2a68ab5e` |
+| Club Quarters photos | `dd084eec987e32c088c142a21af9e484a27c228c93c02fd65b6d0a8b90e1d9b9` |
+| Club Quarters reviews | `cb2cd46f41cc0f4e6cd509ee32e7c7f167bc7b328398b096a1cc1af99eecb3f3` |
+| Michelangelo listing | `0d13115670d8e770368b5dd7fe3b513ebd483bbc4ad3750284a7a68c2254af25` |
+| Michelangelo photos | `a362c9c1fbbfcbdd2de458590b008d3384803e7ac492a6575306ab0448d3573e` |
+| Michelangelo reviews | `92e25997b04277044d8271d158c41c4cbc0a67db76f63e6eee9407c4bef1d16a` |

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -15,11 +15,17 @@ import * as bookingScraper from './booking/scraper.js';
 import { runAnalyze, parseModelConfig, getProviderApiKey, PROVIDER_KEY_NAMES, type AnalysisResult } from './analyze.js';
 import { runAnalyzePhotos, type PhotoAnalysisResult } from './analyze-photos.js';
 import {
+  getTriageRequirementParserVersion,
   normalizeTriageEvidenceGaps,
   runTriage,
   type TriageEvidenceGap,
   type TriageResult,
 } from './triage.js';
+import type {
+  AffordabilityBudget,
+  CanonicalRequirementSet,
+} from './triage-rubric.js';
+import { buildCanonicalRequirementSet } from './triage-rubric.js';
 import {
   buildDetailsCacheVariant,
   buildPhotosCacheVariant,
@@ -45,6 +51,7 @@ export interface BatchOptions {
   triage: boolean;
   aiModel?: string;
   aiPriorities?: string;
+  analysisBudget?: AffordabilityBudget;
   aiReviewLimit?: number;
   aiReviewsExplicit: boolean;  // true when --ai-reviews was explicitly passed
   aiPhotosExplicit: boolean;   // true when --ai-photos was explicitly passed
@@ -101,6 +108,11 @@ export interface BatchManifest {
   createdAt: string;
   updatedAt: string;
   dates: { checkIn?: string; checkOut?: string; adults?: number };
+  requirementSet?: {
+    id: string;
+    parserVersion: string;
+    file: string;
+  };
   listings: Record<string, ManifestEntry>;
 }
 
@@ -388,6 +400,43 @@ function loadManifest(manifestPath: string): BatchManifest | null {
     }
   } catch {}
   return null;
+}
+
+function normalizeRequirementBrief(value?: string | null): string | null {
+  const normalized = value?.trim().replace(/\s+/g, ' ') || '';
+  return normalized || null;
+}
+
+function loadPersistedRequirementSet(input: {
+  file: string;
+  expectedBrief?: string;
+  expectedParserVersion: string;
+}): CanonicalRequirementSet | null {
+  try {
+    if (!fs.existsSync(input.file)) return null;
+    const parsed = JSON.parse(
+      fs.readFileSync(input.file, 'utf-8'),
+    ) as CanonicalRequirementSet;
+    if (
+      !parsed
+      || typeof parsed !== 'object'
+      || !Array.isArray(parsed.definitions)
+      || parsed.parserVersion !== input.expectedParserVersion
+      || normalizeRequirementBrief(parsed.brief)
+        !== normalizeRequirementBrief(input.expectedBrief)
+    ) {
+      return null;
+    }
+    const rebuilt = buildCanonicalRequirementSet({
+      brief: parsed.brief,
+      parserVersion: parsed.parserVersion,
+      definitions: parsed.definitions,
+      parsedBudget: parsed.parsedBudget,
+    });
+    return rebuilt.id === parsed.id ? rebuilt : null;
+  } catch {
+    return null;
+  }
 }
 
 function saveManifest(manifest: BatchManifest, manifestPath: string): void {
@@ -2061,6 +2110,33 @@ export async function runBatch(
         level: 'info',
         message: `Starting AI triage (${modelConfig.model})`,
       });
+      const requirementSetPath = path.join(
+        path.dirname(manifestPath),
+        'triage-requirements.json',
+      );
+      const expectedParserVersion = getTriageRequirementParserVersion(
+        aiModel,
+        options.aiPriorities,
+      );
+      let activeRequirementSet = loadPersistedRequirementSet({
+        file: requirementSetPath,
+        expectedBrief: options.aiPriorities,
+        expectedParserVersion,
+      }) ?? undefined;
+      if (activeRequirementSet) {
+        manifest.requirementSet = {
+          id: activeRequirementSet.id,
+          parserVersion: activeRequirementSet.parserVersion,
+          file: path.relative(
+            path.dirname(manifestPath),
+            requirementSetPath,
+          ),
+        };
+        saveManifest(manifest, manifestPath);
+        console.log(
+          `Canonical requirements: ${activeRequirementSet.id} (persisted)`,
+        );
+      }
       let triageIndex = 0;
       const triageEntries = Object.entries(manifest.listings);
       for (const [manifestKey, entry] of triageEntries) {
@@ -2175,10 +2251,45 @@ export async function runBatch(
             aiPhotosFile: availableAiPhotosPath,
             model: aiModel,
             priorities: options.aiPriorities,
+            requirementSet: activeRequirementSet,
+            budget: options.analysisBudget,
+            priceFreshness:
+              entry.details.source === 'network' ? 'fresh' : 'unknown',
           });
 
           if (!result.data || typeof result.data !== 'object' || Array.isArray(result.data)) {
             throw new Error('Triage result data must be a JSON object.');
+          }
+          if (!activeRequirementSet) {
+            activeRequirementSet = result.requirementSet;
+            fs.mkdirSync(path.dirname(requirementSetPath), {
+              recursive: true,
+            });
+            fs.writeFileSync(
+              requirementSetPath,
+              JSON.stringify(activeRequirementSet, null, 2),
+            );
+            manifest.requirementSet = {
+              id: activeRequirementSet.id,
+              parserVersion: activeRequirementSet.parserVersion,
+              file: path.relative(
+                path.dirname(manifestPath),
+                requirementSetPath,
+              ),
+            };
+            saveManifest(manifest, manifestPath);
+            console.log(
+              `Canonical requirements: ${activeRequirementSet.id} (created)`,
+            );
+          } else {
+            manifest.requirementSet = {
+              id: activeRequirementSet.id,
+              parserVersion: activeRequirementSet.parserVersion,
+              file: path.relative(
+                path.dirname(manifestPath),
+                requirementSetPath,
+              ),
+            };
           }
           const evidenceGaps = normalizeTriageEvidenceGaps([
             ...missingInputEvidence,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,6 +52,30 @@ function setupProxy(opts: any): void {
   applyProxyToEnv(resolved);
 }
 
+function parseAnalysisBudget(options: {
+  budget?: unknown;
+  budgetCurrency?: unknown;
+}) {
+  if (options.budget == null) return undefined;
+  const amount = Number(options.budget);
+  const currency =
+    typeof options.budgetCurrency === 'string'
+      ? options.budgetCurrency.trim().toUpperCase()
+      : 'USD';
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error('--budget must be a positive full-stay amount.');
+  }
+  if (!/^[A-Z]{3}$/.test(currency)) {
+    throw new Error('--budget-currency must be a three-letter currency code.');
+  }
+  return {
+    amount,
+    currency,
+    basis: 'stay' as const,
+    source: 'explicit' as const,
+  };
+}
+
 // --- Default command: single URL ---
 // Both platforms: fetches listing details by default
 program
@@ -404,6 +428,8 @@ program
   .option('--triage', 'Run AI triage (grade listings against priorities)')
   .option('--model <model>', 'LLM model for AI phases (default: gemini-3-flash-preview:high)')
   .option('--priorities <text>', 'Guest priorities for AI analysis (e.g. "quiet, fresh air")')
+  .option('--budget <amount>', 'Maximum analysis budget for the full stay')
+  .option('--budget-currency <code>', 'Analysis budget currency (default: USD)', 'USD')
   .option('--max-ai-reviews <n>', 'Maximum post-filter reviews sent to AI per listing (default: 250)')
   .option('--checkin <date>', 'Check-in date (YYYY-MM-DD)')
   .option('--checkout <date>', 'Check-out date (YYYY-MM-DD)')
@@ -437,6 +463,7 @@ program
       triage: hasPhaseFlag ? !!cmdOpts.triage : true,
       aiModel: cmdOpts.model || undefined,
       aiPriorities: cmdOpts.priorities || undefined,
+      analysisBudget: parseAnalysisBudget(cmdOpts),
       aiReviewLimit: cmdOpts.maxAiReviews == null ? undefined : Number(cmdOpts.maxAiReviews),
       aiReviewsExplicit: !!cmdOpts.aiReviews,
       aiPhotosExplicit: !!cmdOpts.aiPhotos,
@@ -532,6 +559,9 @@ program
   .option('--ai-photos <file>', 'AI photo analysis JSON')
   .option('--model <model>', 'LLM model (default: gemini-3-flash-preview:high)')
   .option('--priorities <text>', 'Guest requirements to evaluate against')
+  .option('--temperature <n>', 'Evidence-classification temperature (default: 0)', '0')
+  .option('--budget <amount>', 'Maximum analysis budget for the full stay')
+  .option('--budget-currency <code>', 'Analysis budget currency (default: USD)', 'USD')
   .action(async (listingFile: string, cmdOpts: any) => {
     // Load .env for GEMINI_API_KEY
     try { await import('dotenv/config'); } catch {}
@@ -543,6 +573,8 @@ program
       aiPhotosFile: cmdOpts.aiPhotos || undefined,
       model: cmdOpts.model || undefined,
       priorities: cmdOpts.priorities || undefined,
+      temperature: Number(cmdOpts.temperature),
+      budget: parseAnalysisBudget(cmdOpts),
     });
     console.log(JSON.stringify(result.data, null, 2));
   });

--- a/src/report.ts
+++ b/src/report.ts
@@ -23,9 +23,17 @@ interface ManifestEntry {
 }
 
 interface TriageData {
+  scoreSource?: string;
+  rubricVersion?: string;
+  requirementSetId?: string;
+  rawFitScore?: number;
   fitScore: number;
   tier: string;
   tierReason: string;
+  capReasons?: string[];
+  coverage?: number;
+  rankingStatus?: string;
+  rankingReason?: string;
   requirements: Array<{
     requirement: string;
     type: string;
@@ -40,6 +48,12 @@ interface TriageData {
   concerns: string[];
   dealBreakers: string[];
   summary: string;
+  affordability?: {
+    status?: string;
+    reasonCode?: string | null;
+    reason?: string | null;
+    overByPercent?: number | null;
+  };
 }
 
 interface ListingRow {
@@ -47,6 +61,20 @@ interface ListingRow {
   platform: string;
   url: string;
   title: string;
+  sourceOrder: number;
+  scoreSource: 'deterministic_rubric' | 'model_legacy';
+  rubricVersion: string | null;
+  requirementSetId: string | null;
+  rankingStatus: 'ranked' | 'insufficient_evidence' | 'legacy_unranked';
+  coverage: number | null;
+  rawFitScore: number | null;
+  capReasons: string[];
+  affordability: {
+    status: string;
+    reasonCode: string | null;
+    reason: string | null;
+    overByPercent: number | null;
+  } | null;
   tier: string;
   fitScore: number;
   tierReason: string;
@@ -202,11 +230,57 @@ export async function generateReport(options: ReportOptions): Promise<string> {
       }
     }
 
+    const deterministic =
+      triage.scoreSource === 'deterministic_rubric'
+      && typeof triage.rubricVersion === 'string'
+      && typeof triage.requirementSetId === 'string';
+    const coverage =
+      typeof triage.coverage === 'number' && Number.isFinite(triage.coverage)
+        ? triage.coverage
+        : null;
+    const rankingStatus =
+      deterministic
+        ? triage.rankingStatus === 'insufficient_evidence'
+          || (coverage != null && coverage < 0.5)
+          ? 'insufficient_evidence'
+          : 'ranked'
+        : 'legacy_unranked';
+    const affordability =
+      triage.affordability
+      && typeof triage.affordability === 'object'
+      && typeof triage.affordability.status === 'string'
+        ? {
+            status: triage.affordability.status,
+            reasonCode: triage.affordability.reasonCode ?? null,
+            reason: triage.affordability.reason ?? null,
+            overByPercent:
+              typeof triage.affordability.overByPercent === 'number'
+                ? triage.affordability.overByPercent
+                : null,
+          }
+        : null;
+
     rows.push({
       id: entry.id,
       platform: entry.platform,
       url: entry.url,
       title,
+      sourceOrder: rows.length,
+      scoreSource: deterministic
+        ? 'deterministic_rubric'
+        : 'model_legacy',
+      rubricVersion: deterministic ? triage.rubricVersion! : null,
+      requirementSetId: deterministic ? triage.requirementSetId! : null,
+      rankingStatus,
+      coverage,
+      rawFitScore:
+        typeof triage.rawFitScore === 'number'
+          ? triage.rawFitScore
+          : null,
+      capReasons: Array.isArray(triage.capReasons)
+        ? triage.capReasons
+        : [],
+      affordability,
       tier: triage.tier,
       fitScore: triage.fitScore,
       tierReason: triage.tierReason,
@@ -251,7 +325,22 @@ export async function generateReport(options: ReportOptions): Promise<string> {
     });
   }
 
-  rows.sort((a, b) => b.fitScore - a.fitScore);
+  const activeRequirementSetId = getActiveRequirementSetId(rows);
+  rows.sort((a, b) => {
+    if (activeRequirementSetId) {
+      const groupA = getReportComparisonGroup(
+        a,
+        activeRequirementSetId,
+      );
+      const groupB = getReportComparisonGroup(
+        b,
+        activeRequirementSetId,
+      );
+      if (groupA !== groupB) return groupA - groupB;
+      if (groupA !== 0) return a.sourceOrder - b.sourceOrder;
+    }
+    return b.fitScore - a.fitScore;
+  });
 
   // Load or create picks.json
   const picksPath = join(outputDir, 'picks.json');
@@ -307,6 +396,45 @@ function esc(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
+function getActiveRequirementSetId(rows: ListingRow[]): string | null {
+  const counts = new Map<string, { count: number; first: number }>();
+  for (const row of rows) {
+    if (
+      row.scoreSource !== 'deterministic_rubric'
+      || !row.requirementSetId
+    ) {
+      continue;
+    }
+    const current = counts.get(row.requirementSetId);
+    counts.set(row.requirementSetId, {
+      count: (current?.count ?? 0) + 1,
+      first: current?.first ?? row.sourceOrder,
+    });
+  }
+  return (
+    [...counts.entries()]
+      .sort(
+        (a, b) =>
+          b[1].count - a[1].count || a[1].first - b[1].first,
+      )[0]?.[0]
+    ?? null
+  );
+}
+
+function getReportComparisonGroup(
+  row: ListingRow,
+  activeRequirementSetId: string | null,
+): number {
+  if (!activeRequirementSetId) return 0;
+  if (
+    row.scoreSource === 'deterministic_rubric'
+    && row.requirementSetId === activeRequirementSetId
+  ) {
+    return row.rankingStatus === 'insufficient_evidence' ? 1 : 0;
+  }
+  return 2;
+}
+
 function buildHTML(rows: ListingRow[], dates?: { checkIn: string; checkOut: string; adults: number }, picks?: { liked: string[]; hidden: string[] }): string {
   const dataJSON = JSON.stringify(rows);
   const picksJSON = JSON.stringify(picks || { liked: [], hidden: [] });
@@ -316,11 +444,34 @@ function buildHTML(rows: ListingRow[], dates?: { checkIn: string; checkOut: stri
   );
   const tierOrder = ['top_pick', 'shortlist', 'consider', 'unlikely', 'no_go'];
   const tierCounts: Record<string, number> = {};
+  const activeRequirementSetId = getActiveRequirementSetId(rows);
+  const comparableRows = activeRequirementSetId
+    ? rows.filter(
+        (row) =>
+          getReportComparisonGroup(row, activeRequirementSetId) === 0,
+      )
+    : rows;
+  const insufficientCount = activeRequirementSetId
+    ? rows.filter(
+        (row) =>
+          getReportComparisonGroup(row, activeRequirementSetId) === 1,
+      ).length
+    : 0;
+  const legacyOrStaleCount = activeRequirementSetId
+    ? rows.filter(
+        (row) =>
+          getReportComparisonGroup(row, activeRequirementSetId) === 2,
+      ).length
+    : 0;
   for (const t of tierOrder) tierCounts[t] = 0;
-  for (const r of rows) tierCounts[r.tier] = (tierCounts[r.tier] || 0) + 1;
+  for (const r of comparableRows) {
+    tierCounts[r.tier] = (tierCounts[r.tier] || 0) + 1;
+  }
 
-  const topPicks = rows.filter(r => r.tier === 'top_pick');
-  const heroRows = topPicks.length >= 3 ? topPicks : rows.slice(0, 5);
+  const topPicks = comparableRows.filter(r => r.tier === 'top_pick');
+  const heroRows = topPicks.length >= 3
+    ? topPicks
+    : comparableRows.slice(0, 5);
 
   const dateLabel = dates ? `${dates.checkIn} → ${dates.checkOut} · ${dates.adults} guests` : '';
 
@@ -341,13 +492,16 @@ ${getCSS()}
 <header>
   <h1>Listing Report</h1>
   <p class="subtitle">${rows.length} listings triaged${dateLabel ? ` · ${esc(dateLabel)}` : ''}</p>
+  ${activeRequirementSetId && (insufficientCount > 0 || legacyOrStaleCount > 0)
+    ? `<p class="subtitle">${insufficientCount} insufficient-evidence and ${legacyOrStaleCount} legacy/stale verdicts are shown outside the peer ranking.</p>`
+    : ''}
 </header>
 
 <!-- TOP PICKS -->
 <section id="top-picks">
   <h2>Top Picks</h2>
   <div class="hero-grid">
-${heroRows.map(r => heroCard(r)).join('\n')}
+${heroRows.map(r => heroCard(r, activeRequirementSetId)).join('\n')}
   </div>
 </section>
 
@@ -437,7 +591,45 @@ ${getJS()}
 </html>`;
 }
 
-function heroCard(r: ListingRow): string {
+function reportVerdictBadges(
+  row: ListingRow,
+  activeRequirementSetId: string | null,
+): string {
+  const group = getReportComparisonGroup(row, activeRequirementSetId);
+  if (row.scoreSource === 'model_legacy') {
+    return '<span class="source-badge source-legacy">Legacy AI score</span>';
+  }
+  if (group === 2) {
+    return '<span class="source-badge source-unranked">Stale requirement set</span>';
+  }
+  if (group === 1) {
+    return `<span class="source-badge source-insufficient">Insufficient evidence · ${Math.round((row.coverage ?? 0) * 100)}% coverage</span>`;
+  }
+  return `<span class="source-badge source-rubric">Rubric v${esc(row.rubricVersion ?? '?')} · ${Math.round((row.coverage ?? 0) * 100)}% coverage</span>`;
+}
+
+function reportAffordabilityBadge(row: ListingRow): string {
+  const affordability = row.affordability;
+  if (!affordability) return '';
+  if (affordability.status === 'within') {
+    return '<span class="source-badge affordability-within">Within budget</span>';
+  }
+  if (affordability.status === 'over') {
+    const percentage =
+      affordability.overByPercent == null
+        ? 'Unknown'
+        : new Intl.NumberFormat('en-US', {
+            maximumFractionDigits: 2,
+          }).format(affordability.overByPercent);
+    return `<span class="source-badge affordability-over">${percentage}% over budget</span>`;
+  }
+  return `<span class="source-badge affordability-unknown" title="${esc(affordability.reason ?? 'Reason unavailable.')}">Budget unknown · ${esc(affordability.reason ?? 'Reason unavailable.')}</span>`;
+}
+
+function heroCard(
+  r: ListingRow,
+  activeRequirementSetId: string | null,
+): string {
   const photo = r.photos[0] || '';
   const metaParts = [
     esc(r.priceTotal),
@@ -448,11 +640,23 @@ function heroCard(r: ListingRow): string {
   const reqDots = r.requirements.map(req =>
     `<span class="req-dot status-${req.status}" title="${esc(req.requirement)}: ${req.status}"></span>`
   ).join('');
+  const comparisonGroup = getReportComparisonGroup(
+    r,
+    activeRequirementSetId,
+  );
+  const displayedTier =
+    comparisonGroup === 1
+      ? 'insufficient evidence'
+      : comparisonGroup === 2
+        ? 'unranked'
+        : r.tier.replace('_', ' ');
+  const displayedTierClass =
+    comparisonGroup === 0 ? ` tier-${r.tier}` : '';
 
   return `    <div class="hero-card" data-id="${esc(r.id)}" onclick="scrollToRow('${esc(r.id)}')">
       ${photo ? `<img class="hero-photo" src="${esc(photo)}" alt="${esc(r.title)}" loading="lazy">` : '<div class="hero-photo no-photo"></div>'}
       <div class="hero-body">
-        <div class="hero-badges"><span class="score-badge">${r.fitScore}</span><span class="tier-badge tier-${r.tier}">${r.tier.replace('_', ' ')}</span></div>
+        <div class="hero-badges"><span class="score-badge">${r.fitScore}</span><span class="tier-badge${displayedTierClass}">${displayedTier}</span>${reportVerdictBadges(r, activeRequirementSetId)}${reportAffordabilityBadge(r)}</div>
         <h3><a href="${esc(r.url)}" target="_blank" rel="noopener">${esc(r.title)}</a></h3>
         <div class="hero-meta">${metaParts.join(' · ')}</div>
         <p class="hero-summary">${esc(r.summary.substring(0, 160))}${r.summary.length > 160 ? '…' : ''}</p>
@@ -484,9 +688,17 @@ header h1 { font-size: 24px; font-weight: 700; }
 .hero-photo { width: 100%; height: 180px; object-fit: cover; display: block; background: #e2e8f0; }
 .no-photo { height: 180px; background: #cbd5e1; }
 .hero-body { padding: 12px 16px; }
-.hero-badges { display: flex; gap: 6px; margin-bottom: 6px; }
+.hero-badges { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 6px; }
 .score-badge { background: var(--text); color: #fff; font-weight: 700; font-size: 13px; padding: 2px 8px; border-radius: 6px; }
-.tier-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 6px; color: #fff; text-transform: capitalize; }
+.tier-badge { background: #64748b; font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 6px; color: #fff; text-transform: capitalize; }
+.source-badge { display: inline-block; max-width: 420px; font-size: 10px; font-weight: 600; line-height: 1.35; padding: 3px 7px; border: 1px solid var(--border); border-radius: 999px; }
+.source-legacy { color: #6d28d9; background: #f5f3ff; border-color: #ddd6fe; }
+.source-unranked { color: #475569; background: #f1f5f9; }
+.source-insufficient { color: #92400e; background: #fffbeb; border-color: #fde68a; }
+.source-rubric { color: #075985; background: #f0f9ff; border-color: #bae6fd; }
+.affordability-within { color: #166534; background: #f0fdf4; border-color: #bbf7d0; }
+.affordability-over { color: #9a3412; background: #fff7ed; border-color: #fed7aa; }
+.affordability-unknown { color: #475569; background: #f8fafc; }
 .tier-top_pick { background: var(--top_pick); } .tier-shortlist { background: var(--shortlist); }
 .tier-consider { background: var(--consider); } .tier-unlikely { background: var(--unlikely); }
 .tier-no_go { background: var(--no_go); }
@@ -689,6 +901,44 @@ function getJS(): string {
   const STATUS_COLORS = {met:'#22c55e',partial:'#f59e0b',unmet:'#ef4444',unknown:'#9ca3af'};
   const SCORE_KEYS = ['fit','location','sleepQuality','cleanliness','modernity','valueForMoney'];
   const SCORE_LABELS = {fit:'Fit',location:'Location',sleepQuality:'Sleep',cleanliness:'Clean',modernity:'Modern',valueForMoney:'Value'};
+  const requirementSetCounts = new Map();
+  DATA.forEach((r, index) => {
+    if (r.scoreSource !== 'deterministic_rubric' || !r.requirementSetId) return;
+    const current = requirementSetCounts.get(r.requirementSetId);
+    requirementSetCounts.set(r.requirementSetId, {
+      count: (current?.count || 0) + 1,
+      first: current?.first ?? index,
+    });
+  });
+  const ACTIVE_REQUIREMENT_SET_ID = [...requirementSetCounts.entries()]
+    .sort((a,b) => b[1].count - a[1].count || a[1].first - b[1].first)[0]?.[0] || null;
+  function comparisonGroup(r) {
+    if (!ACTIVE_REQUIREMENT_SET_ID) return 0;
+    if (r.scoreSource === 'deterministic_rubric' && r.requirementSetId === ACTIVE_REQUIREMENT_SET_ID) {
+      return r.rankingStatus === 'insufficient_evidence' ? 1 : 0;
+    }
+    return 2;
+  }
+  function verdictSourceBadge(r) {
+    const group = comparisonGroup(r);
+    if (r.scoreSource === 'model_legacy') return '<span class="source-badge source-legacy">Legacy AI score</span>';
+    if (group === 2) return '<span class="source-badge source-unranked">Stale requirement set</span>';
+    if (group === 1) return '<span class="source-badge source-insufficient">Insufficient evidence · ' + Math.round((r.coverage || 0) * 100) + '% coverage</span>';
+    return '<span class="source-badge source-rubric">Rubric v' + esc(r.rubricVersion || '?') + ' · ' + Math.round((r.coverage || 0) * 100) + '% coverage</span>';
+  }
+  function affordabilityBadge(r) {
+    const a = r.affordability;
+    if (!a) return '';
+    if (a.status === 'within') return '<span class="source-badge affordability-within">Within budget</span>';
+    if (a.status === 'over') {
+      const percentage = a.overByPercent == null
+        ? 'Unknown'
+        : new Intl.NumberFormat('en-US', {maximumFractionDigits:2}).format(a.overByPercent);
+      return '<span class="source-badge affordability-over">' + percentage + '% over budget</span>';
+    }
+    const reason = a.reason || 'Reason unavailable.';
+    return '<span class="source-badge affordability-unknown" title="' + esc(reason) + '">Budget unknown · ' + esc(reason) + '</span>';
+  }
   const IC = {
     bedroom: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 20H2"/><path d="M11 4.562v16.157a1 1 0 0 0 1.242.97L19 20V5.562a2 2 0 0 0-1.515-1.94l-4-1A2 2 0 0 0 11 4.561z"/><path d="M11 4H8a2 2 0 0 0-2 2v14"/><path d="M14 12h.01"/><path d="M22 20h-3"/></svg>',
     bed: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 20v-8a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v8"/><path d="M4 10V6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4"/><path d="M12 4v6"/><path d="M2 18h20"/></svg>',
@@ -730,10 +980,13 @@ function getJS(): string {
     if (hc) hc.textContent = String(hiddenIds.size);
   }
 
-  function buildRow(r, i) {
+  function buildRow(r, i, showGroupHeader) {
     const photo = r.photos[0] || '';
     const thumbHtml = photo ? '<img class="thumb" src="' + esc(photo) + '" loading="lazy" alt="">' : '<div class="thumb"></div>';
-    const tierBadge = '<span class="tier-badge tier-' + r.tier + '">' + r.tier.replace('_',' ') + '</span>';
+    const group = comparisonGroup(r);
+    const tierLabel = group === 1 ? 'insufficient evidence' : group === 2 ? 'unranked' : r.tier.replace('_',' ');
+    const tierClass = group === 0 ? ' tier-' + r.tier : '';
+    const tierBadge = '<span class="tier-badge' + tierClass + '">' + tierLabel + '</span>';
     const platBadge = '<span class="platform-badge platform-' + r.platform + '">' + r.platform + '</span>';
 
     // Mini score bars
@@ -756,14 +1009,21 @@ function getJS(): string {
 
     const isLiked = likedIds.has(r.id);
     const isHidden = hiddenIds.has(r.id);
-    let html = '<tr class="listing-row' + (expandedId === r.id ? ' expanded' : '') + (isLiked ? ' is-liked' : '') + '" data-id="' + esc(r.id) + '"' + (isHidden ? ' style="opacity:.4"' : '') + '>';
+    let html = '';
+    if (showGroupHeader && group > 0) {
+      const label = group === 1
+        ? 'Insufficient evidence — shown for audit, not ranked with comparable results'
+        : 'Legacy or stale verdicts — regrade the whole job before comparing';
+      html += '<tr><td colspan="12" style="background:#f8fafc;color:#475569;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em">' + label + '</td></tr>';
+    }
+    html += '<tr class="listing-row' + (expandedId === r.id ? ' expanded' : '') + (isLiked ? ' is-liked' : '') + '" data-id="' + esc(r.id) + '"' + (isHidden ? ' style="opacity:.4"' : '') + '>';
     html += '<td><button class="act-btn like-btn' + (isLiked ? ' liked' : '') + '" onclick="toggleLike(event,\\''+esc(r.id)+'\\')">&#9829;</button></td>';
-    html += '<td>' + (i+1) + '</td>';
+    html += '<td>' + (group === 0 ? i+1 : '—') + '</td>';
     html += '<td>' + thumbHtml + '</td>';
     html += '<td>' + platBadge + ' <a href="' + esc(r.url) + '" target="_blank" rel="noopener" onclick="event.stopPropagation()">' + esc(r.title) + '</a></td>';
-    html += '<td>' + tierBadge + '</td>';
+    html += '<td><div class="hero-badges">' + tierBadge + verdictSourceBadge(r) + '</div></td>';
     html += '<td><strong>' + r.fitScore + '</strong></td>';
-    html += '<td>' + esc(r.priceTotal) + '</td>';
+    html += '<td>' + esc(r.priceTotal) + '<div style="margin-top:5px">' + affordabilityBadge(r) + '</div></td>';
 
     // Info icons: bedrooms, beds, bathrooms + amenity flags
     let info = '<div class="info-icons">';
@@ -796,8 +1056,13 @@ function getJS(): string {
     const tbody = document.getElementById('table-body');
     const likedBody = document.getElementById('liked-body');
     const likedSection = document.getElementById('liked-section');
-    const filtered = [...DATA].filter(r => activeTiers.has(r.tier) && (showHidden || !hiddenIds.has(r.id)));
+    const filtered = [...DATA].filter(r =>
+      (comparisonGroup(r) !== 0 || activeTiers.has(r.tier))
+      && (showHidden || !hiddenIds.has(r.id)));
     filtered.sort((a,b) => {
+      const groupA = comparisonGroup(a), groupB = comparisonGroup(b);
+      if (groupA !== groupB) return groupA - groupB;
+      if (groupA !== 0) return a.sourceOrder - b.sourceOrder;
       let va = a[sortKey], vb = b[sortKey];
       if (sortKey === 'price') { va = parsePrice(a.priceTotal); vb = parsePrice(b.priceTotal); }
       if (sortKey === 'tier') { va = tierRank(a.tier); vb = tierRank(b.tier); }
@@ -812,13 +1077,17 @@ function getJS(): string {
 
     // Render liked table
     let likedHtml = '';
-    liked.forEach((r, i) => { likedHtml += buildRow(r, i); });
+    liked.forEach((r, i) => {
+      likedHtml += buildRow(r, i, i === 0 || comparisonGroup(r) !== comparisonGroup(liked[i - 1]));
+    });
     likedBody.innerHTML = likedHtml;
     likedSection.style.display = liked.length > 0 ? '' : 'none';
 
     // Render main table
     let html = '';
-    rest.forEach((r, i) => { html += buildRow(r, i); });
+    rest.forEach((r, i) => {
+      html += buildRow(r, i, i === 0 || comparisonGroup(r) !== comparisonGroup(rest[i - 1]));
+    });
     tbody.innerHTML = html;
 
     bindRowClicks();
@@ -872,7 +1141,8 @@ function getJS(): string {
     const concerns = r.concerns.map(c => '<span class="tag tag-orange">'+esc(c)+'</span>').join('');
     const dealBreakers = r.dealBreakers.map(d => '<span class="tag tag-red">'+esc(d)+'</span>').join('');
 
-    let tabTriage = '<div class="prop-info">'
+    let tabTriage = '<div class="hero-badges">' + verdictSourceBadge(r) + affordabilityBadge(r) + '</div>'
+      + '<div class="prop-info">'
       + '<div class="pi">Price: <b>' + esc(r.priceTotal) + '</b> (' + esc(r.pricePerNight) + '/n)</div>'
       + (r.poiDistanceMeters != null ? '<div class="pi">POI distance: <b>' + esc(formatPoiDistance(r.poiDistanceMeters) || '') + '</b></div>' : '')
       + (r.bedrooms != null ? '<div class="pi">Bedrooms: <b>' + r.bedrooms + '</b></div>' : '')

--- a/src/triage-rubric.ts
+++ b/src/triage-rubric.ts
@@ -1,0 +1,952 @@
+import { createHash } from 'node:crypto';
+
+export const TRIAGE_RUBRIC_VERSION = '1';
+export const REQUIREMENT_SCHEMA_VERSION = '1';
+export const MIN_RANKED_COVERAGE = 0.5;
+
+export type RequirementType =
+  | 'deal_breaker'
+  | 'must_have'
+  | 'priority'
+  | 'nice_to_have';
+
+export type RequirementStatus = 'met' | 'partial' | 'unmet' | 'unknown';
+export type RequirementConfidence = 'high' | 'medium' | 'low';
+export type TriageTier =
+  | 'top_pick'
+  | 'shortlist'
+  | 'consider'
+  | 'unlikely'
+  | 'no_go';
+export type TriageRankingStatus = 'ranked' | 'insufficient_evidence';
+
+export interface CanonicalRequirementInput {
+  label: string;
+  type: RequirementType;
+  rank?: number | null;
+  sourceText?: string | null;
+  criteria?: string[];
+  order?: number;
+}
+
+export interface CanonicalRequirement {
+  id: string;
+  label: string;
+  type: RequirementType;
+  rank: number | null;
+  weight: number;
+  sourceText: string;
+  criteria: string[];
+  order: number;
+}
+
+export interface ParsedAnalysisBudget {
+  minimumAmount?: number | null;
+  maximumAmount: number;
+  currency: string;
+  basis: 'stay';
+  source: 'brief';
+}
+
+export interface CanonicalRequirementSet {
+  id: string;
+  schemaVersion: typeof REQUIREMENT_SCHEMA_VERSION;
+  parserVersion: string;
+  brief: string | null;
+  definitions: CanonicalRequirement[];
+  parsedBudget: ParsedAnalysisBudget | null;
+}
+
+export interface RequirementEvidence {
+  layer: 'details' | 'reviews' | 'photos';
+  polarity: 'supports' | 'contradicts';
+  text: string;
+  frequency?: string | null;
+  years?: number[];
+}
+
+export interface RequirementAssessmentInput {
+  requirementId: string;
+  status: RequirementStatus;
+  confidence: RequirementConfidence;
+  note: string;
+  evidence?: RequirementEvidence[];
+}
+
+export interface ScoredRequirementAssessment
+  extends RequirementAssessmentInput {
+  requirement: string;
+  label: string;
+  type: RequirementType;
+  rank: number | null;
+  weight: number;
+  order: number;
+  effective: number;
+}
+
+export interface DeterministicTriageScore {
+  scoreSource: 'deterministic_rubric';
+  rubricVersion: typeof TRIAGE_RUBRIC_VERSION;
+  requirementSetId: string;
+  rawFitScore: number;
+  fitScore: number;
+  tier: TriageTier;
+  capReasons: string[];
+  coverage: number;
+  rankingStatus: TriageRankingStatus;
+  rankingReason: string | null;
+  requirements: ScoredRequirementAssessment[];
+}
+
+export interface AffordabilityBudget {
+  amount: number | string;
+  currency: string;
+  basis: 'stay';
+  source: 'explicit' | 'brief';
+}
+
+export interface ComparableStayPrice {
+  amount: number | string;
+  currency: string;
+  basis: 'stay' | 'night' | 'unknown';
+  source: string;
+  capturedAt?: string | null;
+  freshness: 'fresh' | 'stale' | 'unknown';
+  rateType: 'public' | 'member' | 'unknown';
+  mandatoryChargesResolved: boolean;
+}
+
+export type AffordabilityUnknownReasonCode =
+  | 'no_budget_given'
+  | 'invalid_budget'
+  | 'price_missing'
+  | 'invalid_price'
+  | 'price_stale'
+  | 'price_freshness_unknown'
+  | 'currency_mismatch'
+  | 'stay_basis_unresolved'
+  | 'mandatory_charges_unresolved'
+  | 'rate_not_public';
+
+export interface AffordabilityResult {
+  status: 'within' | 'over' | 'unknown';
+  reasonCode: AffordabilityUnknownReasonCode | null;
+  reason: string | null;
+  budgetAmount: number | null;
+  priceAmount: number | null;
+  currency: string | null;
+  budgetCurrency: string | null;
+  priceCurrency: string | null;
+  basis: 'stay';
+  priceBasis: ComparableStayPrice['basis'] | null;
+  overByAmount: number | null;
+  overByPercent: number | null;
+  budgetSource: AffordabilityBudget['source'] | null;
+  priceSource: string | null;
+  priceCapturedAt: string | null;
+  freshness: ComparableStayPrice['freshness'] | null;
+  rateType: ComparableStayPrice['rateType'] | null;
+  mandatoryChargesResolved: boolean | null;
+  comparablePrice: ComparableStayPrice | null;
+}
+
+const REQUIREMENT_TYPES = new Set<RequirementType>([
+  'deal_breaker',
+  'must_have',
+  'priority',
+  'nice_to_have',
+]);
+
+const REQUIREMENT_STATUSES = new Set<RequirementStatus>([
+  'met',
+  'partial',
+  'unmet',
+  'unknown',
+]);
+
+const REQUIREMENT_CONFIDENCES = new Set<RequirementConfidence>([
+  'high',
+  'medium',
+  'low',
+]);
+
+const DEFAULT_REQUIREMENT_INPUTS: CanonicalRequirementInput[] = [
+  {
+    label: 'Clean and well maintained',
+    type: 'priority',
+    sourceText: 'Clean and well maintained',
+    criteria: ['clean rooms', 'well-maintained fixtures and furnishings'],
+  },
+  {
+    label: 'Comfortable sleep',
+    type: 'priority',
+    sourceText: 'Comfortable sleep',
+    criteria: ['comfortable bed', 'sleep environment without material disruption'],
+  },
+  {
+    label: 'Accurate and functional listing',
+    type: 'priority',
+    sourceText: 'Accurate and functional listing',
+    criteria: ['listing matches reality', 'advertised essentials work'],
+  },
+  {
+    label: 'Convenient location',
+    type: 'nice_to_have',
+    sourceText: 'Convenient location',
+    criteria: ['convenient access for a general traveler'],
+  },
+];
+
+function cleanText(value: unknown): string {
+  return typeof value === 'string' ? value.trim().replace(/\s+/g, ' ') : '';
+}
+
+function cleanCriteria(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const criterion = cleanText(value);
+    const key = criterion.toLocaleLowerCase('en-US');
+    if (!criterion || seen.has(key)) continue;
+    seen.add(key);
+    result.push(criterion);
+  }
+  return result;
+}
+
+function requirementSlug(label: string): string {
+  const slug = label
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase('en-US')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48)
+    .replace(/-+$/g, '');
+  return slug || 'requirement';
+}
+
+function normalizedCurrency(value: unknown): string {
+  return cleanText(value).toLocaleUpperCase('en-US');
+}
+
+function normalizeParsedBudget(
+  value: ParsedAnalysisBudget | null | undefined,
+): ParsedAnalysisBudget | null {
+  if (!value) return null;
+  const maximumAmount = Number(value.maximumAmount);
+  const minimumAmount =
+    value.minimumAmount == null ? null : Number(value.minimumAmount);
+  const currency = normalizedCurrency(value.currency);
+  if (
+    !Number.isFinite(maximumAmount)
+    || maximumAmount <= 0
+    || (minimumAmount != null
+      && (!Number.isFinite(minimumAmount)
+        || minimumAmount < 0
+        || minimumAmount > maximumAmount))
+    || !/^[A-Z]{3}$/.test(currency)
+  ) {
+    return null;
+  }
+  return {
+    ...(minimumAmount == null ? {} : { minimumAmount }),
+    maximumAmount,
+    currency,
+    basis: 'stay',
+    source: 'brief',
+  };
+}
+
+export function resolveRequirementWeight(
+  type: RequirementType,
+  rank?: number | null,
+): number {
+  switch (type) {
+    case 'deal_breaker':
+      return 4;
+    case 'must_have':
+      return 3;
+    case 'priority':
+      return rank === 1 ? 3 : 2;
+    case 'nice_to_have':
+      return 1;
+  }
+}
+
+export function buildCanonicalRequirementSet(input: {
+  brief?: string | null;
+  parserVersion: string;
+  definitions?: CanonicalRequirementInput[] | null;
+  parsedBudget?: ParsedAnalysisBudget | null;
+}): CanonicalRequirementSet {
+  const parserVersion = cleanText(input.parserVersion);
+  if (!parserVersion) {
+    throw new Error('Requirement parserVersion is required.');
+  }
+
+  const supplied =
+    Array.isArray(input.definitions) && input.definitions.length > 0
+      ? input.definitions
+      : DEFAULT_REQUIREMENT_INPUTS;
+  const ordered = supplied
+    .map((definition, index) => ({ definition, index }))
+    .sort((a, b) => {
+      const orderA = Number.isFinite(a.definition.order)
+        ? Number(a.definition.order)
+        : a.index + 1;
+      const orderB = Number.isFinite(b.definition.order)
+        ? Number(b.definition.order)
+        : b.index + 1;
+      return orderA - orderB || a.index - b.index;
+    });
+
+  const definitions = ordered.map(({ definition }, index) => {
+    const label = cleanText(definition.label);
+    if (!label) {
+      throw new Error(`Requirement ${index + 1} is missing a label.`);
+    }
+    if (!REQUIREMENT_TYPES.has(definition.type)) {
+      throw new Error(`Requirement ${index + 1} has an invalid type.`);
+    }
+    const rawRank = definition.rank;
+    const rank =
+      rawRank != null && Number.isInteger(rawRank) && rawRank > 0
+        ? rawRank
+        : null;
+    return {
+      id: `req-${String(index + 1).padStart(2, '0')}-${requirementSlug(label)}`,
+      label,
+      type: definition.type,
+      rank,
+      weight: resolveRequirementWeight(definition.type, rank),
+      sourceText: cleanText(definition.sourceText) || label,
+      criteria: cleanCriteria(definition.criteria),
+      order: index + 1,
+    } satisfies CanonicalRequirement;
+  });
+
+  const hashPayload = {
+    schemaVersion: REQUIREMENT_SCHEMA_VERSION,
+    parserVersion,
+    definitions,
+  };
+  const definitionHash = createHash('sha256')
+    .update(JSON.stringify(hashPayload))
+    .digest('hex')
+    .slice(0, 20);
+
+  return {
+    id: `reqset_${definitionHash}`,
+    schemaVersion: REQUIREMENT_SCHEMA_VERSION,
+    parserVersion,
+    brief: cleanText(input.brief) || null,
+    definitions,
+    parsedBudget: normalizeParsedBudget(input.parsedBudget),
+  };
+}
+
+export function getDefaultRequirementInputs(): CanonicalRequirementInput[] {
+  return DEFAULT_REQUIREMENT_INPUTS.map((definition) => ({
+    ...definition,
+    criteria: [...(definition.criteria ?? [])],
+  }));
+}
+
+export function requirementStatusValue(status: RequirementStatus): number {
+  switch (status) {
+    case 'met':
+      return 1;
+    case 'partial':
+    case 'unknown':
+      return 0.5;
+    case 'unmet':
+      return 0;
+  }
+}
+
+export function requirementConfidenceFactor(
+  confidence: RequirementConfidence,
+): number {
+  switch (confidence) {
+    case 'high':
+      return 1;
+    case 'medium':
+      return 0.75;
+    case 'low':
+      return 0.5;
+  }
+}
+
+export function effectiveRequirementValue(
+  status: RequirementStatus,
+  confidence: RequirementConfidence,
+): number {
+  if (status === 'unknown') return 0.5;
+  return (
+    0.5
+    + requirementConfidenceFactor(confidence)
+      * (requirementStatusValue(status) - 0.5)
+  );
+}
+
+export function tierForFitScore(score: number): TriageTier {
+  if (score >= 80) return 'top_pick';
+  if (score >= 65) return 'shortlist';
+  if (score >= 45) return 'consider';
+  if (score >= 25) return 'unlikely';
+  return 'no_go';
+}
+
+function normalizedAssessment(
+  definition: CanonicalRequirement,
+  assessment: RequirementAssessmentInput | undefined,
+): ScoredRequirementAssessment {
+  if (!assessment) {
+    return {
+      requirementId: definition.id,
+      requirement: definition.label,
+      label: definition.label,
+      type: definition.type,
+      rank: definition.rank,
+      weight: definition.weight,
+      order: definition.order,
+      status: 'unknown',
+      confidence: 'low',
+      note: 'The classifier did not return an outcome for this requirement.',
+      evidence: [],
+      effective: 0.5,
+    };
+  }
+  if (!REQUIREMENT_STATUSES.has(assessment.status)) {
+    throw new Error(`Invalid status for ${definition.id}: ${assessment.status}`);
+  }
+  if (!REQUIREMENT_CONFIDENCES.has(assessment.confidence)) {
+    throw new Error(
+      `Invalid confidence for ${definition.id}: ${assessment.confidence}`,
+    );
+  }
+  return {
+    requirementId: definition.id,
+    requirement: definition.label,
+    label: definition.label,
+    type: definition.type,
+    rank: definition.rank,
+    weight: definition.weight,
+    order: definition.order,
+    status: assessment.status,
+    confidence: assessment.confidence,
+    note: cleanText(assessment.note),
+    evidence: Array.isArray(assessment.evidence)
+      ? assessment.evidence.map((item) => ({
+          ...item,
+          text: cleanText(item.text),
+          years: Array.isArray(item.years)
+            ? item.years.filter((year) => Number.isInteger(year))
+            : undefined,
+        }))
+      : [],
+    effective: effectiveRequirementValue(
+      assessment.status,
+      assessment.confidence,
+    ),
+  };
+}
+
+export function scoreTriageAssessments(
+  requirementSet: CanonicalRequirementSet,
+  assessments: RequirementAssessmentInput[],
+): DeterministicTriageScore {
+  if (requirementSet.definitions.length === 0) {
+    throw new Error('Cannot score an empty requirement set.');
+  }
+
+  const definitionsById = new Map(
+    requirementSet.definitions.map((definition) => [definition.id, definition]),
+  );
+  const assessmentsById = new Map<string, RequirementAssessmentInput>();
+  for (const assessment of assessments) {
+    if (!definitionsById.has(assessment.requirementId)) {
+      throw new Error(
+        `Classifier returned unknown requirement ID: ${assessment.requirementId}`,
+      );
+    }
+    if (assessmentsById.has(assessment.requirementId)) {
+      throw new Error(
+        `Classifier returned duplicate requirement ID: ${assessment.requirementId}`,
+      );
+    }
+    assessmentsById.set(assessment.requirementId, assessment);
+  }
+
+  const requirements = requirementSet.definitions.map((definition) =>
+    normalizedAssessment(definition, assessmentsById.get(definition.id)));
+  const totalWeight = requirements.reduce(
+    (sum, requirement) => sum + requirement.weight,
+    0,
+  );
+  const knownWeight = requirements.reduce(
+    (sum, requirement) =>
+      sum + (requirement.status === 'unknown' ? 0 : requirement.weight),
+    0,
+  );
+  const weightedEffectiveEighths = requirements.reduce(
+    (sum, requirement) =>
+      sum + requirement.weight * Math.round(requirement.effective * 8),
+    0,
+  );
+
+  const rawFitScore = Number(
+    divideRoundHalfUp(
+      BigInt(100 * weightedEffectiveEighths),
+      BigInt(8 * totalWeight),
+    ),
+  );
+  const coverage = Number((knownWeight / totalWeight).toFixed(4));
+  const caps: Array<{ maximum: number; reason: string }> = [];
+  const addCap = (maximum: number, reason: string) => {
+    caps.push({ maximum, reason });
+  };
+
+  const majorUnmetHigh = requirements.filter(
+    (requirement) =>
+      requirement.weight >= 3
+      && requirement.status === 'unmet'
+      && requirement.confidence === 'high',
+  );
+
+  for (const requirement of requirements) {
+    const key = requirement.requirementId;
+    const isCritical = requirement.weight >= 4;
+    const isMajor = requirement.weight >= 3;
+
+    if (
+      isCritical
+      && requirement.status === 'unmet'
+      && requirement.confidence === 'high'
+    ) {
+      addCap(24, `weight_gte_4_unmet_high:${key}`);
+    }
+    if (
+      isMajor
+      && requirement.status === 'unmet'
+      && requirement.confidence === 'high'
+    ) {
+      addCap(44, `weight_gte_3_unmet_high:${key}`);
+    }
+    if (
+      isCritical
+      && requirement.status === 'unmet'
+      && requirement.confidence === 'medium'
+    ) {
+      addCap(44, `weight_gte_4_unmet_medium:${key}`);
+    }
+    if (
+      isCritical
+      && (
+        (requirement.status === 'unmet'
+          && requirement.confidence === 'low')
+        || requirement.status === 'partial'
+        || requirement.status === 'unknown'
+      )
+    ) {
+      addCap(64, `weight_gte_4_uncertain_or_unmet_low:${key}`);
+    }
+    if (
+      isMajor
+      && (
+        (requirement.status === 'unmet'
+          && requirement.confidence !== 'high')
+        || requirement.status === 'unknown'
+      )
+    ) {
+      addCap(64, `weight_gte_3_unknown_or_unmet_non_high:${key}`);
+    }
+    if (
+      isMajor
+      && requirement.status === 'met'
+      && requirement.confidence === 'low'
+    ) {
+      addCap(79, `weight_gte_3_met_low:${key}`);
+    }
+    if (isMajor && requirement.status === 'partial') {
+      addCap(79, `weight_gte_3_partial:${key}`);
+    }
+  }
+
+  if (majorUnmetHigh.length >= 2) {
+    addCap(
+      24,
+      `multiple_weight_gte_3_unmet_high:${majorUnmetHigh
+        .map((requirement) => requirement.requirementId)
+        .join(',')}`,
+    );
+  }
+
+  const maximum = caps.reduce(
+    (lowest, cap) => Math.min(lowest, cap.maximum),
+    100,
+  );
+  const fitScore = Math.min(rawFitScore, maximum);
+  const rankingStatus: TriageRankingStatus =
+    knownWeight / totalWeight < MIN_RANKED_COVERAGE
+      ? 'insufficient_evidence'
+      : 'ranked';
+
+  return {
+    scoreSource: 'deterministic_rubric',
+    rubricVersion: TRIAGE_RUBRIC_VERSION,
+    requirementSetId: requirementSet.id,
+    rawFitScore,
+    fitScore,
+    tier: tierForFitScore(fitScore),
+    capReasons: caps.map((cap) => cap.reason),
+    coverage,
+    rankingStatus,
+    rankingReason:
+      rankingStatus === 'insufficient_evidence'
+        ? `Insufficient evidence: ${Math.round(
+            coverage * 100,
+          )}% of requirement weight has a known outcome.`
+        : null,
+    requirements,
+  };
+}
+
+function currencyMinorDigits(currency: string): number {
+  if (['BIF', 'CLP', 'DJF', 'GNF', 'ISK', 'JPY', 'KMF', 'KRW', 'PYG', 'RWF',
+    'UGX', 'UYI', 'VND', 'VUV', 'XAF', 'XOF', 'XPF'].includes(currency)) {
+    return 0;
+  }
+  if (['BHD', 'IQD', 'JOD', 'KWD', 'LYD', 'OMR', 'TND'].includes(currency)) {
+    return 3;
+  }
+  return 2;
+}
+
+function decimalToMinorUnits(
+  value: number | string,
+  digits: number,
+): bigint | null {
+  let text: string;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value < 0) return null;
+    text = value.toFixed(Math.max(digits + 1, 6));
+  } else {
+    text = value.trim();
+  }
+  const match = text.match(/^(\d+)(?:\.(\d+))?$/);
+  if (!match) return null;
+  const whole = match[1];
+  const fraction = match[2] ?? '';
+  const kept = fraction.slice(0, digits).padEnd(digits, '0');
+  let minor = BigInt(whole) * (10n ** BigInt(digits));
+  if (kept) minor += BigInt(kept);
+  if ((fraction[digits] ?? '0') >= '5') minor += 1n;
+  return minor;
+}
+
+function minorUnitsToNumber(value: bigint, digits: number): number {
+  return Number(value) / (10 ** digits);
+}
+
+function divideRoundHalfUp(numerator: bigint, denominator: bigint): bigint {
+  return (numerator * 2n + denominator) / (denominator * 2n);
+}
+
+function staleAgeLabel(
+  capturedAt: string | null | undefined,
+  now: Date,
+): string {
+  if (!capturedAt) return 'capture age unavailable';
+  const capturedMs = Date.parse(capturedAt);
+  if (!Number.isFinite(capturedMs)) return 'capture age unavailable';
+  const ageMs = Math.max(0, now.getTime() - capturedMs);
+  const hours = Math.floor(ageMs / 3_600_000);
+  if (hours < 48) return `${hours} ${hours === 1 ? 'hour' : 'hours'} old`;
+  const days = Math.floor(hours / 24);
+  return `${days} ${days === 1 ? 'day' : 'days'} old`;
+}
+
+export function computeAffordability(input: {
+  budget?: AffordabilityBudget | null;
+  price?: ComparableStayPrice | null;
+  now?: Date;
+}): AffordabilityResult {
+  const budget = input.budget ?? null;
+  const price = input.price ?? null;
+  const now = input.now ?? new Date();
+  const budgetCurrencySnapshot = budget
+    ? normalizedCurrency(budget.currency) || null
+    : null;
+  const priceCurrencySnapshot = price
+    ? normalizedCurrency(price.currency) || null
+    : null;
+  const comparablePrice: ComparableStayPrice | null = price
+    ? {
+        amount: price.amount,
+        currency: price.currency,
+        basis: price.basis,
+        source: price.source,
+        capturedAt: price.capturedAt ?? null,
+        freshness: price.freshness,
+        rateType: price.rateType,
+        mandatoryChargesResolved: price.mandatoryChargesResolved,
+      }
+    : null;
+
+  const unknown = (
+    reasonCode: AffordabilityUnknownReasonCode,
+    reason: string,
+    values: Partial<AffordabilityResult> = {},
+  ): AffordabilityResult => ({
+    status: 'unknown',
+    reasonCode,
+    reason,
+    budgetAmount: null,
+    priceAmount: null,
+    currency: null,
+    budgetCurrency: budgetCurrencySnapshot,
+    priceCurrency: priceCurrencySnapshot,
+    basis: 'stay',
+    priceBasis: price?.basis ?? null,
+    overByAmount: null,
+    overByPercent: null,
+    budgetSource: budget?.source ?? null,
+    priceSource: price?.source ?? null,
+    priceCapturedAt: price?.capturedAt ?? null,
+    freshness: price?.freshness ?? null,
+    rateType: price?.rateType ?? null,
+    mandatoryChargesResolved: price?.mandatoryChargesResolved ?? null,
+    comparablePrice,
+    ...values,
+  });
+
+  if (!budget) {
+    return unknown(
+      'no_budget_given',
+      'No analysis budget was given.',
+    );
+  }
+
+  const budgetCurrency = normalizedCurrency(budget.currency);
+  const budgetDigits = currencyMinorDigits(budgetCurrency);
+  const budgetMinor = decimalToMinorUnits(budget.amount, budgetDigits);
+  if (
+    budget.basis !== 'stay'
+    || !/^[A-Z]{3}$/.test(budgetCurrency)
+    || budgetMinor == null
+    || budgetMinor <= 0n
+  ) {
+    return unknown(
+      'invalid_budget',
+      'The analysis budget is invalid or is not a full-stay amount.',
+    );
+  }
+  const budgetAmount = minorUnitsToNumber(budgetMinor, budgetDigits);
+
+  if (!price) {
+    return unknown(
+      'price_missing',
+      'Price is missing for the selected stay.',
+      { budgetAmount, currency: budgetCurrency },
+    );
+  }
+
+  const priceCurrency = normalizedCurrency(price.currency);
+  const priceDigits = currencyMinorDigits(priceCurrency);
+  const priceMinor = decimalToMinorUnits(price.amount, priceDigits);
+  if (
+    !/^[A-Z]{3}$/.test(priceCurrency)
+    || priceMinor == null
+    || priceMinor < 0n
+  ) {
+    return unknown(
+      'invalid_price',
+      'The selected-stay price is invalid.',
+      { budgetAmount, currency: budgetCurrency },
+    );
+  }
+  const priceAmount = minorUnitsToNumber(priceMinor, priceDigits);
+  const knownValues = {
+    budgetAmount,
+    priceAmount,
+    currency: budgetCurrency,
+    budgetCurrency,
+    priceCurrency,
+  };
+
+  if (priceCurrency !== budgetCurrency) {
+    return unknown(
+      'currency_mismatch',
+      `Price currency ${priceCurrency} does not match budget currency ${budgetCurrency}.`,
+      knownValues,
+    );
+  }
+  if (price.freshness === 'stale') {
+    return unknown(
+      'price_stale',
+      `Price is stale (${staleAgeLabel(price.capturedAt, now)}).`,
+      knownValues,
+    );
+  }
+  if (price.freshness !== 'fresh') {
+    const age = price.capturedAt
+      ? ` (${staleAgeLabel(price.capturedAt, now)})`
+      : '';
+    return unknown(
+      'price_freshness_unknown',
+      `Price freshness is unknown${age}.`,
+      knownValues,
+    );
+  }
+  if (price.basis !== 'stay') {
+    return unknown(
+      'stay_basis_unresolved',
+      'Price is not a comparable total for the full stay.',
+      knownValues,
+    );
+  }
+  if (!price.mandatoryChargesResolved) {
+    return unknown(
+      'mandatory_charges_unresolved',
+      'Mandatory charges are unresolved in this price.',
+      knownValues,
+    );
+  }
+  if (price.rateType !== 'public') {
+    return unknown(
+      'rate_not_public',
+      'The available price is not a public rate.',
+      knownValues,
+    );
+  }
+
+  if (priceMinor <= budgetMinor) {
+    return {
+      status: 'within',
+      reasonCode: null,
+      reason: null,
+      budgetAmount,
+      priceAmount,
+      currency: budgetCurrency,
+      budgetCurrency,
+      priceCurrency,
+      basis: 'stay',
+      priceBasis: price.basis,
+      overByAmount: 0,
+      overByPercent: 0,
+      budgetSource: budget.source,
+      priceSource: price.source,
+      priceCapturedAt: price.capturedAt ?? null,
+      freshness: price.freshness,
+      rateType: price.rateType,
+      mandatoryChargesResolved: price.mandatoryChargesResolved,
+      comparablePrice,
+    };
+  }
+
+  const overMinor = priceMinor - budgetMinor;
+  const percentHundredths = divideRoundHalfUp(
+    overMinor * 10_000n,
+    budgetMinor,
+  );
+  return {
+    status: 'over',
+    reasonCode: null,
+    reason: null,
+    budgetAmount,
+    priceAmount,
+    currency: budgetCurrency,
+    budgetCurrency,
+    priceCurrency,
+    basis: 'stay',
+    priceBasis: price.basis,
+    overByAmount: minorUnitsToNumber(overMinor, budgetDigits),
+    overByPercent: Number(percentHundredths) / 100,
+    budgetSource: budget.source,
+    priceSource: price.source,
+    priceCapturedAt: price.capturedAt ?? null,
+    freshness: price.freshness,
+    rateType: price.rateType,
+    mandatoryChargesResolved: price.mandatoryChargesResolved,
+    comparablePrice,
+  };
+}
+
+function asStoredRecord(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function parseStoredComparablePrice(
+  value: unknown,
+): ComparableStayPrice | null | undefined {
+  if (value === null) return null;
+  const record = asStoredRecord(value);
+  if (!record) return undefined;
+
+  const amount = record.amount;
+  const currency = record.currency;
+  const basis = record.basis;
+  const source = record.source;
+  const capturedAt = record.capturedAt;
+  const freshness = record.freshness;
+  const rateType = record.rateType;
+  const mandatoryChargesResolved = record.mandatoryChargesResolved;
+  if (
+    (typeof amount !== 'number' && typeof amount !== 'string')
+    || typeof currency !== 'string'
+    || (basis !== 'stay' && basis !== 'night' && basis !== 'unknown')
+    || typeof source !== 'string'
+    || (capturedAt !== null && capturedAt !== undefined
+      && typeof capturedAt !== 'string')
+    || (freshness !== 'fresh' && freshness !== 'stale'
+      && freshness !== 'unknown')
+    || (rateType !== 'public' && rateType !== 'member'
+      && rateType !== 'unknown')
+    || typeof mandatoryChargesResolved !== 'boolean'
+  ) {
+    return undefined;
+  }
+
+  return {
+    amount,
+    currency,
+    basis,
+    source,
+    capturedAt:
+      typeof capturedAt === 'string' ? capturedAt : null,
+    freshness,
+    rateType,
+    mandatoryChargesResolved,
+  };
+}
+
+/**
+ * Recalculate only the affordability dimension from a persisted rubric result.
+ * Returns null for pre-snapshot records so callers preserve old JSON rather than
+ * guessing at price inputs.
+ */
+export function recomputeStoredAffordability(input: {
+  affordability: unknown;
+  budget?: AffordabilityBudget | null;
+  now?: Date;
+}): AffordabilityResult | null {
+  const stored = asStoredRecord(input.affordability);
+  if (
+    !stored
+    || !Object.prototype.hasOwnProperty.call(stored, 'comparablePrice')
+  ) {
+    return null;
+  }
+  const price = parseStoredComparablePrice(stored.comparablePrice);
+  if (price === undefined) return null;
+  return computeAffordability({
+    budget: input.budget ?? null,
+    price,
+    now: input.now,
+  });
+}

--- a/src/triage.ts
+++ b/src/triage.ts
@@ -7,6 +7,17 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { parseModelConfig, getProviderApiKey, PROVIDER_KEY_NAMES, type LLMProvider, type UsageSummary } from './analyze.js';
+import {
+  buildCanonicalRequirementSet,
+  computeAffordability,
+  scoreTriageAssessments,
+  type AffordabilityBudget,
+  type CanonicalRequirementInput,
+  type CanonicalRequirementSet,
+  type ComparableStayPrice,
+  type ParsedAnalysisBudget,
+  type RequirementAssessmentInput,
+} from './triage-rubric.js';
 
 // --- Types ---
 
@@ -16,6 +27,11 @@ export interface TriageOptions {
   aiPhotosFile?: string;     // Path to ai-photos JSON
   model?: string;            // Default: gemini-3-flash-preview:high
   priorities?: string;       // Guest requirements (free text)
+  requirementSet?: CanonicalRequirementSet;
+  temperature?: number;      // Classification temperature. Default: 0
+  budget?: AffordabilityBudget;
+  price?: ComparableStayPrice;
+  priceFreshness?: ComparableStayPrice['freshness'];
 }
 
 export const TRIAGE_EVIDENCE_GAP_ORDER = [
@@ -37,6 +53,7 @@ export interface TriageResult {
   data: any;                 // Parsed triage JSON
   model: string;
   provider: LLMProvider;
+  requirementSet: CanonicalRequirementSet;
   evidenceGaps: TriageEvidenceGap[];
   tokensUsed?: number;
   usage?: UsageSummary;
@@ -46,6 +63,7 @@ export interface TriageResult {
 
 const MAX_RETRIES = 3;
 const RETRY_BASE_MS = 5000;
+export const TRIAGE_REQUIREMENT_PARSER_VERSION = 'triage-requirements-v1';
 
 // Pricing per 1M tokens (USD)
 const PRICING: Record<string, { input: number; output: number }> = {
@@ -57,7 +75,36 @@ const PRICING: Record<string, { input: number; output: number }> = {
 
 // --- System prompt ---
 
-const TRIAGE_SYSTEM_PROMPT = `You are a property evaluator helping a specific guest decide which rental to book. You have three data sources for each listing:
+const REQUIREMENT_PARSE_SYSTEM_PROMPT = `Convert one guest brief into a canonical, reusable set of quality requirements for comparing many properties.
+
+## Separation of concerns
+- Quality requirements describe evidence-backed property fit only.
+- Extract price/budget language into the separate budget object. Never emit budget, price, value for money, price freshness, or availability as a quality requirement.
+
+## Requirement types
+- deal_breaker: an explicit cannot-accept condition ("will not", "cannot", "must not") or an objective safety/accessibility constraint.
+- must_have: explicit "must", "need", "require", or an objective occupancy/accessibility need.
+- priority: a strong or ranked preference that is not stated as non-negotiable.
+- nice_to_have: a preference or bonus.
+
+## Canonicalization
+- Preserve explicit ranks. Use rank=1 for "#1", "first", or "by far" priority language.
+- Split compound text only when parts can be evaluated independently.
+- Keep synonyms and closely related evidence signals together as criteria.
+- If a ranked umbrella is split, copy its type and rank to every child.
+- Quiet environment, bed comfort, blackout conditions, workspace, and walkability are independently evaluable.
+- Keep sourceText grounded in the guest brief.
+- Do not create IDs or weights. Code owns them.
+- If the brief has only budget language, return an empty definitions array; code will apply the versioned default quality set.
+
+## Budget
+- Use the upper bound of a range as maximumAmount and retain minimumAmount when supplied.
+- Normalize currency to an ISO 4217 code when the brief makes it clear.
+- Do not inflate the maximum for "slightly over is acceptable"; overage is shown separately.`;
+
+const TRIAGE_SYSTEM_PROMPT = `You are a property evidence classifier helping a specific guest compare rentals. The user message supplies a frozen canonical requirement set. Classify exactly those requirement IDs; never parse, merge, split, rename, reorder, reweight, or add requirements.
+
+You have three data sources for each listing:
 
 1. **Listing Details** (most reliable) — factual data from the platform: beds, amenities, pricing, description, ratings
 2. **Review Analysis** (reliable) — AI-condensed summary of guest reviews with themes, quotes, scores
@@ -72,67 +119,126 @@ const TRIAGE_SYSTEM_PROMPT = `You are a property evaluator helping a specific gu
 - Mark requirements that depend only on missing evidence as unknown, and state the limitation in the tier reason and summary.
 
 ## Requirement Evaluation Rules
-1. Parse the guest's requirements from their free text.
-2. Classify each as **must_have** (strong language: "need", "must", "essential", "require", critical needs like beds/rooms) or **nice_to_have** (preferences: "prefer", "ideally", "would be nice", "bonus").
-3. For each requirement, determine status:
+1. Return one outcome for every supplied requirement ID.
+2. For each requirement, determine status:
    - **met**: Clear evidence it's satisfied
    - **partial**: Partially satisfied or with caveats
    - **unmet**: Clear evidence it's NOT satisfied
    - **unknown**: Insufficient data to determine
-4. Be **conservative**: prefer "unknown" over "unmet" when data is insufficient. Never assume the worst.
-5. **An unmet must_have with high confidence IS a deal-breaker.** These are the guest's non-negotiable requirements. If someone needs a separate bedroom for their daughter and the listing doesn't have one, that's a deal-breaker — period. It doesn't matter how clean or well-located the place is. Include it in the dealBreakers array.
+3. Be conservative: prefer "unknown" over "unmet" when data is insufficient. Never assume the worst.
+4. Confidence describes evidence strength, not how important the requirement is.
+5. Include the strongest supporting and contradicting evidence. Use exact, concise evidence text from the supplied artifacts when possible.
+6. Frequency and years are evidence metadata only; omit them when unavailable.
 
-## Scoring Rules
-- **scores.fit** (0-10): How well the listing matches the guest's specific requirements. This is the MOST important dimension.
-  - If ANY must_have is unmet with high confidence, fit score MUST be ≤ 3.
-  - If ANY must_have is unmet with medium confidence, fit score MUST be ≤ 5.
-- **fitScore** (0-100): Overall suitability score combining:
-  - ~50% from fit (requirement match)
-  - ~25% from quality (cleanliness, modernity, reviews)
-  - ~15% from value for money
-  - ~10% from bonuses (great location, exceptional host, standout features)
-- Same quality at a lower price should score higher on valueForMoney.
-- **Hard tier caps based on must_have status:**
-  - If ONE must_have is unmet with high confidence → tier MUST be "unlikely" or "no_go", fitScore ≤ 40
-  - If TWO+ must_haves are unmet with high confidence → tier MUST be "no_go", fitScore ≤ 24
-  - If ANY must_have is unmet with medium confidence → tier MUST be "unlikely" or below, fitScore ≤ 44
-  - top_pick requires ALL must_haves met
-  - shortlist requires ALL must_haves met or partial
-- **Tier must match fitScore range exactly:**
-  - top_pick: 80-100 — All must-haves met, strong on priorities
-  - shortlist: 65-79 — Most requirements met, minor compromises on nice-to-haves only
-  - consider: 45-64 — Notable gaps but could work (no unmet must-haves with high confidence)
-  - unlikely: 25-44 — Significant issues on key requirements, or a must-have unmet
-  - no_go: 0-24 — Multiple confirmed deal-breakers or a single critical one that makes the listing completely unsuitable
+## Verdict boundary
+- Do not output fitScore, tier, weights, requirement types, caps, or requirement definitions.
+- Code computes the quality score and tier deterministically after your classifications.
+- Price/value prose and diagnostic dimension scores never affect that verdict.
 
 ## Output Guidelines
 - **bedSetup**: Describe the actual sleeping arrangement concisely
 - **highlights**: Top 3-5 genuinely standout features relevant to this guest
 - **concerns**: Top 3-5 notable issues relevant to this guest
-- **dealBreakers**: Any must_have requirement that is unmet with high confidence.
+- **dealBreakers**: Confirmed evidence that makes a weight-3-or-higher requirement fail.
 - **summary**: 2-3 sentences — would you recommend this to this specific guest? Why or why not?
 - **price.valueAssessment**: Compare price to quality/location/amenities. "unknown" if no price data.`;
 
 // --- JSON response schema for Gemini structured output ---
 
+const REQUIREMENT_PARSE_JSON_SCHEMA = {
+  type: 'object' as const,
+  properties: {
+    definitions: {
+      type: 'array' as const,
+      items: {
+        type: 'object' as const,
+        properties: {
+          label: { type: 'string' as const },
+          type: {
+            type: 'string' as const,
+            enum: ['deal_breaker', 'must_have', 'priority', 'nice_to_have'],
+          },
+          rank: { type: 'number' as const, nullable: true },
+          sourceText: { type: 'string' as const },
+          criteria: {
+            type: 'array' as const,
+            items: { type: 'string' as const },
+          },
+          order: { type: 'number' as const },
+        },
+        required: [
+          'label',
+          'type',
+          'rank',
+          'sourceText',
+          'criteria',
+          'order',
+        ] as const,
+      },
+    },
+    budget: {
+      type: 'object' as const,
+      nullable: true,
+      properties: {
+        minimumAmount: { type: 'number' as const, nullable: true },
+        maximumAmount: { type: 'number' as const },
+        currency: { type: 'string' as const },
+      },
+      required: ['minimumAmount', 'maximumAmount', 'currency'] as const,
+    },
+  },
+  required: ['definitions', 'budget'] as const,
+};
+
 const TRIAGE_JSON_SCHEMA = {
   type: 'object' as const,
   properties: {
-    fitScore: { type: 'number' as const },
-    tier: { type: 'string' as const, enum: ['top_pick', 'shortlist', 'consider', 'unlikely', 'no_go'] },
-    tierReason: { type: 'string' as const },
     requirements: {
       type: 'array' as const,
       items: {
         type: 'object' as const,
         properties: {
-          requirement: { type: 'string' as const },
-          type: { type: 'string' as const, enum: ['must_have', 'nice_to_have'] },
+          requirementId: { type: 'string' as const },
           status: { type: 'string' as const, enum: ['met', 'partial', 'unmet', 'unknown'] },
           confidence: { type: 'string' as const, enum: ['high', 'medium', 'low'] },
           note: { type: 'string' as const },
+          evidence: {
+            type: 'array' as const,
+            items: {
+              type: 'object' as const,
+              properties: {
+                layer: {
+                  type: 'string' as const,
+                  enum: ['details', 'reviews', 'photos'],
+                },
+                polarity: {
+                  type: 'string' as const,
+                  enum: ['supports', 'contradicts'],
+                },
+                text: { type: 'string' as const },
+                frequency: { type: 'string' as const, nullable: true },
+                years: {
+                  type: 'array' as const,
+                  items: { type: 'number' as const },
+                },
+              },
+              required: [
+                'layer',
+                'polarity',
+                'text',
+                'frequency',
+                'years',
+              ] as const,
+            },
+          },
         },
-        required: ['requirement', 'type', 'status', 'confidence', 'note'] as const,
+        required: [
+          'requirementId',
+          'status',
+          'confidence',
+          'note',
+          'evidence',
+        ] as const,
       },
     },
     scores: {
@@ -162,7 +268,7 @@ const TRIAGE_JSON_SCHEMA = {
     dealBreakers: { type: 'array' as const, items: { type: 'string' as const } },
     summary: { type: 'string' as const },
   },
-  required: ['fitScore', 'tier', 'tierReason', 'requirements', 'scores', 'bedSetup', 'price', 'highlights', 'concerns', 'dealBreakers', 'summary'] as const,
+  required: ['requirements', 'scores', 'bedSetup', 'price', 'highlights', 'concerns', 'dealBreakers', 'summary'] as const,
 };
 
 // --- Helpers ---
@@ -221,6 +327,7 @@ async function callGeminiTriage(
   userMessage: string,
   jsonSchema: any,
   label?: string,
+  temperature = 0,
 ): Promise<CallResult> {
   const generateConfig: any = {
     model: modelName,
@@ -228,7 +335,7 @@ async function callGeminiTriage(
     config: {
       systemInstruction: systemPrompt,
       maxOutputTokens: 8192,
-      temperature: 1.0,
+      temperature,
       responseMimeType: 'application/json',
       responseSchema: jsonSchema,
     },
@@ -278,7 +385,10 @@ async function callGeminiTriage(
 
 // --- Usage tracking ---
 
-function formatUsageSummary(usageMetadata: any, modelName: string, durationMs: number): string {
+function usageSummary(
+  usageMetadata: any,
+  modelName: string,
+): UsageSummary {
   const prompt = usageMetadata?.promptTokenCount || 0;
   const response = usageMetadata?.candidatesTokenCount || 0;
   const thinking = usageMetadata?.thoughtsTokenCount || 0;
@@ -286,13 +396,307 @@ function formatUsageSummary(usageMetadata: any, modelName: string, durationMs: n
   const pricing = PRICING[modelName] || PRICING.default;
   const inputCost = (prompt / 1_000_000) * pricing.input;
   const outputCost = (response / 1_000_000) * pricing.output;
-  const totalCost = inputCost + outputCost;
+  return {
+    inputTokens: prompt,
+    outputTokens: response,
+    thinkingTokens: thinking || undefined,
+    cost: +(inputCost + outputCost).toFixed(4),
+  };
+}
 
-  let line = `  ${prompt.toLocaleString()} in / ${response.toLocaleString()} out`;
-  if (thinking) line += ` (${thinking.toLocaleString()} thinking)`;
+function mergeUsage(
+  values: Array<UsageSummary | undefined>,
+): UsageSummary {
+  const present = values.filter(
+    (value): value is UsageSummary => value != null,
+  );
+  const thinking = present.reduce(
+    (sum, value) => sum + (value.thinkingTokens ?? 0),
+    0,
+  );
+  return {
+    inputTokens: present.reduce(
+      (sum, value) => sum + value.inputTokens,
+      0,
+    ),
+    outputTokens: present.reduce(
+      (sum, value) => sum + value.outputTokens,
+      0,
+    ),
+    thinkingTokens: thinking || undefined,
+    cost: +present.reduce((sum, value) => sum + value.cost, 0).toFixed(4),
+  };
+}
+
+function formatUsageSummary(
+  usage: UsageSummary,
+  modelName: string,
+  durationMs: number,
+): string {
+  const pricing = PRICING[modelName] || PRICING.default;
+  const inputCost = (usage.inputTokens / 1_000_000) * pricing.input;
+  const outputCost = (usage.outputTokens / 1_000_000) * pricing.output;
+
+  let line = `  ${usage.inputTokens.toLocaleString()} in / ${usage.outputTokens.toLocaleString()} out`;
+  if (usage.thinkingTokens) {
+    line += ` (${usage.thinkingTokens.toLocaleString()} thinking)`;
+  }
   line += ` [${(durationMs / 1000).toFixed(1)}s]`;
-  line += `\n  Cost: $${inputCost.toFixed(4)} input + $${outputCost.toFixed(4)} output = $${totalCost.toFixed(4)} (${modelName})`;
+  line += `\n  Cost: $${inputCost.toFixed(4)} input + $${outputCost.toFixed(4)} output = $${usage.cost.toFixed(4)} (${modelName})`;
   return line;
+}
+
+export function getTriageRequirementParserVersion(
+  modelStr: string,
+  priorities?: string | null,
+): string {
+  if (!priorities?.trim()) return 'triage-default-requirements-v1';
+  const modelConfig = parseModelConfig(modelStr);
+  return [
+    TRIAGE_REQUIREMENT_PARSER_VERSION,
+    modelConfig.provider,
+    modelConfig.model,
+    modelConfig.thinkingLevel || 'default',
+  ].join(':');
+}
+
+async function parseRequirementSet(input: {
+  ai: any;
+  modelName: string;
+  thinkingLevel: string | null;
+  priorities?: string;
+}): Promise<{
+  requirementSet: CanonicalRequirementSet;
+  call: CallResult | null;
+}> {
+  const parserVersion = getTriageRequirementParserVersion(
+    `${input.modelName}${input.thinkingLevel ? `:${input.thinkingLevel}` : ''}`,
+    input.priorities,
+  );
+  if (!input.priorities?.trim()) {
+    return {
+      requirementSet: buildCanonicalRequirementSet({
+        brief: null,
+        parserVersion,
+      }),
+      call: null,
+    };
+  }
+
+  const call = await callGeminiTriage(
+    input.ai,
+    input.modelName,
+    input.thinkingLevel,
+    REQUIREMENT_PARSE_SYSTEM_PROMPT,
+    input.priorities,
+    REQUIREMENT_PARSE_JSON_SCHEMA,
+    'requirements',
+    0,
+  );
+  let parsed: any;
+  try {
+    parsed = JSON.parse(call.text);
+  } catch {
+    throw new Error(
+      `Failed to parse requirement response as JSON:\n${call.text.slice(0, 500)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Requirement response must be a JSON object.');
+  }
+  if (!Array.isArray(parsed.definitions)) {
+    throw new Error('Requirement response must contain definitions.');
+  }
+
+  const parsedBudget: ParsedAnalysisBudget | null =
+    parsed.budget && typeof parsed.budget === 'object'
+      ? {
+          minimumAmount: parsed.budget.minimumAmount ?? null,
+          maximumAmount: parsed.budget.maximumAmount,
+          currency: parsed.budget.currency,
+          basis: 'stay',
+          source: 'brief',
+        }
+      : null;
+
+  return {
+    requirementSet: buildCanonicalRequirementSet({
+      brief: input.priorities,
+      parserVersion,
+      definitions: parsed.definitions as CanonicalRequirementInput[],
+      parsedBudget,
+    }),
+    call,
+  };
+}
+
+function normalizePriceCurrency(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const text = value.trim().toUpperCase();
+  if (/^[A-Z]{3}$/.test(text)) return text;
+  if (text === '$' || text.includes('US$')) return 'USD';
+  if (text === '€') return 'EUR';
+  if (text === '£') return 'GBP';
+  if (text.includes('ZŁ')) return 'PLN';
+  return null;
+}
+
+function parsePriceText(
+  value: unknown,
+  fallbackCurrency?: unknown,
+): { amount: number; currency: string } | null {
+  if (typeof value !== 'string') return null;
+  const currency =
+    normalizePriceCurrency(value.match(/\b[A-Z]{3}\b/)?.[0])
+    ?? normalizePriceCurrency(
+      value.includes('zł')
+        ? 'PLN'
+        : value.includes('€')
+          ? 'EUR'
+          : value.includes('£')
+            ? 'GBP'
+            : value.includes('$')
+              ? 'USD'
+              : fallbackCurrency,
+    );
+  if (!currency) return null;
+
+  const numeric = value.match(/\d[\d\s\u00a0.,]*/)?.[0]
+    ?.replace(/[\s\u00a0]/g, '');
+  if (!numeric) return null;
+
+  const lastComma = numeric.lastIndexOf(',');
+  const lastDot = numeric.lastIndexOf('.');
+  let normalized = numeric;
+  if (lastComma >= 0 && lastDot >= 0) {
+    const decimalSeparator = lastComma > lastDot ? ',' : '.';
+    const thousandsSeparator = decimalSeparator === ',' ? '.' : ',';
+    normalized = normalized.split(thousandsSeparator).join('');
+    normalized = normalized.replace(decimalSeparator, '.');
+  } else {
+    const separator = lastComma >= 0 ? ',' : lastDot >= 0 ? '.' : null;
+    if (separator) {
+      const occurrences = normalized.split(separator).length - 1;
+      const fractionalDigits = normalized.length
+        - normalized.lastIndexOf(separator)
+        - 1;
+      if (occurrences > 1 || fractionalDigits === 3) {
+        normalized = normalized.split(separator).join('');
+      } else {
+        normalized = normalized.replace(separator, '.');
+      }
+    }
+  }
+  const amount = Number(normalized);
+  return Number.isFinite(amount) && amount >= 0
+    ? { amount, currency }
+    : null;
+}
+
+export function extractComparableStayPrice(
+  listing: any,
+  freshness: ComparableStayPrice['freshness'] = 'unknown',
+): ComparableStayPrice | null {
+  const pricing = listing?.pricing;
+  if (!pricing || typeof pricing !== 'object') return null;
+
+  const capturedAt =
+    typeof listing.priceCapturedAt === 'string'
+      ? listing.priceCapturedAt
+      : typeof listing.scrapedAt === 'string'
+        ? listing.scrapedAt
+        : null;
+  const rateType: ComparableStayPrice['rateType'] =
+    pricing.rateType === 'member'
+      ? 'member'
+      : pricing.rateType === 'unknown'
+        ? 'unknown'
+        : 'public';
+  const mandatoryChargesResolved =
+    typeof pricing.mandatoryChargesResolved === 'boolean'
+      ? pricing.mandatoryChargesResolved
+      : true;
+
+  if (
+    pricing.total
+    && typeof pricing.total === 'object'
+    && typeof pricing.total.amount === 'number'
+  ) {
+    const currency = normalizePriceCurrency(pricing.total.currency);
+    if (currency) {
+      return {
+        amount: pricing.total.amount,
+        currency,
+        basis: 'stay',
+        source:
+          typeof pricing.total.source === 'string'
+            ? pricing.total.source
+            : 'upstream',
+        capturedAt,
+        freshness,
+        rateType,
+        mandatoryChargesResolved,
+      };
+    }
+  }
+
+  const directTotal = parsePriceText(
+    pricing.totalPrice,
+    pricing.currency,
+  );
+  if (directTotal) {
+    return {
+      ...directTotal,
+      basis: 'stay',
+      source: 'upstream',
+      capturedAt,
+      freshness,
+      rateType,
+      mandatoryChargesResolved,
+    };
+  }
+
+  if (Array.isArray(pricing.rooms)) {
+    const totals = pricing.rooms
+      .map((room: any) =>
+        parsePriceText(room?.totalPrice, pricing.currency))
+      .filter(
+        (
+          total: { amount: number; currency: string } | null,
+        ): total is { amount: number; currency: string } => total != null,
+      )
+      .sort((a: { amount: number }, b: { amount: number }) =>
+        a.amount - b.amount);
+    if (totals.length > 0) {
+      return {
+        ...totals[0],
+        basis: 'stay',
+        source: 'upstream',
+        capturedAt,
+        freshness,
+        rateType,
+        mandatoryChargesResolved,
+      };
+    }
+  }
+  return null;
+}
+
+function deterministicTierReason(
+  score: ReturnType<typeof scoreTriageAssessments>,
+): string {
+  if (score.rankingReason) return score.rankingReason;
+  if (score.capReasons.length > 0) {
+    return (
+      `Deterministic quality score ${score.rawFitScore} was capped to `
+      + `${score.fitScore} by ${score.capReasons.length} hard-requirement `
+      + `${score.capReasons.length === 1 ? 'rule' : 'rules'}.`
+    );
+  }
+  return (
+    `Deterministic quality fit from ${score.requirements.length} canonical `
+    + `requirements with ${Math.round(score.coverage * 100)}% known-weight coverage.`
+  );
 }
 
 // --- Main entry point ---
@@ -300,6 +704,10 @@ function formatUsageSummary(usageMetadata: any, modelName: string, durationMs: n
 export async function runTriage(options: TriageOptions): Promise<TriageResult> {
   const { listingFile, aiReviewsFile, aiPhotosFile, priorities } = options;
   const modelStr = options.model || process.env.LLM_MODEL || 'gemini-3-flash-preview:high';
+  const temperature = options.temperature ?? 0;
+  if (!Number.isFinite(temperature) || temperature < 0 || temperature > 2) {
+    throw new Error('Triage temperature must be between 0 and 2.');
+  }
 
   // 1. Parse model config
   const modelConfig = parseModelConfig(modelStr);
@@ -356,11 +764,24 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
 
   const normalizedEvidenceGaps = normalizeTriageEvidenceGaps(evidenceGaps);
 
-  // 5. Build user message
+  // 5. Resolve the canonical set before evaluating the listing.
+  const { GoogleGenAI } = await import('@google/genai');
+  const ai = new GoogleGenAI({ apiKey });
+  const parsedRequirements = options.requirementSet
+    ? { requirementSet: options.requirementSet, call: null }
+    : await parseRequirementSet({
+        ai,
+        modelName: modelConfig.model,
+        thinkingLevel: modelConfig.thinkingLevel,
+        priorities,
+      });
+  const requirementSet = parsedRequirements.requirementSet;
+
+  // 6. Build the classifier message.
   const sections: string[] = [];
 
-  sections.push('## Guest Requirements');
-  sections.push(priorities || 'No specific requirements provided. Evaluate for a general traveler.');
+  sections.push('## Canonical Requirement Definitions');
+  sections.push(JSON.stringify(requirementSet.definitions, null, 2));
   sections.push('');
 
   sections.push('## Evidence Availability');
@@ -388,12 +809,11 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
 
   const userMessage = sections.join('\n');
 
-  // 6. Call Gemini API
+  // 7. Classify evidence with no model-authored verdict.
   console.error(`Triage: ${listingData.title || listingData.id || listingFile}`);
   console.error(`Model: ${modelConfig.model}${modelConfig.thinkingLevel ? `:${modelConfig.thinkingLevel}` : ''}`);
-
-  const { GoogleGenAI } = await import('@google/genai');
-  const ai = new GoogleGenAI({ apiKey });
+  console.error(`Requirement set: ${requirementSet.id}`);
+  console.error(`Classification temperature: ${temperature}`);
 
   const result = await callGeminiTriage(
     ai,
@@ -403,9 +823,10 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
     userMessage,
     TRIAGE_JSON_SCHEMA,
     'triage',
+    temperature,
   );
 
-  // 7. Parse result
+  // 8. Parse classifications and apply the pure rubric.
   let parsed: any;
   try {
     parsed = JSON.parse(result.text);
@@ -415,25 +836,68 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error('Gemini triage response must be a JSON object.');
   }
-  parsed.evidenceGaps = normalizedEvidenceGaps;
+  if (!Array.isArray(parsed.requirements)) {
+    throw new Error('Gemini triage response must contain requirements.');
+  }
 
-  // 8. Log usage
+  const score = scoreTriageAssessments(
+    requirementSet,
+    parsed.requirements as RequirementAssessmentInput[],
+  );
+  const parsedBudget = requirementSet.parsedBudget;
+  const budget: AffordabilityBudget | null =
+    options.budget
+    ?? (parsedBudget
+      ? {
+          amount: parsedBudget.maximumAmount,
+          currency: parsedBudget.currency,
+          basis: 'stay',
+          source: 'brief',
+        }
+      : null);
+  const price =
+    options.price
+    ?? extractComparableStayPrice(
+      listingData,
+      options.priceFreshness ?? 'unknown',
+    );
+  const affordability = computeAffordability({ budget, price });
+  const triageData = {
+    ...parsed,
+    ...score,
+    tierReason: deterministicTierReason(score),
+    requirementSet,
+    affordability,
+    evidenceGaps: normalizedEvidenceGaps,
+  };
+
+  // 9. Log and return combined parser + classifier usage.
+  const requirementUsage = parsedRequirements.call
+    ? usageSummary(
+        parsedRequirements.call.usageMetadata,
+        modelConfig.model,
+      )
+    : undefined;
+  const classificationUsage = usageSummary(
+    result.usageMetadata,
+    modelConfig.model,
+  );
+  const usage = mergeUsage([requirementUsage, classificationUsage]);
+  const durationMs =
+    (parsedRequirements.call?.durationMs ?? 0) + result.durationMs;
   console.error(`\nUsage:`);
-  console.error(formatUsageSummary(result.usageMetadata, modelConfig.model, result.durationMs));
-
-  const prompt = result.usageMetadata?.promptTokenCount || 0;
-  const response = result.usageMetadata?.candidatesTokenCount || 0;
-  const thinking = result.usageMetadata?.thoughtsTokenCount || 0;
-  const pricing = PRICING[modelConfig.model] || PRICING.default;
-  const cost = +(((prompt / 1_000_000) * pricing.input) + ((response / 1_000_000) * pricing.output)).toFixed(4);
+  console.error(
+    formatUsageSummary(usage, modelConfig.model, durationMs),
+  );
 
   return {
-    data: parsed,
+    data: triageData,
     model: modelConfig.model,
     provider: modelConfig.provider,
+    requirementSet,
     evidenceGaps: normalizedEvidenceGaps,
-    tokensUsed: prompt,
-    usage: { inputTokens: prompt, outputTokens: response, thinkingTokens: thinking || undefined, cost },
+    tokensUsed: usage.inputTokens,
+    usage,
   };
 }
 
@@ -442,7 +906,7 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
 async function main() {
   const args = process.argv.slice(2);
   if (args.length === 0) {
-    console.error('Usage: triage <listing-file> [--ai-reviews <file>] [--ai-photos <file>] [--model <model>] [--priorities <text>]');
+    console.error('Usage: triage <listing-file> [--ai-reviews <file>] [--ai-photos <file>] [--model <model>] [--priorities <text>] [--temperature <n>] [--budget <amount>] [--budget-currency <code>]');
     process.exit(1);
   }
 
@@ -454,15 +918,38 @@ async function main() {
   let aiPhotosFile: string | undefined;
   let model: string | undefined;
   let priorities: string | undefined;
+  let temperature = 0;
+  let budgetAmount: number | undefined;
+  let budgetCurrency = 'USD';
 
   for (let i = 1; i < args.length; i++) {
     if (args[i] === '--ai-reviews' && args[i + 1]) { aiReviewsFile = args[++i]; }
     else if (args[i] === '--ai-photos' && args[i + 1]) { aiPhotosFile = args[++i]; }
     else if (args[i] === '--model' && args[i + 1]) { model = args[++i]; }
     else if (args[i] === '--priorities' && args[i + 1]) { priorities = args[++i]; }
+    else if (args[i] === '--temperature' && args[i + 1]) { temperature = Number(args[++i]); }
+    else if (args[i] === '--budget' && args[i + 1]) { budgetAmount = Number(args[++i]); }
+    else if (args[i] === '--budget-currency' && args[i + 1]) { budgetCurrency = args[++i].toUpperCase(); }
   }
 
-  const result = await runTriage({ listingFile, aiReviewsFile, aiPhotosFile, model, priorities });
+  const budget =
+    budgetAmount == null
+      ? undefined
+      : {
+          amount: budgetAmount,
+          currency: budgetCurrency,
+          basis: 'stay' as const,
+          source: 'explicit' as const,
+        };
+  const result = await runTriage({
+    listingFile,
+    aiReviewsFile,
+    aiPhotosFile,
+    model,
+    priorities,
+    temperature,
+    budget,
+  });
   console.log(JSON.stringify(result.data, null, 2));
 }
 

--- a/tests/batch-output-paths.test.ts
+++ b/tests/batch-output-paths.test.ts
@@ -5,16 +5,25 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { resolveBatchOutputDir, runBatch } from '../src/batch.js';
+import { buildCanonicalRequirementSet } from '../src/triage-rubric.js';
 
 const repositoryRoot = process.cwd();
 const bookingUrl =
   'https://www.booking.com/hotel/us/example-hotel.en-gb.html';
+const fixtureRequirementSet = buildCanonicalRequirementSet({
+  parserVersion: 'fixture-parser-v1',
+  definitions: [{ label: 'Fixture quality', type: 'priority' }],
+});
 
 function canonicalPath(filePath: string): string {
   return fs.realpathSync(filePath);
 }
 
-function writeBookingFixture(rootDir: string): {
+function writeBookingFixture(
+  rootDir: string,
+  id = 'example-hotel',
+  url = bookingUrl,
+): {
   listingFile: string;
   reviewsFile: string;
   photosDir: string;
@@ -22,14 +31,14 @@ function writeBookingFixture(rootDir: string): {
   const listingFile = path.join(
     rootDir,
     'listings',
-    'listing_example-hotel.json',
+    `listing_${id}.json`,
   );
   const reviewsFile = path.join(
     rootDir,
     'reviews',
-    'example-hotel_reviews.json',
+    `${id}_reviews.json`,
   );
-  const photosDir = path.join(rootDir, 'photos', 'example-hotel');
+  const photosDir = path.join(rootDir, 'photos', id);
 
   fs.mkdirSync(path.dirname(listingFile), { recursive: true });
   fs.mkdirSync(path.dirname(reviewsFile), { recursive: true });
@@ -37,8 +46,8 @@ function writeBookingFixture(rootDir: string): {
   fs.writeFileSync(
     listingFile,
     JSON.stringify({
-      id: 'example-hotel',
-      url: bookingUrl,
+      id,
+      url,
       linkedRoomId: null,
       reviewCount: 1,
       photos: [{ associatedRooms: [] }],
@@ -71,6 +80,152 @@ test('default batch output directories are platform-specific', () => {
     resolveBatchOutputDir({ outputDir: '/tmp/reviewr-output' }, 'booking'),
     '/tmp/reviewr-output',
   );
+});
+
+test('batch freezes one canonical requirement set and reloads it on rerun', async () => {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'reviewr-requirement-set-'),
+  );
+  const outputDir = path.join(tempDir, 'output');
+  const manifestPath = path.join(outputDir, 'batch_manifest.json');
+  const urlsFile = path.join(tempDir, 'urls.txt');
+  const originalGeminiApiKey = process.env.GEMINI_API_KEY;
+  const ids = ['first-hotel', 'second-hotel'];
+  const urls = ids.map(
+    (id) => `https://www.booking.com/hotel/us/${id}.en-gb.html`,
+  );
+  const reusableSet = buildCanonicalRequirementSet({
+    parserVersion: 'triage-default-requirements-v1',
+    definitions: [{ label: 'Frozen quality', type: 'priority' }],
+  });
+
+  try {
+    for (let index = 0; index < ids.length; index++) {
+      writeBookingFixture(outputDir, ids[index], urls[index]);
+    }
+    fs.writeFileSync(urlsFile, `${urls.join('\n')}\n`);
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        version: 2,
+        createdAt: '2026-07-24T00:00:00.000Z',
+        updatedAt: '2026-07-24T00:00:00.000Z',
+        dates: {},
+        listings: Object.fromEntries(
+          ids.map((id, index) => [
+            `booking/${id}`,
+            {
+              platform: 'booking',
+              id,
+              url: urls[index],
+              details: {
+                status: 'fetched',
+                file: `listings/listing_${id}.json`,
+              },
+              reviews: { status: 'skipped', reason: 'not needed' },
+              photos: { status: 'skipped', reason: 'not needed' },
+              aiReviews: { status: 'skipped', reason: 'not needed' },
+              aiPhotos: { status: 'skipped', reason: 'not needed' },
+              triage: { status: 'not_requested' },
+            },
+          ]),
+        ),
+      }),
+    );
+    process.env.GEMINI_API_KEY = 'fixture-key';
+
+    const firstRunSets: Array<string | null> = [];
+    await runBatch(
+      [urlsFile],
+      {
+        fetchDetails: false,
+        fetchReviews: false,
+        fetchPhotos: false,
+        aiReviews: false,
+        aiPhotos: false,
+        triage: true,
+        aiReviewsExplicit: false,
+        aiPhotosExplicit: false,
+        triageExplicit: true,
+        force: false,
+        retryFailed: false,
+        downloadPhotosAll: false,
+        outputDir,
+        scopeManifestToInput: true,
+        print: false,
+        artifactCache: null,
+      },
+      {
+        runTriage: async (options) => {
+          firstRunSets.push(options.requirementSet?.id ?? null);
+          return {
+            data: { tier: 'shortlist', fitScore: 75 },
+            model: 'fixture-model',
+            provider: 'gemini',
+            requirementSet: options.requirementSet ?? reusableSet,
+            evidenceGaps: [],
+          };
+        },
+      },
+    );
+
+    assert.deepEqual(firstRunSets, [null, reusableSet.id]);
+    const persistedSet = JSON.parse(
+      fs.readFileSync(
+        path.join(outputDir, 'triage-requirements.json'),
+        'utf-8',
+      ),
+    );
+    assert.equal(persistedSet.id, reusableSet.id);
+    const persistedManifest = JSON.parse(
+      fs.readFileSync(manifestPath, 'utf-8'),
+    );
+    assert.equal(persistedManifest.requirementSet.id, reusableSet.id);
+
+    const rerunSets: string[] = [];
+    await runBatch(
+      [urlsFile],
+      {
+        fetchDetails: false,
+        fetchReviews: false,
+        fetchPhotos: false,
+        aiReviews: false,
+        aiPhotos: false,
+        triage: true,
+        aiReviewsExplicit: false,
+        aiPhotosExplicit: false,
+        triageExplicit: true,
+        force: true,
+        retryFailed: false,
+        downloadPhotosAll: false,
+        outputDir,
+        scopeManifestToInput: true,
+        print: false,
+        artifactCache: null,
+      },
+      {
+        runTriage: async (options) => {
+          assert.ok(options.requirementSet);
+          rerunSets.push(options.requirementSet.id);
+          return {
+            data: { tier: 'shortlist', fitScore: 75 },
+            model: 'fixture-model',
+            provider: 'gemini',
+            requirementSet: options.requirementSet,
+            evidenceGaps: [],
+          };
+        },
+      },
+    );
+    assert.deepEqual(rerunSets, [reusableSet.id, reusableSet.id]);
+  } finally {
+    if (originalGeminiApiKey === undefined) {
+      delete process.env.GEMINI_API_KEY;
+    } else {
+      process.env.GEMINI_API_KEY = originalGeminiApiKey;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 test('default-dir resumed Booking artifacts remain eligible for every AI phase', async () => {
@@ -202,6 +357,8 @@ test('default-dir resumed Booking artifacts remain eligible for every AI phase',
             data: { tier: 'shortlist', fitScore: 75 },
             model: 'fixture-model',
             provider: 'gemini',
+            requirementSet:
+              options.requirementSet ?? fixtureRequirementSet,
             evidenceGaps: [],
           };
         },
@@ -368,6 +525,8 @@ test('triage records missing review evidence in its artifact and manifest', asyn
             data: { tier: 'consider', fitScore: 55 },
             model: 'fixture-model',
             provider: 'gemini',
+            requirementSet:
+              options.requirementSet ?? fixtureRequirementSet,
             evidenceGaps: [],
           };
         },
@@ -485,6 +644,8 @@ test('triage records missing photo evidence in its artifact and manifest', async
             data: { tier: 'consider', fitScore: 55 },
             model: 'fixture-model',
             provider: 'gemini',
+            requirementSet:
+              options.requirementSet ?? fixtureRequirementSet,
             evidenceGaps: [],
           };
         },

--- a/tests/report-poi.test.ts
+++ b/tests/report-poi.test.ts
@@ -109,3 +109,140 @@ test('generateReport surfaces POI distance in the report output', async () => {
 
   fs.rmSync(rootDir, { recursive: true, force: true });
 });
+
+test('generateReport ranks only the active deterministic set', async () => {
+  const rootDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'report-rubric-test-'),
+  );
+  const fixtures = [
+    {
+      id: 'ranked',
+      title: 'Comparable ranked',
+      triage: {
+        scoreSource: 'deterministic_rubric',
+        rubricVersion: '1',
+        requirementSetId: 'reqset_active',
+        rawFitScore: 60,
+        fitScore: 60,
+        tier: 'consider',
+        coverage: 1,
+        rankingStatus: 'ranked',
+      },
+    },
+    {
+      id: 'thin',
+      title: 'Thin evidence',
+      triage: {
+        scoreSource: 'deterministic_rubric',
+        rubricVersion: '1',
+        requirementSetId: 'reqset_active',
+        rawFitScore: 90,
+        fitScore: 90,
+        tier: 'top_pick',
+        coverage: 0.25,
+        rankingStatus: 'insufficient_evidence',
+      },
+    },
+    {
+      id: 'legacy',
+      title: 'Legacy high score',
+      triage: {
+        fitScore: 99,
+        tier: 'top_pick',
+      },
+    },
+  ];
+
+  try {
+    fs.mkdirSync(path.join(rootDir, 'listings'), { recursive: true });
+    fs.mkdirSync(path.join(rootDir, 'triage'), { recursive: true });
+    const listings: Record<string, unknown> = {};
+    for (const fixture of fixtures) {
+      listings[fixture.id] = {
+        platform: 'booking',
+        id: fixture.id,
+        url: `https://www.booking.com/hotel/us/${fixture.id}.html`,
+        details: {
+          status: 'fetched',
+          file: `listings/listing_${fixture.id}.json`,
+        },
+        reviews: { status: 'skipped' },
+        photos: { status: 'skipped' },
+        aiReviews: { status: 'skipped' },
+        aiPhotos: { status: 'skipped' },
+        triage: {
+          status: 'fetched',
+          file: `triage/${fixture.id}.json`,
+        },
+      };
+      fs.writeFileSync(
+        path.join(rootDir, 'listings', `listing_${fixture.id}.json`),
+        JSON.stringify({
+          title: fixture.title,
+          amenities: [],
+        }),
+      );
+      fs.writeFileSync(
+        path.join(rootDir, 'triage', `${fixture.id}.json`),
+        JSON.stringify({
+          ...fixture.triage,
+          tierReason: 'Fixture verdict',
+          requirements: [],
+          scores: {},
+          bedSetup: '',
+          price: {
+            total: '',
+            perNight: '',
+            valueAssessment: 'unknown',
+          },
+          highlights: [],
+          concerns: [],
+          dealBreakers: [],
+          summary: fixture.title,
+          affordability: {
+            status: 'unknown',
+            reasonCode: 'price_missing',
+            reason: 'Price is missing for the selected stay.',
+          },
+        }),
+      );
+    }
+    fs.writeFileSync(
+      path.join(rootDir, 'batch_manifest.json'),
+      JSON.stringify({
+        version: 2,
+        createdAt: '2026-07-25T00:00:00.000Z',
+        updatedAt: '2026-07-25T00:00:00.000Z',
+        dates: {},
+        listings,
+      }),
+    );
+
+    const outputFile = await generateReport({ outputDir: rootDir });
+    const html = fs.readFileSync(outputFile, 'utf-8');
+    const dataStart = html.indexOf('const DATA = ') + 'const DATA = '.length;
+    const dataEnd = html.indexOf(';\nconst INITIAL_PICKS', dataStart);
+    const reportRows = JSON.parse(html.slice(dataStart, dataEnd));
+    assert.deepEqual(
+      reportRows.map((row: { id: string }) => row.id),
+      ['ranked', 'thin', 'legacy'],
+    );
+
+    const heroStart = html.indexOf('<!-- TOP PICKS -->');
+    const heroEnd = html.indexOf('<!-- TIER FILTERS -->', heroStart);
+    const heroHtml = html.slice(heroStart, heroEnd);
+    assert.match(heroHtml, /Comparable ranked/);
+    assert.doesNotMatch(heroHtml, /Thin evidence/);
+    assert.doesNotMatch(heroHtml, /Legacy high score/);
+    assert.match(
+      html,
+      /1 insufficient-evidence and 1 legacy\/stale verdicts/,
+    );
+    assert.match(
+      html,
+      /Budget unknown · Price is missing for the selected stay\./,
+    );
+  } finally {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/tests/results-rubric.test.ts
+++ b/tests/results-rubric.test.ts
@@ -1,0 +1,225 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getActiveRequirementSetId,
+  getListingResultsSnapshot,
+  getTriageComparisonStatus,
+} from '../web/src/lib/results.js';
+import type { ReviewJobListing } from '../web/src/types.js';
+
+function listing(
+  id: string,
+  triage: Record<string, unknown> | null,
+): ReviewJobListing {
+  return {
+    id,
+    platform: 'booking',
+    name: id,
+    url: `https://example.com/${id}`,
+    rating: null,
+    reviewCount: 0,
+    pricing: null,
+    coordinates: null,
+    propertyType: null,
+    photoUrl: null,
+    selected: true,
+    liked: false,
+    hidden: false,
+    poiDistanceMeters: null,
+    analysis: triage
+      ? {
+          triage,
+          aiReviews: null,
+          aiPhotos: null,
+        }
+      : null,
+  } as unknown as ReviewJobListing;
+}
+
+test('missing rubric metadata is explicitly parsed as a legacy AI score', () => {
+  const snapshot = getListingResultsSnapshot(
+    listing('legacy', {
+      fitScore: 88,
+      tier: 'top_pick',
+      requirements: [
+        {
+          requirement: 'Quiet',
+          type: 'must_have',
+          status: 'met',
+          confidence: 'high',
+          note: 'Legacy shape',
+        },
+      ],
+    }),
+  );
+
+  assert.equal(snapshot.triage?.scoreSource, 'model_legacy');
+  assert.equal(snapshot.triage?.rankingStatus, 'legacy_unranked');
+  assert.equal(snapshot.triage?.requirementSetId, null);
+  assert.equal(snapshot.triage?.requirements[0].label, 'Quiet');
+  assert.equal(snapshot.triage?.requirements[0].requirementId, null);
+});
+
+test('deterministic metadata and affordability reason survive parsing', () => {
+  const snapshot = getListingResultsSnapshot(
+    listing('rubric', {
+      scoreSource: 'deterministic_rubric',
+      rubricVersion: '1',
+      requirementSetId: 'reqset_a',
+      rawFitScore: 70,
+      fitScore: 44,
+      tier: 'unlikely',
+      capReasons: ['weight_gte_3_unmet_high:req-01-quiet'],
+      coverage: 0.75,
+      rankingStatus: 'ranked',
+      requirements: [
+        {
+          requirementId: 'req-01-quiet',
+          label: 'Quiet sleep',
+          requirement: 'Quiet sleep',
+          type: 'priority',
+          rank: 1,
+          weight: 3,
+          order: 1,
+          status: 'unmet',
+          confidence: 'high',
+          note: 'HVAC noise',
+          evidence: [
+            {
+              layer: 'reviews',
+              polarity: 'contradicts',
+              text: 'The HVAC sounded like a freight train.',
+              frequency: 'repeated',
+              years: [2025, 2026],
+            },
+          ],
+        },
+      ],
+      affordability: {
+        status: 'unknown',
+        reasonCode: 'currency_mismatch',
+        reason: 'Price currency PLN does not match budget currency USD.',
+        budgetAmount: 4500,
+        priceAmount: 12300,
+        currency: 'USD',
+        budgetCurrency: 'USD',
+        priceCurrency: 'PLN',
+        priceBasis: 'stay',
+        overByAmount: null,
+        overByPercent: null,
+        priceSource: 'upstream',
+        freshness: 'fresh',
+        mandatoryChargesResolved: true,
+      },
+    }),
+  );
+
+  assert.equal(snapshot.triage?.scoreSource, 'deterministic_rubric');
+  assert.equal(snapshot.triage?.rawFitScore, 70);
+  assert.equal(snapshot.triage?.fitScore, 44);
+  assert.deepEqual(snapshot.triage?.capReasons, [
+    'weight_gte_3_unmet_high:req-01-quiet',
+  ]);
+  assert.equal(snapshot.triage?.requirements[0].weight, 3);
+  assert.equal(
+    snapshot.triage?.requirements[0].evidence[0].years[1],
+    2026,
+  );
+  assert.equal(
+    snapshot.triage?.affordability?.reason,
+    'Price currency PLN does not match budget currency USD.',
+  );
+  assert.equal(snapshot.triage?.affordability?.priceCurrency, 'PLN');
+  assert.equal(
+    snapshot.triage?.affordability?.mandatoryChargesResolved,
+    true,
+  );
+});
+
+test('coverage below one half is treated as insufficient even for older rubric JSON', () => {
+  const snapshot = getListingResultsSnapshot(
+    listing('thin', {
+      scoreSource: 'deterministic_rubric',
+      rubricVersion: '1',
+      requirementSetId: 'reqset_a',
+      fitScore: 50,
+      tier: 'consider',
+      coverage: 0.49,
+    }),
+  );
+  assert.equal(snapshot.triage?.rankingStatus, 'insufficient_evidence');
+});
+
+test('active requirement set is the modal set with stable first-seen ties', () => {
+  const a = {
+    scoreSource: 'deterministic_rubric',
+    rubricVersion: '1',
+    requirementSetId: 'reqset_a',
+    fitScore: 80,
+    tier: 'top_pick',
+    rankingStatus: 'ranked',
+  };
+  const b = { ...a, requirementSetId: 'reqset_b' };
+  const listings = [
+    listing('a1', a),
+    listing('b1', b),
+    listing('b2', b),
+    listing('legacy', { fitScore: 99, tier: 'top_pick' }),
+  ];
+  assert.equal(getActiveRequirementSetId(listings), 'reqset_b');
+});
+
+test('comparison status separates ranked, insufficient, legacy, and stale sets', () => {
+  const ranked = getListingResultsSnapshot(
+    listing('ranked', {
+      scoreSource: 'deterministic_rubric',
+      rubricVersion: '1',
+      requirementSetId: 'reqset_active',
+      fitScore: 90,
+      tier: 'top_pick',
+      rankingStatus: 'ranked',
+    }),
+  ).triage;
+  const thin = getListingResultsSnapshot(
+    listing('thin', {
+      scoreSource: 'deterministic_rubric',
+      rubricVersion: '1',
+      requirementSetId: 'reqset_active',
+      fitScore: 50,
+      tier: 'consider',
+      rankingStatus: 'insufficient_evidence',
+    }),
+  ).triage;
+  const stale = getListingResultsSnapshot(
+    listing('stale', {
+      scoreSource: 'deterministic_rubric',
+      rubricVersion: '1',
+      requirementSetId: 'reqset_old',
+      fitScore: 100,
+      tier: 'top_pick',
+      rankingStatus: 'ranked',
+    }),
+  ).triage;
+  const legacy = getListingResultsSnapshot(
+    listing('legacy', { fitScore: 100, tier: 'top_pick' }),
+  ).triage;
+
+  assert.equal(
+    getTriageComparisonStatus(ranked, 'reqset_active'),
+    'ranked',
+  );
+  assert.equal(
+    getTriageComparisonStatus(thin, 'reqset_active'),
+    'insufficient_evidence',
+  );
+  assert.equal(
+    getTriageComparisonStatus(stale, 'reqset_active'),
+    'stale_requirement_set',
+  );
+  assert.equal(
+    getTriageComparisonStatus(legacy, 'reqset_active'),
+    'legacy',
+  );
+  assert.equal(getTriageComparisonStatus(null, 'reqset_active'), 'unscored');
+});

--- a/tests/review-job-persistence.test.ts
+++ b/tests/review-job-persistence.test.ts
@@ -31,6 +31,8 @@ function makeJob(overrides: Record<string, unknown> = {}) {
     checkout: '2026-03-29',
     adults: 2,
     currency: 'USD',
+    analysisBudgetAmount: null,
+    analysisBudgetCurrency: null,
     filters: null,
     totalResults: 1,
     pagesScanned: 2,
@@ -185,6 +187,22 @@ test('native results readiness is derived from persisted analysis state, not rep
     triageUsd: 0.0027,
     totalUsd: 0.023,
   });
+});
+
+test('explicit full-stay analysis budget is exposed independently of search currency', () => {
+  const response = toReviewJobResponse({
+    job: makeJob({
+      currency: 'PLN',
+      analysisBudgetAmount: 4500,
+      analysisBudgetCurrency: 'USD',
+    }),
+    listings: [makeListing()],
+    events: [],
+  });
+
+  assert.equal(response.job.currency, 'PLN');
+  assert.equal(response.job.analysisBudgetAmount, 4500);
+  assert.equal(response.job.analysisBudgetCurrency, 'USD');
 });
 
 test('legacy html export availability remains separate from native results readiness', () => {

--- a/tests/triage-rubric.test.ts
+++ b/tests/triage-rubric.test.ts
@@ -1,0 +1,760 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  MIN_RANKED_COVERAGE,
+  buildCanonicalRequirementSet,
+  computeAffordability,
+  effectiveRequirementValue,
+  getDefaultRequirementInputs,
+  recomputeStoredAffordability,
+  resolveRequirementWeight,
+  scoreTriageAssessments,
+  tierForFitScore,
+  type CanonicalRequirementInput,
+  type CanonicalRequirementSet,
+  type RequirementAssessmentInput,
+  type RequirementConfidence,
+  type RequirementStatus,
+} from '../src/triage-rubric.js';
+import {
+  extractComparableStayPrice,
+  getTriageRequirementParserVersion,
+} from '../src/triage.js';
+
+function makeSet(
+  definitions: CanonicalRequirementInput[],
+): CanonicalRequirementSet {
+  return buildCanonicalRequirementSet({
+    brief: 'Test brief',
+    parserVersion: 'test-parser-v1',
+    definitions,
+  });
+}
+
+function outcomes(
+  set: CanonicalRequirementSet,
+  status: RequirementStatus = 'met',
+  confidence: RequirementConfidence = 'high',
+): RequirementAssessmentInput[] {
+  return set.definitions.map((definition) => ({
+    requirementId: definition.id,
+    status,
+    confidence,
+    note: `${status}/${confidence}`,
+    evidence: [],
+  }));
+}
+
+test('confidence shrinks met and unmet outcomes toward neutral', () => {
+  assert.equal(effectiveRequirementValue('met', 'high'), 1);
+  assert.equal(effectiveRequirementValue('met', 'medium'), 0.875);
+  assert.equal(effectiveRequirementValue('met', 'low'), 0.75);
+  assert.equal(effectiveRequirementValue('unmet', 'high'), 0);
+  assert.equal(effectiveRequirementValue('unmet', 'medium'), 0.125);
+  assert.equal(effectiveRequirementValue('unmet', 'low'), 0.25);
+});
+
+test('partial and unknown are neutral at every confidence', () => {
+  for (const confidence of ['high', 'medium', 'low'] as const) {
+    assert.equal(effectiveRequirementValue('partial', confidence), 0.5);
+    assert.equal(effectiveRequirementValue('unknown', confidence), 0.5);
+  }
+});
+
+test('requirement weights follow type and rank-one priority rules', () => {
+  assert.equal(resolveRequirementWeight('deal_breaker'), 4);
+  assert.equal(resolveRequirementWeight('must_have'), 3);
+  assert.equal(resolveRequirementWeight('priority'), 2);
+  assert.equal(resolveRequirementWeight('priority', 1), 3);
+  assert.equal(resolveRequirementWeight('priority', 2), 2);
+  assert.equal(resolveRequirementWeight('nice_to_have'), 1);
+});
+
+test('default requirements are deterministic and defensive copies', () => {
+  const first = getDefaultRequirementInputs();
+  const second = getDefaultRequirementInputs();
+  assert.equal(first.length, 4);
+  assert.deepEqual(
+    first.map((definition) => definition.type),
+    ['priority', 'priority', 'priority', 'nice_to_have'],
+  );
+  first[0].label = 'changed';
+  first[0].criteria?.push('changed');
+  assert.notEqual(second[0].label, 'changed');
+  assert.ok(!second[0].criteria?.includes('changed'));
+});
+
+test('canonical IDs and set hashes are stable for the same definitions', () => {
+  const definitions: CanonicalRequirementInput[] = [
+    {
+      label: 'Quiet sleep',
+      type: 'priority',
+      rank: 1,
+      order: 2,
+      criteria: ['No HVAC noise'],
+    },
+    {
+      label: 'Workspace',
+      type: 'priority',
+      rank: 3,
+      order: 3,
+    },
+    {
+      label: 'Value',
+      type: 'priority',
+      rank: 2,
+      order: 1,
+    },
+  ];
+  const first = buildCanonicalRequirementSet({
+    brief: 'Original prose',
+    parserVersion: 'parser-v1',
+    definitions,
+  });
+  const second = buildCanonicalRequirementSet({
+    brief: 'Equivalent revised prose',
+    parserVersion: 'parser-v1',
+    definitions: [...definitions].reverse(),
+  });
+
+  assert.equal(first.id, second.id);
+  assert.deepEqual(first.definitions, second.definitions);
+  assert.deepEqual(
+    first.definitions.map((definition) => definition.id),
+    ['req-01-value', 'req-02-quiet-sleep', 'req-03-workspace'],
+  );
+  assert.equal(first.definitions[1].weight, 3);
+});
+
+test('parser version and definitions affect the requirement-set hash, budget does not', () => {
+  const definitions: CanonicalRequirementInput[] = [
+    { label: 'Quiet', type: 'priority', rank: 1 },
+  ];
+  const original = buildCanonicalRequirementSet({
+    parserVersion: 'parser-v1',
+    definitions,
+    parsedBudget: {
+      maximumAmount: 4500,
+      currency: 'USD',
+      basis: 'stay',
+      source: 'brief',
+    },
+  });
+  const changedBudget = buildCanonicalRequirementSet({
+    parserVersion: 'parser-v1',
+    definitions,
+    parsedBudget: {
+      maximumAmount: 5000,
+      currency: 'USD',
+      basis: 'stay',
+      source: 'brief',
+    },
+  });
+  const changedParser = buildCanonicalRequirementSet({
+    parserVersion: 'parser-v2',
+    definitions,
+  });
+  const changedDefinition = buildCanonicalRequirementSet({
+    parserVersion: 'parser-v1',
+    definitions: [{ label: 'Very quiet', type: 'priority', rank: 1 }],
+  });
+
+  assert.equal(original.id, changedBudget.id);
+  assert.notEqual(original.id, changedParser.id);
+  assert.notEqual(original.id, changedDefinition.id);
+});
+
+test('requirement parser version is model-aware but defaults need no model parse', () => {
+  assert.equal(
+    getTriageRequirementParserVersion('gemini-3-flash-preview:high'),
+    'triage-default-requirements-v1',
+  );
+  assert.match(
+    getTriageRequirementParserVersion(
+      'gemini-3-flash-preview:high',
+      'Quiet sleep',
+    ),
+    /triage-requirements-v1:gemini:gemini-3-flash-preview:high/,
+  );
+});
+
+test('weighted scoring is deterministic and uses integer half-up rounding', () => {
+  const set = makeSet([
+    { label: 'A', type: 'nice_to_have' },
+    { label: 'B', type: 'nice_to_have' },
+    { label: 'C', type: 'nice_to_have' },
+  ]);
+  const result = scoreTriageAssessments(set, [
+    {
+      requirementId: set.definitions[2].id,
+      status: 'unmet',
+      confidence: 'high',
+      note: '',
+    },
+    {
+      requirementId: set.definitions[0].id,
+      status: 'met',
+      confidence: 'high',
+      note: '',
+    },
+    {
+      requirementId: set.definitions[1].id,
+      status: 'partial',
+      confidence: 'high',
+      note: '',
+    },
+  ]);
+
+  assert.equal(result.rawFitScore, 50);
+  assert.equal(result.fitScore, 50);
+  assert.equal(result.tier, 'consider');
+  assert.deepEqual(
+    result.requirements.map((requirement) => requirement.requirementId),
+    set.definitions.map((definition) => definition.id),
+  );
+});
+
+test('score rounding resolves exact half points upward', () => {
+  const set = makeSet(
+    Array.from({ length: 8 }, (_, index) => ({
+      label: `Requirement ${index + 1}`,
+      type: 'nice_to_have' as const,
+    })),
+  );
+  const assessment = outcomes(set, 'unmet', 'high');
+  assessment[0] = {
+    requirementId: set.definitions[0].id,
+    status: 'met',
+    confidence: 'high',
+    note: '',
+  };
+
+  const result = scoreTriageAssessments(set, assessment);
+  assert.equal(result.rawFitScore, 13);
+  assert.equal(result.fitScore, 13);
+});
+
+test('a rank-boosted priority uses the major cap ladder', () => {
+  const set = makeSet([
+    { label: 'Sleep quality', type: 'priority', rank: 1 },
+    { label: 'A', type: 'priority' },
+    { label: 'B', type: 'priority' },
+    { label: 'C', type: 'nice_to_have' },
+    { label: 'D', type: 'nice_to_have' },
+    { label: 'E', type: 'nice_to_have' },
+  ]);
+  const assessment = outcomes(set);
+  assessment[0] = {
+    requirementId: set.definitions[0].id,
+    status: 'unmet',
+    confidence: 'high',
+    note: 'Freight-train HVAC noise',
+  };
+  const result = scoreTriageAssessments(set, assessment);
+
+  assert.equal(result.rawFitScore, 70);
+  assert.equal(result.fitScore, 44);
+  assert.equal(result.tier, 'unlikely');
+  assert.ok(
+    result.capReasons.includes(
+      `weight_gte_3_unmet_high:${set.definitions[0].id}`,
+    ),
+  );
+});
+
+test('critical and multiple-major failures force no-go', () => {
+  const criticalSet = makeSet([
+    { label: 'Accessible entrance', type: 'deal_breaker' },
+    ...Array.from({ length: 10 }, (_, index) => ({
+      label: `Bonus ${index + 1}`,
+      type: 'nice_to_have' as const,
+    })),
+  ]);
+  const criticalAssessments = outcomes(criticalSet);
+  criticalAssessments[0] = {
+    requirementId: criticalSet.definitions[0].id,
+    status: 'unmet',
+    confidence: 'high',
+    note: '',
+  };
+  const critical = scoreTriageAssessments(
+    criticalSet,
+    criticalAssessments,
+  );
+  assert.equal(critical.rawFitScore, 71);
+  assert.equal(critical.fitScore, 24);
+  assert.equal(critical.tier, 'no_go');
+
+  const majorSet = makeSet([
+    { label: 'Quiet', type: 'must_have' },
+    { label: 'Elevator', type: 'must_have' },
+    ...Array.from({ length: 20 }, (_, index) => ({
+      label: `Bonus ${index + 1}`,
+      type: 'nice_to_have' as const,
+    })),
+  ]);
+  const majorAssessments = outcomes(majorSet);
+  for (const index of [0, 1]) {
+    majorAssessments[index] = {
+      requirementId: majorSet.definitions[index].id,
+      status: 'unmet',
+      confidence: 'high',
+      note: '',
+    };
+  }
+  const multiple = scoreTriageAssessments(majorSet, majorAssessments);
+  assert.equal(multiple.fitScore, 24);
+  assert.ok(
+    multiple.capReasons.some((reason) =>
+      reason.startsWith('multiple_weight_gte_3_unmet_high:')),
+  );
+});
+
+test('major and critical uncertainty caps use lowest-cap-wins', () => {
+  const set = makeSet([
+    { label: 'Critical', type: 'deal_breaker' },
+    { label: 'Major', type: 'must_have' },
+    ...Array.from({ length: 20 }, (_, index) => ({
+      label: `Bonus ${index + 1}`,
+      type: 'nice_to_have' as const,
+    })),
+  ]);
+  const assessment = outcomes(set);
+  assessment[0] = {
+    requirementId: set.definitions[0].id,
+    status: 'partial',
+    confidence: 'high',
+    note: '',
+  };
+  assessment[1] = {
+    requirementId: set.definitions[1].id,
+    status: 'met',
+    confidence: 'low',
+    note: '',
+  };
+  const result = scoreTriageAssessments(set, assessment);
+
+  assert.equal(result.fitScore, 64);
+  assert.ok(
+    result.capReasons.includes(
+      `weight_gte_4_uncertain_or_unmet_low:${set.definitions[0].id}`,
+    ),
+  );
+  assert.ok(
+    result.capReasons.includes(
+      `weight_gte_3_partial:${set.definitions[0].id}`,
+    ),
+  );
+  assert.ok(
+    result.capReasons.includes(
+      `weight_gte_3_met_low:${set.definitions[1].id}`,
+    ),
+  );
+});
+
+test('major unmet non-high, unknown, partial, and met-low caps are explicit', () => {
+  const cases: Array<{
+    status: RequirementStatus;
+    confidence: RequirementConfidence;
+    cap: number;
+    reason: string;
+  }> = [
+    {
+      status: 'unmet',
+      confidence: 'medium',
+      cap: 64,
+      reason: 'weight_gte_3_unknown_or_unmet_non_high',
+    },
+    {
+      status: 'unmet',
+      confidence: 'low',
+      cap: 64,
+      reason: 'weight_gte_3_unknown_or_unmet_non_high',
+    },
+    {
+      status: 'unknown',
+      confidence: 'low',
+      cap: 64,
+      reason: 'weight_gte_3_unknown_or_unmet_non_high',
+    },
+    {
+      status: 'partial',
+      confidence: 'high',
+      cap: 79,
+      reason: 'weight_gte_3_partial',
+    },
+    {
+      status: 'met',
+      confidence: 'low',
+      cap: 79,
+      reason: 'weight_gte_3_met_low',
+    },
+  ];
+
+  for (const item of cases) {
+    const set = makeSet([
+      { label: 'Major', type: 'must_have' },
+      ...Array.from({ length: 20 }, (_, index) => ({
+        label: `Bonus ${index + 1}`,
+        type: 'nice_to_have' as const,
+      })),
+    ]);
+    const assessment = outcomes(set);
+    assessment[0] = {
+      requirementId: set.definitions[0].id,
+      status: item.status,
+      confidence: item.confidence,
+      note: '',
+    };
+    const result = scoreTriageAssessments(set, assessment);
+    assert.equal(result.fitScore, item.cap);
+    assert.ok(
+      result.capReasons.some((reason) => reason.startsWith(item.reason)),
+    );
+  }
+});
+
+test('coverage below one half is auditable but unranked', () => {
+  const set = makeSet([
+    { label: 'A', type: 'priority' },
+    { label: 'B', type: 'priority' },
+    { label: 'C', type: 'priority' },
+  ]);
+  const result = scoreTriageAssessments(set, outcomes(set, 'unknown', 'low'));
+
+  assert.equal(MIN_RANKED_COVERAGE, 0.5);
+  assert.equal(result.rawFitScore, 50);
+  assert.equal(result.tier, 'consider');
+  assert.equal(result.coverage, 0);
+  assert.equal(result.rankingStatus, 'insufficient_evidence');
+  assert.match(result.rankingReason ?? '', /0%/);
+});
+
+test('coverage exactly one half remains rankable', () => {
+  const set = makeSet([
+    { label: 'Known', type: 'priority' },
+    { label: 'Unknown', type: 'priority' },
+  ]);
+  const assessment = outcomes(set, 'unknown', 'low');
+  assessment[0] = {
+    requirementId: set.definitions[0].id,
+    status: 'met',
+    confidence: 'high',
+    note: '',
+  };
+  const result = scoreTriageAssessments(set, assessment);
+
+  assert.equal(result.coverage, 0.5);
+  assert.equal(result.rankingStatus, 'ranked');
+});
+
+test('missing assessments become explicit unknown outcomes', () => {
+  const set = makeSet([
+    { label: 'A', type: 'priority' },
+    { label: 'B', type: 'priority' },
+  ]);
+  const result = scoreTriageAssessments(set, [
+    {
+      requirementId: set.definitions[0].id,
+      status: 'met',
+      confidence: 'high',
+      note: '',
+    },
+  ]);
+  assert.equal(result.requirements[1].status, 'unknown');
+  assert.match(result.requirements[1].note, /did not return/);
+});
+
+test('unknown and duplicate classifier IDs are rejected', () => {
+  const set = makeSet([{ label: 'A', type: 'priority' }]);
+  assert.throws(
+    () =>
+      scoreTriageAssessments(set, [
+        {
+          requirementId: 'req-99-unknown',
+          status: 'met',
+          confidence: 'high',
+          note: '',
+        },
+      ]),
+    /unknown requirement ID/,
+  );
+  const valid = outcomes(set)[0];
+  assert.throws(
+    () => scoreTriageAssessments(set, [valid, valid]),
+    /duplicate requirement ID/,
+  );
+});
+
+test('tier boundaries are exact', () => {
+  assert.equal(tierForFitScore(100), 'top_pick');
+  assert.equal(tierForFitScore(80), 'top_pick');
+  assert.equal(tierForFitScore(79), 'shortlist');
+  assert.equal(tierForFitScore(65), 'shortlist');
+  assert.equal(tierForFitScore(64), 'consider');
+  assert.equal(tierForFitScore(45), 'consider');
+  assert.equal(tierForFitScore(44), 'unlikely');
+  assert.equal(tierForFitScore(25), 'unlikely');
+  assert.equal(tierForFitScore(24), 'no_go');
+  assert.equal(tierForFitScore(0), 'no_go');
+});
+
+const freshPublicPrice = {
+  amount: 4500,
+  currency: 'USD',
+  basis: 'stay' as const,
+  source: 'upstream',
+  capturedAt: '2026-07-24T12:00:00.000Z',
+  freshness: 'fresh' as const,
+  rateType: 'public' as const,
+  mandatoryChargesResolved: true,
+};
+
+const usdBudget = {
+  amount: 4500,
+  currency: 'USD',
+  basis: 'stay' as const,
+  source: 'explicit' as const,
+};
+
+test('affordability uses exact stay-total comparison and overage math', () => {
+  const within = computeAffordability({
+    budget: usdBudget,
+    price: freshPublicPrice,
+  });
+  assert.equal(within.status, 'within');
+  assert.equal(within.overByAmount, 0);
+  assert.equal(within.overByPercent, 0);
+
+  const over = computeAffordability({
+    budget: usdBudget,
+    price: { ...freshPublicPrice, amount: 4950 },
+  });
+  assert.equal(over.status, 'over');
+  assert.equal(over.overByAmount, 450);
+  assert.equal(over.overByPercent, 10);
+  assert.equal(over.budgetCurrency, 'USD');
+  assert.equal(over.priceCurrency, 'USD');
+  assert.equal(over.priceBasis, 'stay');
+  assert.equal(over.mandatoryChargesResolved, true);
+  assert.deepEqual(over.comparablePrice, {
+    ...freshPublicPrice,
+    amount: 4950,
+  });
+});
+
+test('affordability rounds percentage half-up to two decimals', () => {
+  const result = computeAffordability({
+    budget: { ...usdBudget, amount: '3.00' },
+    price: { ...freshPublicPrice, amount: '3.01' },
+  });
+  assert.equal(result.status, 'over');
+  assert.equal(result.overByAmount, 0.01);
+  assert.equal(result.overByPercent, 0.33);
+});
+
+test('affordability unknown reasons are specific and user-facing', () => {
+  const now = new Date('2026-07-25T12:00:00.000Z');
+  const cases = [
+    {
+      result: computeAffordability({ budget: null, price: freshPublicPrice }),
+      code: 'no_budget_given',
+      message: 'No analysis budget was given.',
+    },
+    {
+      result: computeAffordability({ budget: usdBudget, price: null }),
+      code: 'price_missing',
+      message: 'Price is missing for the selected stay.',
+    },
+    {
+      result: computeAffordability({
+        budget: usdBudget,
+        price: {
+          ...freshPublicPrice,
+          freshness: 'stale' as const,
+          capturedAt: '2026-07-13T12:00:00.000Z',
+        },
+        now,
+      }),
+      code: 'price_stale',
+      message: 'Price is stale (12 days old).',
+    },
+    {
+      result: computeAffordability({
+        budget: usdBudget,
+        price: { ...freshPublicPrice, currency: 'PLN' },
+      }),
+      code: 'currency_mismatch',
+      message: 'Price currency PLN does not match budget currency USD.',
+    },
+    {
+      result: computeAffordability({
+        budget: usdBudget,
+        price: { ...freshPublicPrice, mandatoryChargesResolved: false },
+      }),
+      code: 'mandatory_charges_unresolved',
+      message: 'Mandatory charges are unresolved in this price.',
+    },
+  ];
+
+  for (const item of cases) {
+    assert.equal(item.result.status, 'unknown');
+    assert.equal(item.result.reasonCode, item.code);
+    assert.equal(item.result.reason, item.message);
+  }
+});
+
+test('affordability rejects unknown freshness, non-stay basis, and non-public rates', () => {
+  const unknownFreshness = computeAffordability({
+    budget: usdBudget,
+    price: { ...freshPublicPrice, freshness: 'unknown' },
+  });
+  assert.equal(
+    unknownFreshness.reasonCode,
+    'price_freshness_unknown',
+  );
+  assert.match(unknownFreshness.reason ?? '', /freshness is unknown/);
+
+  const nightly = computeAffordability({
+    budget: usdBudget,
+    price: { ...freshPublicPrice, basis: 'night' },
+  });
+  assert.equal(nightly.reasonCode, 'stay_basis_unresolved');
+
+  const memberRate = computeAffordability({
+    budget: usdBudget,
+    price: { ...freshPublicPrice, rateType: 'member' },
+  });
+  assert.equal(memberRate.reasonCode, 'rate_not_public');
+});
+
+test('affordability never changes a deterministic quality verdict', () => {
+  const set = makeSet([
+    { label: 'Quiet', type: 'priority', rank: 1 },
+    { label: 'Workspace', type: 'priority' },
+  ]);
+  const before = scoreTriageAssessments(set, outcomes(set));
+  computeAffordability({
+    budget: usdBudget,
+    price: { ...freshPublicPrice, amount: 9000 },
+  });
+  const after = scoreTriageAssessments(set, outcomes(set));
+  assert.deepEqual(after, before);
+});
+
+test('stored affordability recomputes from price inputs without an LLM call', () => {
+  const initial = computeAffordability({
+    budget: usdBudget,
+    price: {
+      ...freshPublicPrice,
+      amount: 4950,
+      currency: 'PLN',
+    },
+  });
+  assert.equal(initial.reasonCode, 'currency_mismatch');
+  assert.equal(initial.priceCurrency, 'PLN');
+
+  const recomputed = recomputeStoredAffordability({
+    affordability: initial,
+    budget: {
+      amount: 5000,
+      currency: 'PLN',
+      basis: 'stay',
+      source: 'explicit',
+    },
+  });
+  assert.equal(recomputed?.status, 'within');
+  assert.equal(recomputed?.budgetAmount, 5000);
+  assert.equal(recomputed?.priceAmount, 4950);
+  assert.equal(recomputed?.currency, 'PLN');
+});
+
+test('stored affordability preserves missing prices and refuses pre-snapshot guesses', () => {
+  const missing = computeAffordability({
+    budget: null,
+    price: null,
+  });
+  const recomputedMissing = recomputeStoredAffordability({
+    affordability: missing,
+    budget: usdBudget,
+  });
+  assert.equal(recomputedMissing?.reasonCode, 'price_missing');
+  assert.equal(recomputedMissing?.budgetAmount, 4500);
+
+  assert.equal(
+    recomputeStoredAffordability({
+      affordability: {
+        status: 'over',
+        priceAmount: 5000,
+        currency: 'USD',
+      },
+      budget: usdBudget,
+    }),
+    null,
+  );
+});
+
+test('Booking room totals become a comparable stay price with detected PLN', () => {
+  const price = extractComparableStayPrice(
+    {
+      scrapedAt: '2026-07-24T12:00:00.000Z',
+      pricing: {
+        currency: null,
+        rooms: [
+          { totalPrice: '13,779 zł' },
+          { totalPrice: '12,300 zł' },
+        ],
+      },
+    },
+    'fresh',
+  );
+
+  assert.deepEqual(price, {
+    amount: 12300,
+    currency: 'PLN',
+    basis: 'stay',
+    source: 'upstream',
+    capturedAt: '2026-07-24T12:00:00.000Z',
+    freshness: 'fresh',
+    rateType: 'public',
+    mandatoryChargesResolved: true,
+  });
+  const affordability = computeAffordability({
+    budget: usdBudget,
+    price,
+  });
+  assert.equal(affordability.reasonCode, 'currency_mismatch');
+  assert.equal(
+    affordability.reason,
+    'Price currency PLN does not match budget currency USD.',
+  );
+});
+
+test('structured upstream totals remain full-stay prices', () => {
+  assert.deepEqual(
+    extractComparableStayPrice(
+      {
+        pricing: {
+          total: {
+            amount: 1877.52,
+            currency: 'USD',
+            source: 'derived',
+          },
+        },
+      },
+      'fresh',
+    ),
+    {
+      amount: 1877.52,
+      currency: 'USD',
+      basis: 'stay',
+      source: 'derived',
+      capturedAt: null,
+      freshness: 'fresh',
+      rateType: 'public',
+      mandatoryChargesResolved: true,
+    },
+  );
+  assert.equal(extractComparableStayPrice({ pricing: null }), null);
+});

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -112,6 +112,8 @@ model ReviewJob {
   checkout       String?
   adults         Int             @default(2)
   currency       String          @default("USD")
+  analysisBudgetAmount   Float?
+  analysisBudgetCurrency String?
   filters        Json?
   totalResults   Int             @default(0)
   pagesScanned   Int             @default(0)

--- a/web/src/app/api/jobs/[jobId]/route.ts
+++ b/web/src/app/api/jobs/[jobId]/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
+import {
+  recomputeStoredAffordability,
+  type AffordabilityBudget,
+} from '@cli/triage-rubric.js';
 import { prisma } from '@/lib/prisma';
 import { getReviewJobOwnerKey } from '@/lib/reviewJobOwner';
 import {
@@ -14,6 +18,76 @@ export const dynamic = 'force-dynamic';
 
 interface Params {
   params: Promise<{ jobId: string }>;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function getStoredBriefBudget(
+  triage: Record<string, unknown>,
+): AffordabilityBudget | null {
+  const requirementSet = asRecord(triage.requirementSet);
+  const parsedBudget = asRecord(requirementSet?.parsedBudget);
+  const maximumAmount = Number(parsedBudget?.maximumAmount);
+  const currency =
+    typeof parsedBudget?.currency === 'string'
+      ? parsedBudget.currency.trim().toUpperCase()
+      : '';
+  if (
+    parsedBudget?.basis !== 'stay'
+    || parsedBudget?.source !== 'brief'
+    || !Number.isFinite(maximumAmount)
+    || maximumAmount <= 0
+    || !/^[A-Z]{3}$/.test(currency)
+  ) {
+    return null;
+  }
+  return {
+    amount: maximumAmount,
+    currency,
+    basis: 'stay',
+    source: 'brief',
+  };
+}
+
+async function recomputeJobAffordability(
+  tx: Prisma.TransactionClient,
+  jobId: string,
+  explicitBudget: AffordabilityBudget | null,
+) {
+  const analyses = await tx.reviewJobListingAnalysis.findMany({
+    where: {
+      jobListing: { jobId },
+    },
+    select: {
+      id: true,
+      triage: true,
+    },
+  });
+
+  for (const analysis of analyses) {
+    const triage = asRecord(analysis.triage);
+    if (triage?.scoreSource !== 'deterministic_rubric') continue;
+
+    const affordability = recomputeStoredAffordability({
+      affordability: triage.affordability,
+      budget: explicitBudget ?? getStoredBriefBudget(triage),
+    });
+    if (!affordability) continue;
+
+    await tx.reviewJobListingAnalysis.update({
+      where: { id: analysis.id },
+      data: {
+        triage: {
+          ...triage,
+          affordability,
+        } as unknown as Prisma.InputJsonValue,
+      },
+    });
+  }
 }
 
 export async function GET(_request: Request, { params }: Params) {
@@ -43,6 +117,8 @@ export async function PATCH(request: Request, { params }: Params) {
 
   let body: {
     prompt?: string | null;
+    analysisBudgetAmount?: number | null;
+    analysisBudgetCurrency?: string | null;
     selectedListings?: Array<{ id: string; platform: Platform }> | null;
     isPublic?: boolean;
   };
@@ -71,6 +147,9 @@ export async function PATCH(request: Request, { params }: Params) {
       id: true,
       analysisStatus: true,
       analysisCurrentPhase: true,
+      currency: true,
+      analysisBudgetAmount: true,
+      analysisBudgetCurrency: true,
     },
   });
 
@@ -83,15 +162,56 @@ export async function PATCH(request: Request, { params }: Params) {
     || existingJob.analysisCurrentPhase === 'queued'
   ) {
     return NextResponse.json(
-      { error: 'Wait for the current analysis run to finish before changing brief or selection' },
+      { error: 'Wait for the current analysis run to finish before changing brief, budget, or selection' },
       { status: 409 },
     );
+  }
+
+  const hasBudgetUpdate =
+    Object.prototype.hasOwnProperty.call(body, 'analysisBudgetAmount')
+    || Object.prototype.hasOwnProperty.call(body, 'analysisBudgetCurrency');
+  const hasBudgetAmountUpdate =
+    Object.prototype.hasOwnProperty.call(body, 'analysisBudgetAmount');
+  let normalizedBudgetAmount: number | null | undefined;
+  let normalizedBudgetCurrency: string | null | undefined;
+  if (hasBudgetUpdate) {
+    const requestedAmount = hasBudgetAmountUpdate
+      ? body.analysisBudgetAmount
+      : existingJob.analysisBudgetAmount;
+    if (requestedAmount == null) {
+      normalizedBudgetAmount = null;
+      normalizedBudgetCurrency = null;
+    } else {
+      normalizedBudgetAmount = Number(requestedAmount);
+      const requestedCurrency =
+        body.analysisBudgetCurrency
+        ?? existingJob.analysisBudgetCurrency
+        ?? existingJob.currency;
+      normalizedBudgetCurrency =
+        typeof requestedCurrency === 'string'
+          ? requestedCurrency.trim().toUpperCase()
+          : '';
+      if (
+        !Number.isFinite(normalizedBudgetAmount)
+        || normalizedBudgetAmount <= 0
+        || !/^[A-Z]{3}$/.test(normalizedBudgetCurrency)
+      ) {
+        return NextResponse.json(
+          { error: 'Analysis budget requires a positive amount and three-letter currency code' },
+          { status: 400 },
+        );
+      }
+    }
   }
 
   const job = await prisma.$transaction(async (tx) => {
     const updateData: Prisma.ReviewJobUpdateInput = {};
     if (Object.prototype.hasOwnProperty.call(body, 'prompt')) {
       updateData.prompt = body.prompt?.trim() || null;
+    }
+    if (normalizedBudgetAmount !== undefined) {
+      updateData.analysisBudgetAmount = normalizedBudgetAmount;
+      updateData.analysisBudgetCurrency = normalizedBudgetCurrency ?? null;
     }
     if (typeof body.isPublic === 'boolean') {
       updateData.isPublic = body.isPublic;
@@ -102,6 +222,19 @@ export async function PATCH(request: Request, { params }: Params) {
         where: { id: jobId },
         data: updateData,
       });
+    }
+
+    if (normalizedBudgetAmount !== undefined) {
+      const explicitBudget: AffordabilityBudget | null =
+        normalizedBudgetAmount != null && normalizedBudgetCurrency
+          ? {
+              amount: normalizedBudgetAmount,
+              currency: normalizedBudgetCurrency,
+              basis: 'stay',
+              source: 'explicit',
+            }
+          : null;
+      await recomputeJobAffordability(tx, jobId, explicitBudget);
     }
 
     if (selectedListings) {

--- a/web/src/app/api/jobs/route.ts
+++ b/web/src/app/api/jobs/route.ts
@@ -45,6 +45,30 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Missing boundingBox' }, { status: 400 });
   }
 
+  const analysisBudgetAmount =
+    body.analysisBudgetAmount == null
+      ? null
+      : Number(body.analysisBudgetAmount);
+  const requestedBudgetCurrency =
+    body.analysisBudgetCurrency ?? body.currency ?? 'USD';
+  const analysisBudgetCurrency =
+    typeof requestedBudgetCurrency === 'string'
+      ? requestedBudgetCurrency.trim().toUpperCase()
+      : '';
+  if (
+    analysisBudgetAmount != null
+    && (
+      !Number.isFinite(analysisBudgetAmount)
+      || analysisBudgetAmount <= 0
+      || !/^[A-Z]{3}$/.test(analysisBudgetCurrency)
+    )
+  ) {
+    return NextResponse.json(
+      { error: 'Analysis budget requires a positive amount and three-letter currency code' },
+      { status: 400 },
+    );
+  }
+
   const cookieStore = await cookies();
   const existingOwnerKey = cookieStore.get(OWNER_KEY_COOKIE)?.value ?? null;
   const ownerKey = existingOwnerKey ?? randomUUID();
@@ -58,6 +82,9 @@ export async function POST(request: NextRequest) {
       searchAreaMode: body.searchAreaMode,
       poi: body.poi,
       prompt: body.prompt,
+      analysisBudgetAmount,
+      analysisBudgetCurrency:
+        analysisBudgetAmount == null ? null : analysisBudgetCurrency,
     }),
   });
 

--- a/web/src/components/JobWorkspace.tsx
+++ b/web/src/components/JobWorkspace.tsx
@@ -108,6 +108,10 @@ function getSelectedAnalysisSummary(result: ReviewJobResponse['listings'][number
   return {
     tier: triage.tier,
     fitScore: triage.fitScore,
+    scoreSource: triage.scoreSource,
+    rankingStatus: triage.rankingStatus,
+    coverage: triage.coverage,
+    affordability: triage.affordability,
     summary: triage.summary,
     highlights: triage.highlights,
     concerns: triage.concerns,
@@ -124,8 +128,35 @@ interface JobWorkspaceProps {
   initialData: ReviewJobResponse;
 }
 
+function analysisBudgetPayload(amountText: string, currencyText: string) {
+  if (!amountText.trim()) {
+    return {
+      analysisBudgetAmount: null,
+      analysisBudgetCurrency: null,
+    };
+  }
+  const amount = Number(amountText);
+  const currency = currencyText.trim().toUpperCase();
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error('Analysis budget must be a positive full-stay amount.');
+  }
+  if (!/^[A-Z]{3}$/.test(currency)) {
+    throw new Error('Budget currency must be a three-letter code.');
+  }
+  return {
+    analysisBudgetAmount: amount,
+    analysisBudgetCurrency: currency,
+  };
+}
+
 export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
   const initialPrompt = initialData.job.prompt ?? '';
+  const initialBudgetAmount =
+    initialData.job.analysisBudgetAmount?.toString() ?? '';
+  const initialBudgetCurrency =
+    initialData.job.analysisBudgetCurrency
+    ?? initialData.job.currency
+    ?? 'USD';
   const [data, setData] = useState(initialData);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [priceDisplay, setPriceDisplay] = useState<PriceDisplayMode>(
@@ -133,6 +164,16 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
   );
   const [prompt, setPrompt] = useState(initialPrompt);
   const [savedPrompt, setSavedPrompt] = useState(initialPrompt);
+  const [budgetAmount, setBudgetAmount] = useState(initialBudgetAmount);
+  const [savedBudgetAmount, setSavedBudgetAmount] = useState(
+    initialBudgetAmount,
+  );
+  const [budgetCurrency, setBudgetCurrency] = useState(
+    initialBudgetCurrency,
+  );
+  const [savedBudgetCurrency, setSavedBudgetCurrency] = useState(
+    initialBudgetCurrency,
+  );
   const [isSavingPrompt, setIsSavingPrompt] = useState(false);
   const [isSavingSelection, setIsSavingSelection] = useState(false);
   const [isStartingAnalysis, setIsStartingAnalysis] = useState(false);
@@ -141,10 +182,22 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
 
   const applyJobUpdate = useCallback((nextData: ReviewJobResponse) => {
     const nextPrompt = nextData.job.prompt ?? '';
+    const nextBudgetAmount =
+      nextData.job.analysisBudgetAmount?.toString() ?? '';
+    const nextBudgetCurrency =
+      nextData.job.analysisBudgetCurrency
+      ?? nextData.job.currency
+      ?? 'USD';
     setData(nextData);
     setSavedPrompt(nextPrompt);
     setPrompt((currentPrompt) => (currentPrompt === savedPrompt ? nextPrompt : currentPrompt));
-  }, [savedPrompt]);
+    setSavedBudgetAmount(nextBudgetAmount);
+    setBudgetAmount((current) =>
+      current === savedBudgetAmount ? nextBudgetAmount : current);
+    setSavedBudgetCurrency(nextBudgetCurrency);
+    setBudgetCurrency((current) =>
+      current === savedBudgetCurrency ? nextBudgetCurrency : current);
+  }, [savedBudgetAmount, savedBudgetCurrency, savedPrompt]);
 
   const refreshJob = useCallback(async () => {
     const nextData = await fetchReviewJobResponse(data.job.id);
@@ -195,7 +248,10 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
     || isStartingAnalysis
     || data.job.analysisStatus === 'running'
     || analysisQueued;
-  const isPromptDirty = prompt !== savedPrompt;
+  const isPromptDirty =
+    prompt !== savedPrompt
+    || budgetAmount !== savedBudgetAmount
+    || budgetCurrency !== savedBudgetCurrency;
 
   const persistSelection = useCallback(
     async (
@@ -224,9 +280,19 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
 
         const nextData: ReviewJobResponse = await res.json();
         const nextPrompt = nextData.job.prompt ?? '';
+        const nextBudgetAmount =
+          nextData.job.analysisBudgetAmount?.toString() ?? '';
+        const nextBudgetCurrency =
+          nextData.job.analysisBudgetCurrency
+          ?? nextData.job.currency
+          ?? 'USD';
         setData(nextData);
         setSavedPrompt(nextPrompt);
         setPrompt(nextPrompt);
+        setSavedBudgetAmount(nextBudgetAmount);
+        setBudgetAmount(nextBudgetAmount);
+        setSavedBudgetCurrency(nextBudgetCurrency);
+        setBudgetCurrency(nextBudgetCurrency);
         setSaveMessage(successMessage);
       } catch (error) {
         setSaveMessage(error instanceof Error ? error.message : 'Failed to update selection');
@@ -246,10 +312,14 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
     setSaveMessage(null);
 
     try {
+      const budget = analysisBudgetPayload(
+        budgetAmount,
+        budgetCurrency,
+      );
       const res = await fetch(`/api/jobs/${data.job.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt }),
+        body: JSON.stringify({ prompt, ...budget }),
       });
 
       if (!res.ok) {
@@ -259,16 +329,32 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
 
       const nextData: ReviewJobResponse = await res.json();
       const nextPrompt = nextData.job.prompt ?? '';
+      const nextBudgetAmount =
+        nextData.job.analysisBudgetAmount?.toString() ?? '';
+      const nextBudgetCurrency =
+        nextData.job.analysisBudgetCurrency
+        ?? nextData.job.currency
+        ?? 'USD';
       setData(nextData);
       setSavedPrompt(nextPrompt);
       setPrompt(nextPrompt);
+      setSavedBudgetAmount(nextBudgetAmount);
+      setBudgetAmount(nextBudgetAmount);
+      setSavedBudgetCurrency(nextBudgetCurrency);
+      setBudgetCurrency(nextBudgetCurrency);
       setSaveMessage('Saved');
     } catch (error) {
       setSaveMessage(error instanceof Error ? error.message : 'Failed to save prompt');
     } finally {
       setIsSavingPrompt(false);
     }
-  }, [data.job.id, prompt, viewerCanEdit]);
+  }, [
+    budgetAmount,
+    budgetCurrency,
+    data.job.id,
+    prompt,
+    viewerCanEdit,
+  ]);
 
   const startAnalysis = useCallback(async () => {
     if (!viewerCanEdit) {
@@ -279,10 +365,14 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
     setSaveMessage(null);
 
     try {
+      const budget = analysisBudgetPayload(
+        budgetAmount,
+        budgetCurrency,
+      );
       const saveRes = await fetch(`/api/jobs/${data.job.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt }),
+        body: JSON.stringify({ prompt, ...budget }),
       });
 
       if (!saveRes.ok) {
@@ -306,7 +396,14 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
     } finally {
       setIsStartingAnalysis(false);
     }
-  }, [data.job.id, prompt, refreshJob, viewerCanEdit]);
+  }, [
+    budgetAmount,
+    budgetCurrency,
+    data.job.id,
+    prompt,
+    refreshJob,
+    viewerCanEdit,
+  ]);
 
   const setPublicSharing = useCallback(async (nextValue: boolean) => {
     if (!viewerCanEdit) {
@@ -545,7 +642,7 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
                 <div>
                   <p className="text-sm font-semibold text-white">Analysis Brief</p>
                   <p className="mt-1 text-xs text-stone-500">
-                    Saved preferences feed the full CLI-equivalent analysis run.
+                    Saved quality preferences and the separate full-stay budget feed analysis.
                   </p>
                 </div>
                 <button
@@ -555,7 +652,7 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
                     disabled={isSavingPrompt || analysisLocked}
                     className="rounded-2xl border border-white/10 bg-white/[0.06] px-4 py-2 text-xs font-semibold text-stone-200 transition hover:bg-white/[0.1] disabled:cursor-not-allowed disabled:opacity-50"
                   >
-                  {isSavingPrompt ? 'Saving…' : 'Save brief'}
+                  {isSavingPrompt ? 'Saving…' : 'Save setup'}
                 </button>
               </div>
               <textarea
@@ -566,16 +663,47 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
                 className="mt-3 w-full rounded-2xl border border-white/10 bg-black/[0.18] px-4 py-3 text-sm text-white outline-none transition placeholder:text-stone-500 focus:border-[#ff6b5f]/35 focus:bg-black/30"
                 disabled={analysisLocked || isSavingPrompt || isStartingAnalysis}
               />
+              <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_140px]">
+                <label className="text-xs text-stone-400">
+                  Full-stay analysis budget
+                  <input
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={budgetAmount}
+                    onChange={(event) => setBudgetAmount(event.target.value)}
+                    placeholder="Optional, e.g. 4500"
+                    className="mt-1.5 w-full rounded-xl border border-white/10 bg-black/[0.18] px-3 py-2.5 text-sm text-white outline-none transition placeholder:text-stone-600 focus:border-[#ff6b5f]/35"
+                    disabled={analysisLocked || isSavingPrompt || isStartingAnalysis}
+                  />
+                </label>
+                <label className="text-xs text-stone-400">
+                  Currency
+                  <input
+                    type="text"
+                    maxLength={3}
+                    value={budgetCurrency}
+                    onChange={(event) =>
+                      setBudgetCurrency(event.target.value.toUpperCase())}
+                    className="mt-1.5 w-full rounded-xl border border-white/10 bg-black/[0.18] px-3 py-2.5 text-sm uppercase text-white outline-none transition focus:border-[#ff6b5f]/35"
+                    disabled={analysisLocked || isSavingPrompt || isStartingAnalysis}
+                  />
+                </label>
+              </div>
+              <p className="mt-2 text-xs leading-5 text-stone-500">
+                Price never changes the quality tier. It appears separately as within budget,
+                over by a percentage, or unknown with a reason.
+              </p>
               <div className="mt-3 flex items-center justify-between gap-3">
                 <span className="text-xs text-stone-500">
                   {saveMessage
                     ?? (
                       analysisLocked
                         ? (viewerCanEdit
-                          ? 'Brief and selection are locked while analysis is queued or running.'
-                          : 'Shared view is read-only. Ask the owner to edit the brief or run analysis.')
+                          ? 'Brief, budget, and selection are locked while analysis is queued or running.'
+                          : 'Shared view is read-only. Ask the owner to edit the setup or run analysis.')
                         : isPromptDirty
-                        ? 'Unsaved brief changes'
+                        ? 'Unsaved analysis setup changes'
                         : selectedCount > 0
                         ? `Only the ${selectedCount} selected listing${selectedCount === 1 ? '' : 's'} will be analyzed.`
                         : `No shortlist yet, so analysis will run on all ${sortedResults.length} listings.`
@@ -796,15 +924,47 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
                 {selectedAnalysisSummary ? (
                   <div className="mt-4 space-y-3">
                     <div className="flex flex-wrap items-center gap-2 text-xs">
-                      {selectedAnalysisSummary.tier && (
+                      {selectedAnalysisSummary.rankingStatus === 'insufficient_evidence' ? (
+                        <span className="rounded-full border border-amber-300/20 bg-amber-300/10 px-2.5 py-1 font-semibold uppercase tracking-[0.14em] text-amber-100">
+                          Insufficient evidence
+                        </span>
+                      ) : selectedAnalysisSummary.tier && (
                         <span className="rounded-full border border-emerald-300/20 bg-emerald-300/10 px-2.5 py-1 font-semibold uppercase tracking-[0.14em] text-emerald-100">
                           {selectedAnalysisSummary.tier.replace(/_/g, ' ')}
+                        </span>
+                      )}
+                      {selectedAnalysisSummary.scoreSource === 'model_legacy' && (
+                        <span className="rounded-full border border-violet-300/20 bg-violet-300/10 px-2.5 py-1 font-semibold text-violet-100">
+                          Legacy AI score
+                        </span>
+                      )}
+                      {selectedAnalysisSummary.scoreSource === 'deterministic_rubric' && (
+                        <span className="rounded-full border border-sky-300/20 bg-sky-300/10 px-2.5 py-1 font-semibold text-sky-100">
+                          {Math.round((selectedAnalysisSummary.coverage ?? 0) * 100)}% coverage
                         </span>
                       )}
                       <EvidenceGapBadge gaps={selectedAnalysisSummary.evidenceGaps} />
                       {selectedAnalysisSummary.fitScore != null && (
                         <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 font-medium text-stone-300">
                           Fit {selectedAnalysisSummary.fitScore}
+                        </span>
+                      )}
+                      {selectedAnalysisSummary.affordability?.status === 'within' && (
+                        <span className="rounded-full border border-emerald-300/20 bg-emerald-300/10 px-2.5 py-1 font-semibold text-emerald-100">
+                          Within budget
+                        </span>
+                      )}
+                      {selectedAnalysisSummary.affordability?.status === 'over' && (
+                        <span className="rounded-full border border-orange-300/20 bg-orange-300/10 px-2.5 py-1 font-semibold text-orange-100">
+                          {Math.round(selectedAnalysisSummary.affordability.overByPercent ?? 0)}% over budget
+                        </span>
+                      )}
+                      {selectedAnalysisSummary.affordability?.status === 'unknown' && (
+                        <span
+                          className="rounded-full border border-stone-300/20 bg-stone-300/10 px-2.5 py-1 font-semibold text-stone-200"
+                          title={selectedAnalysisSummary.affordability.reason ?? undefined}
+                        >
+                          Budget unknown · {selectedAnalysisSummary.affordability.reason ?? 'Reason unavailable.'}
                         </span>
                       )}
                     </div>

--- a/web/src/components/ResultsWorkspace.tsx
+++ b/web/src/components/ResultsWorkspace.tsx
@@ -17,9 +17,13 @@ import { getPriceDisplayInfo, resolveComparablePrice } from '@/lib/pricing';
 import { buildListingUrl } from '@/lib/listingLinks';
 import {
   formatPoiDistance,
+  getActiveRequirementSetId,
   getListingResultsSnapshot,
+  getTriageComparisonStatus,
   getTierRank,
+  type ParsedTriage,
   type ParsedTheme,
+  type TriageComparisonStatus,
 } from '@/lib/results';
 import {
   fetchReviewJobResponse,
@@ -68,6 +72,115 @@ function tierClassName(tier: string | null): string {
     default:
       return 'border-white/10 bg-white/[0.05] text-stone-300';
   }
+}
+
+function formatPercent(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return 'Unknown';
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function comparisonRank(status: TriageComparisonStatus): number {
+  switch (status) {
+    case 'ranked':
+      return 0;
+    case 'insufficient_evidence':
+      return 1;
+    case 'legacy':
+    case 'stale_requirement_set':
+      return 2;
+    case 'unscored':
+      return 3;
+  }
+}
+
+function displayedTier(
+  triage: ParsedTriage | null,
+  comparisonStatus?: TriageComparisonStatus,
+): { label: string; tier: string | null } {
+  const status =
+    comparisonStatus
+    ?? (triage?.rankingStatus === 'insufficient_evidence'
+      ? 'insufficient_evidence'
+      : triage?.scoreSource === 'model_legacy'
+        ? 'legacy'
+        : triage
+          ? 'ranked'
+          : 'unscored');
+  if (status === 'insufficient_evidence') {
+    return { label: 'Insufficient evidence', tier: null };
+  }
+  if (status === 'stale_requirement_set') {
+    return { label: 'Unranked', tier: null };
+  }
+  return { label: tierLabel(triage?.tier ?? null), tier: triage?.tier ?? null };
+}
+
+function VerdictSourceBadge({
+  triage,
+  comparisonStatus,
+}: {
+  triage: ParsedTriage | null;
+  comparisonStatus?: TriageComparisonStatus;
+}) {
+  if (!triage) return null;
+  const status =
+    comparisonStatus
+    ?? getTriageComparisonStatus(triage, triage.requirementSetId);
+  if (status === 'legacy') {
+    return (
+      <span className="rounded-full border border-violet-300/20 bg-violet-300/10 px-2 py-1 text-[10px] font-semibold text-violet-100">
+        Legacy AI score
+      </span>
+    );
+  }
+  if (status === 'stale_requirement_set') {
+    return (
+      <span className="rounded-full border border-stone-300/20 bg-stone-300/10 px-2 py-1 text-[10px] font-semibold text-stone-200">
+        Stale requirement set
+      </span>
+    );
+  }
+  if (status === 'insufficient_evidence') {
+    return (
+      <span className="rounded-full border border-amber-300/20 bg-amber-300/10 px-2 py-1 text-[10px] font-semibold text-amber-100">
+        Insufficient evidence · {Math.round((triage.coverage ?? 0) * 100)}% coverage
+      </span>
+    );
+  }
+  return (
+    <span className="rounded-full border border-sky-300/20 bg-sky-300/10 px-2 py-1 text-[10px] font-semibold text-sky-100">
+      Rubric v{triage.rubricVersion ?? '?'} · {Math.round((triage.coverage ?? 0) * 100)}% coverage
+    </span>
+  );
+}
+
+function AffordabilityBadge({ triage }: { triage: ParsedTriage | null }) {
+  const affordability = triage?.affordability;
+  if (!affordability) return null;
+  if (affordability.status === 'within') {
+    return (
+      <span className="rounded-full border border-emerald-300/20 bg-emerald-300/10 px-2 py-1 text-[10px] font-semibold text-emerald-100">
+        Within budget
+      </span>
+    );
+  }
+  if (affordability.status === 'over') {
+    return (
+      <span className="rounded-full border border-orange-300/20 bg-orange-300/10 px-2 py-1 text-[10px] font-semibold text-orange-100">
+        {formatPercent(affordability.overByPercent)}% over budget
+      </span>
+    );
+  }
+  return (
+    <span
+      className="max-w-sm rounded-full border border-stone-300/20 bg-stone-300/10 px-2 py-1 text-[10px] font-semibold text-stone-200"
+      title={affordability.reason ?? undefined}
+    >
+      Budget unknown · {affordability.reason ?? 'Reason unavailable.'}
+    </span>
+  );
 }
 
 function phaseBadgeClassName(status: string) {
@@ -414,6 +527,7 @@ function HeroCard({
   onJump: () => void;
 }) {
   const snapshot = getListingResultsSnapshot(listing);
+  const verdictTier = displayedTier(snapshot.triage);
   const priceInfo = getPriceDisplayInfo(listing, priceDisplay, {
     checkin: job.checkin,
     checkout: job.checkout,
@@ -453,11 +567,13 @@ function HeroCard({
           </span>
           <span
             className={`rounded-lg border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] ${tierClassName(
-              snapshot.triage?.tier ?? null,
+              verdictTier.tier,
             )}`}
           >
-            {tierLabel(snapshot.triage?.tier ?? null)}
+            {verdictTier.label}
           </span>
+          <VerdictSourceBadge triage={snapshot.triage} />
+          <AffordabilityBadge triage={snapshot.triage} />
           <EvidenceGapBadge gaps={snapshot.triage?.evidenceGaps} />
         </div>
 
@@ -489,11 +605,13 @@ function ListingDetailPanel({
   listing,
   job,
   priceDisplay,
+  comparisonStatus,
   onLocate,
 }: {
   listing: ReviewJobListing;
   job: ReviewJobResponse['job'];
   priceDisplay: PriceDisplayMode;
+  comparisonStatus: TriageComparisonStatus;
   onLocate: () => void;
 }) {
   const snapshot = useMemo(() => getListingResultsSnapshot(listing), [listing]);
@@ -520,6 +638,7 @@ function ListingDetailPanel({
   const amenities = snapshot.details?.amenities ?? [];
   const amenityFlags = getAmenityFlags(amenities);
   const triage = snapshot.triage;
+  const verdictTier = displayedTier(triage, comparisonStatus);
   const aiReviews = snapshot.aiReviews;
   const aiPhotos = snapshot.aiPhotos;
   const poiDistanceLabel = formatPoiDistance(listing.poiDistanceMeters);
@@ -602,11 +721,16 @@ function ListingDetailPanel({
                 </span>
                 <span
                   className={`rounded-lg border px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] ${tierClassName(
-                    triage?.tier ?? null,
+                    verdictTier.tier,
                   )}`}
                 >
-                  {tierLabel(triage?.tier ?? null)}
+                  {verdictTier.label}
                 </span>
+                <VerdictSourceBadge
+                  triage={triage}
+                  comparisonStatus={comparisonStatus}
+                />
+                <AffordabilityBadge triage={triage} />
                 <EvidenceGapBadge gaps={triage?.evidenceGaps} />
               </div>
 
@@ -687,6 +811,7 @@ function ListingDetailPanel({
                         <tr>
                           <th className="px-3 py-2 font-semibold">Need</th>
                           <th className="px-3 py-2 font-semibold">Type</th>
+                          <th className="px-3 py-2 font-semibold">Weight</th>
                           <th className="px-3 py-2 font-semibold">Status</th>
                           <th className="px-3 py-2 font-semibold">Confidence</th>
                           <th className="px-3 py-2 font-semibold">Note</th>
@@ -694,10 +819,16 @@ function ListingDetailPanel({
                       </thead>
                       <tbody>
                         {triage.requirements.map((requirement) => (
-                          <tr key={requirement.requirement} className="border-t border-white/5">
+                          <tr
+                            key={requirement.requirementId ?? requirement.requirement}
+                            className="border-t border-white/5"
+                          >
                             <td className="px-3 py-2 text-white">{requirement.requirement}</td>
                             <td className="px-3 py-2 text-stone-400">
                               {requirement.type?.replace(/_/g, ' ') ?? '—'}
+                            </td>
+                            <td className="px-3 py-2 text-stone-400">
+                              {requirement.weight ?? '—'}
                             </td>
                             <td className="px-3 py-2">
                               <span
@@ -1174,11 +1305,34 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
     }
   }, [applyJobUpdate, data.job.id, data.listings]);
 
+  const activeRequirementSetId = useMemo(
+    () => getActiveRequirementSetId(data.listings),
+    [data.listings],
+  );
+
   const baseRankedResults = useMemo(() => {
     const next = [...data.listings];
+    const originalIndex = new Map(
+      next.map((listing, index) => [listingKey(listing), index]),
+    );
     next.sort((a, b) => {
       const triageA = getListingResultsSnapshot(a).triage;
       const triageB = getListingResultsSnapshot(b).triage;
+      if (activeRequirementSetId) {
+        const groupA = comparisonRank(
+          getTriageComparisonStatus(triageA, activeRequirementSetId),
+        );
+        const groupB = comparisonRank(
+          getTriageComparisonStatus(triageB, activeRequirementSetId),
+        );
+        if (groupA !== groupB) return groupA - groupB;
+        if (groupA !== 0) {
+          return (
+            (originalIndex.get(listingKey(a)) ?? 0)
+            - (originalIndex.get(listingKey(b)) ?? 0)
+          );
+        }
+      }
 
       const fitA = triageA?.fitScore ?? -1;
       const fitB = triageB?.fitScore ?? -1;
@@ -1213,16 +1367,59 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       return priceA - priceB;
     });
     return next;
-  }, [data.job.checkin, data.job.checkout, data.listings, priceDisplay]);
+  }, [
+    activeRequirementSetId,
+    data.job.checkin,
+    data.job.checkout,
+    data.listings,
+    priceDisplay,
+  ]);
 
   const sortableResults = useMemo(() => {
     const next = [...baseRankedResults];
+    const baseIndex = new Map(
+      next.map((listing, index) => [listingKey(listing), index]),
+    );
 
     if (sortKey === 'rank') {
-      return sortAsc ? [...next].reverse() : next;
+      if (!sortAsc) return next;
+      if (!activeRequirementSetId) return [...next].reverse();
+      const ranked = next.filter((listing) =>
+        getTriageComparisonStatus(
+          getListingResultsSnapshot(listing).triage,
+          activeRequirementSetId,
+        ) === 'ranked');
+      const unranked = next.filter((listing) =>
+        getTriageComparisonStatus(
+          getListingResultsSnapshot(listing).triage,
+          activeRequirementSetId,
+        ) !== 'ranked');
+      return [...ranked.reverse(), ...unranked];
     }
 
     next.sort((a, b) => {
+      if (activeRequirementSetId) {
+        const groupA = comparisonRank(
+          getTriageComparisonStatus(
+            getListingResultsSnapshot(a).triage,
+            activeRequirementSetId,
+          ),
+        );
+        const groupB = comparisonRank(
+          getTriageComparisonStatus(
+            getListingResultsSnapshot(b).triage,
+            activeRequirementSetId,
+          ),
+        );
+        if (groupA !== groupB) return groupA - groupB;
+        if (groupA !== 0) {
+          return (
+            (baseIndex.get(listingKey(a)) ?? 0)
+            - (baseIndex.get(listingKey(b)) ?? 0)
+          );
+        }
+      }
+
       if (sortKey === 'title') {
         return sortAsc
           ? a.name.localeCompare(b.name)
@@ -1263,6 +1460,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
 
     return next;
   }, [
+    activeRequirementSetId,
     baseRankedResults,
     data.job.checkin,
     data.job.checkout,
@@ -1282,8 +1480,16 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
   const filteredResults = useMemo(
     () =>
       displayableResults.filter((listing) => {
-        const tier = getListingResultsSnapshot(listing).triage?.tier ?? 'unscored';
-        if (!activeTiers.has(tier)) {
+        const triage = getListingResultsSnapshot(listing).triage;
+        const comparisonStatus = getTriageComparisonStatus(
+          triage,
+          activeRequirementSetId,
+        );
+        const tier = triage?.tier ?? 'unscored';
+        if (
+          (!activeRequirementSetId || comparisonStatus === 'ranked')
+          && !activeTiers.has(tier)
+        ) {
           return false;
         }
 
@@ -1313,6 +1519,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       }),
     [
       activeTiers,
+      activeRequirementSetId,
       data.job.checkin,
       data.job.checkout,
       displayableResults,
@@ -1333,20 +1540,41 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
   );
 
   const heroResults = useMemo(() => {
-    const topPicks = filteredResults.filter(
-      (listing) => getListingResultsSnapshot(listing).triage?.tier === 'top_pick',
+    const comparable = filteredResults.filter(
+      (listing) =>
+        !activeRequirementSetId
+        || getTriageComparisonStatus(
+          getListingResultsSnapshot(listing).triage,
+          activeRequirementSetId,
+        ) === 'ranked',
     );
-    return topPicks.length >= 3 ? topPicks.slice(0, 5) : filteredResults.slice(0, 5);
-  }, [filteredResults]);
+    const topPicks = comparable.filter(
+      (listing) =>
+        getListingResultsSnapshot(listing).triage?.tier === 'top_pick',
+    );
+    return topPicks.length >= 3
+      ? topPicks.slice(0, 5)
+      : comparable.slice(0, 5);
+  }, [activeRequirementSetId, filteredResults]);
 
   const tierCounts = useMemo(() => {
     const counts = new Map<string, number>();
     for (const listing of displayableResults) {
-      const tier = getListingResultsSnapshot(listing).triage?.tier ?? 'unscored';
+      const triage = getListingResultsSnapshot(listing).triage;
+      if (
+        activeRequirementSetId
+        && getTriageComparisonStatus(
+          triage,
+          activeRequirementSetId,
+        ) !== 'ranked'
+      ) {
+        continue;
+      }
+      const tier = triage?.tier ?? 'unscored';
       counts.set(tier, (counts.get(tier) ?? 0) + 1);
     }
     return counts;
-  }, [displayableResults]);
+  }, [activeRequirementSetId, displayableResults]);
 
   useEffect(() => {
     if (filteredResults.length === 0) {
@@ -1509,6 +1737,36 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       rows.map((listing, index) => {
         const key = listingKey(listing);
         const snapshot = getListingResultsSnapshot(listing);
+        const comparisonStatus = getTriageComparisonStatus(
+          snapshot.triage,
+          activeRequirementSetId,
+        );
+        const verdictTier = displayedTier(
+          snapshot.triage,
+          comparisonStatus,
+        );
+        const comparisonGroup = comparisonRank(comparisonStatus);
+        const previousComparisonGroup =
+          index > 0
+            ? comparisonRank(
+                getTriageComparisonStatus(
+                  getListingResultsSnapshot(rows[index - 1]).triage,
+                  activeRequirementSetId,
+                ),
+              )
+            : null;
+        const groupHeader =
+          activeRequirementSetId
+          && comparisonGroup !== 0
+          && comparisonGroup !== previousComparisonGroup
+            ? comparisonGroup === 1
+              ? 'Insufficient evidence — shown for audit, not ranked with comparable results'
+              : comparisonGroup === 2
+                ? 'Legacy or stale verdicts — regrade the whole job before comparing'
+                : 'Unscored listings'
+            : null;
+        const showPeerRank =
+          !activeRequirementSetId || comparisonStatus === 'ranked';
         const priceInfo = getPriceDisplayInfo(listing, priceDisplay, {
           checkin: data.job.checkin,
           checkout: data.job.checkout,
@@ -1532,6 +1790,16 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
 
         return (
           <Fragment key={key}>
+            {groupHeader && (
+              <tr className="border-y border-white/10 bg-white/[0.035]">
+                <td
+                  colSpan={13}
+                  className="px-4 py-3 text-xs font-semibold uppercase tracking-[0.14em] text-stone-300"
+                >
+                  {groupHeader}
+                </td>
+              </tr>
+            )}
             <tr
               ref={(node) => {
                 rowRefs.current[key] = node;
@@ -1558,7 +1826,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
                 </ActionButton>
               </td>
               <td className="px-3 py-3 align-top text-sm font-semibold text-stone-400">
-                {index + 1}
+                {showPeerRank ? index + 1 : '—'}
               </td>
               <td className="px-3 py-3 align-top">
                 {listing.photoUrl ? (
@@ -1617,11 +1885,15 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
                 <div className="flex flex-col items-start gap-1.5">
                   <span
                     className={`inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] ${tierClassName(
-                      snapshot.triage?.tier ?? null,
+                      verdictTier.tier,
                     )}`}
                   >
-                    {tierLabel(snapshot.triage?.tier ?? null)}
+                    {verdictTier.label}
                   </span>
+                  <VerdictSourceBadge
+                    triage={snapshot.triage}
+                    comparisonStatus={comparisonStatus}
+                  />
                   <EvidenceGapBadge gaps={snapshot.triage?.evidenceGaps} />
                 </div>
               </td>
@@ -1633,6 +1905,9 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
                 {priceInfo.secondary && (
                   <div className="mt-1 text-xs text-stone-500">{priceInfo.secondary}</div>
                 )}
+                <div className="mt-2">
+                  <AffordabilityBadge triage={snapshot.triage} />
+                </div>
               </td>
               <td className="px-3 py-3 align-top">
                 <div className="text-sm font-semibold text-white">
@@ -1704,11 +1979,12 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
 
             {isExpanded && (
               <tr className="border-b border-white/10">
-                <td colSpan={12} className="p-0">
+                <td colSpan={13} className="p-0">
                   <ListingDetailPanel
                     listing={listing}
                     job={data.job}
                     priceDisplay={priceDisplay}
+                    comparisonStatus={comparisonStatus}
                     onLocate={() => handleSelect(key, { scroll: false })}
                   />
                 </td>
@@ -1718,6 +1994,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
         );
       }),
     [
+      activeRequirementSetId,
       data.job,
       expandedId,
       handleSelect,
@@ -1870,12 +2147,19 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
             </p>
           </div>
 
-          {data.job.prompt && (
+          {(data.job.prompt || data.job.analysisBudgetAmount != null) && (
             <div className="mt-5 rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-4 text-sm leading-7 text-stone-300">
               <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-500">
                 Brief
               </p>
-              {data.job.prompt}
+              {data.job.prompt || 'No quality brief supplied; the default requirement set was used.'}
+              {data.job.analysisBudgetAmount != null
+                && data.job.analysisBudgetCurrency && (
+                  <p className="mt-3 text-xs font-semibold text-stone-400">
+                    Full-stay analysis budget: {data.job.analysisBudgetCurrency}{' '}
+                    {data.job.analysisBudgetAmount.toLocaleString()}
+                  </p>
+                )}
             </div>
           )}
 

--- a/web/src/lib/results.ts
+++ b/web/src/lib/results.ts
@@ -31,6 +31,16 @@ function asStringArray(value: unknown): string[] {
   return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
 }
 
+function asNumberArray(value: unknown): number[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (item): item is number =>
+      typeof item === 'number' && Number.isFinite(item),
+  );
+}
+
 function normalizeEvidenceGaps(value: unknown[]): TriageEvidenceGap[] {
   const provided = new Set(value);
   return TRIAGE_EVIDENCE_GAP_ORDER.filter((gap) => provided.has(gap));
@@ -64,11 +74,23 @@ function getPhotoUrl(photo: unknown): string | null {
 }
 
 export interface ParsedRequirement {
+  requirementId: string | null;
   requirement: string;
+  label: string;
   type: string | null;
+  rank: number | null;
+  weight: number | null;
+  order: number | null;
   status: string | null;
   confidence: string | null;
   note: string | null;
+  evidence: Array<{
+    layer: string | null;
+    polarity: string | null;
+    text: string;
+    frequency: string | null;
+    years: number[];
+  }>;
 }
 
 export interface ParsedTheme {
@@ -86,9 +108,20 @@ export interface ParsedPrioritySignal {
 }
 
 export interface ParsedTriage {
+  scoreSource: 'deterministic_rubric' | 'model_legacy';
+  rubricVersion: string | null;
+  requirementSetId: string | null;
+  rawFitScore: number | null;
   fitScore: number | null;
   tier: string | null;
   tierReason: string | null;
+  capReasons: string[];
+  coverage: number | null;
+  rankingStatus:
+    | 'ranked'
+    | 'insufficient_evidence'
+    | 'legacy_unranked';
+  rankingReason: string | null;
   summary: string | null;
   bedSetup: string | null;
   priceTotal: string | null;
@@ -100,7 +133,30 @@ export interface ParsedTriage {
   evidenceGaps: TriageEvidenceGap[];
   requirements: ParsedRequirement[];
   scores: Array<{ key: string; value: number }>;
+  affordability: {
+    status: 'within' | 'over' | 'unknown';
+    reasonCode: string | null;
+    reason: string | null;
+    budgetAmount: number | null;
+    priceAmount: number | null;
+    currency: string | null;
+    budgetCurrency: string | null;
+    priceCurrency: string | null;
+    priceBasis: string | null;
+    overByAmount: number | null;
+    overByPercent: number | null;
+    priceSource: string | null;
+    freshness: string | null;
+    mandatoryChargesResolved: boolean | null;
+  } | null;
 }
+
+export type TriageComparisonStatus =
+  | 'ranked'
+  | 'insufficient_evidence'
+  | 'legacy'
+  | 'stale_requirement_set'
+  | 'unscored';
 
 export interface ParsedAiReviews {
   overallSentiment: string | null;
@@ -182,21 +238,115 @@ export function getListingResultsSnapshot(
   };
 }
 
+export function getActiveRequirementSetId(
+  listings: ReviewJobListing[],
+): string | null {
+  const counts = new Map<string, { count: number; firstIndex: number }>();
+  listings.forEach((listing, index) => {
+    const triage = parseTriage(listing);
+    if (
+      triage?.scoreSource !== 'deterministic_rubric'
+      || !triage.requirementSetId
+    ) {
+      return;
+    }
+    const current = counts.get(triage.requirementSetId);
+    counts.set(triage.requirementSetId, {
+      count: (current?.count ?? 0) + 1,
+      firstIndex: current?.firstIndex ?? index,
+    });
+  });
+  return (
+    [...counts.entries()]
+      .sort(
+        (a, b) =>
+          b[1].count - a[1].count
+          || a[1].firstIndex - b[1].firstIndex,
+      )[0]?.[0]
+    ?? null
+  );
+}
+
+export function getTriageComparisonStatus(
+  triage: ParsedTriage | null,
+  activeRequirementSetId: string | null,
+): TriageComparisonStatus {
+  if (!triage) return 'unscored';
+  if (triage.scoreSource === 'model_legacy') return 'legacy';
+  if (
+    activeRequirementSetId
+    && triage.requirementSetId !== activeRequirementSetId
+  ) {
+    return 'stale_requirement_set';
+  }
+  if (triage.rankingStatus === 'insufficient_evidence') {
+    return 'insufficient_evidence';
+  }
+  return 'ranked';
+}
+
 function parseTriage(listing: ReviewJobListing): ParsedTriage | null {
   const triage = asRecord(listing.analysis?.triage);
   if (!triage) {
     return null;
   }
 
+  const scoreSource =
+    triage.scoreSource === 'deterministic_rubric'
+    && asString(triage.rubricVersion)
+    && asString(triage.requirementSetId)
+      ? 'deterministic_rubric'
+      : 'model_legacy';
+  const coverage = asNumber(triage.coverage);
+  const storedRankingStatus = asString(triage.rankingStatus);
+  const rankingStatus: ParsedTriage['rankingStatus'] =
+    scoreSource === 'model_legacy'
+      ? 'legacy_unranked'
+      : storedRankingStatus === 'insufficient_evidence'
+        || (coverage != null && coverage < 0.5)
+        ? 'insufficient_evidence'
+        : 'ranked';
+
   const requirements = Array.isArray(triage.requirements)
     ? triage.requirements.map((item) => {
         const record = asRecord(item);
+        const label =
+          asString(record?.label)
+          ?? asString(record?.requirement)
+          ?? 'Requirement';
+        const evidence = Array.isArray(record?.evidence)
+          ? record.evidence
+              .map((evidenceItem) => {
+                const evidenceRecord = asRecord(evidenceItem);
+                const text = asString(evidenceRecord?.text);
+                if (!text) return null;
+                return {
+                  layer: asString(evidenceRecord?.layer),
+                  polarity: asString(evidenceRecord?.polarity),
+                  text,
+                  frequency: asString(evidenceRecord?.frequency),
+                  years: asNumberArray(evidenceRecord?.years),
+                };
+              })
+              .filter(
+                (
+                  evidenceItem,
+                ): evidenceItem is ParsedRequirement['evidence'][number] =>
+                  evidenceItem != null,
+              )
+          : [];
         return {
-          requirement: asString(record?.requirement) ?? 'Requirement',
+          requirementId: asString(record?.requirementId),
+          requirement: label,
+          label,
           type: asString(record?.type),
+          rank: asNumber(record?.rank),
+          weight: asNumber(record?.weight),
+          order: asNumber(record?.order),
           status: asString(record?.status),
           confidence: asString(record?.confidence),
           note: asString(record?.note),
+          evidence,
         };
       })
     : [];
@@ -212,11 +362,51 @@ function parseTriage(listing: ReviewJobListing): ParsedTriage | null {
     : [];
 
   const price = asRecord(triage.price);
+  const affordabilityRecord = asRecord(triage.affordability);
+  const affordabilityStatus = asString(affordabilityRecord?.status);
+  const affordability: ParsedTriage['affordability'] =
+    affordabilityStatus === 'within'
+    || affordabilityStatus === 'over'
+    || affordabilityStatus === 'unknown'
+      ? {
+          status: affordabilityStatus,
+          reasonCode: asString(affordabilityRecord?.reasonCode),
+          reason: asString(affordabilityRecord?.reason),
+          budgetAmount: asNumber(affordabilityRecord?.budgetAmount),
+          priceAmount: asNumber(affordabilityRecord?.priceAmount),
+          currency: asString(affordabilityRecord?.currency),
+          budgetCurrency: asString(affordabilityRecord?.budgetCurrency),
+          priceCurrency: asString(affordabilityRecord?.priceCurrency),
+          priceBasis: asString(affordabilityRecord?.priceBasis),
+          overByAmount: asNumber(affordabilityRecord?.overByAmount),
+          overByPercent: asNumber(affordabilityRecord?.overByPercent),
+          priceSource: asString(affordabilityRecord?.priceSource),
+          freshness: asString(affordabilityRecord?.freshness),
+          mandatoryChargesResolved:
+            typeof affordabilityRecord?.mandatoryChargesResolved === 'boolean'
+              ? affordabilityRecord.mandatoryChargesResolved
+              : null,
+        }
+      : null;
 
   return {
+    scoreSource,
+    rubricVersion:
+      scoreSource === 'deterministic_rubric'
+        ? asString(triage.rubricVersion)
+        : null,
+    requirementSetId:
+      scoreSource === 'deterministic_rubric'
+        ? asString(triage.requirementSetId)
+        : null,
+    rawFitScore: asNumber(triage.rawFitScore),
     fitScore: asNumber(triage.fitScore),
     tier: asString(triage.tier),
     tierReason: asString(triage.tierReason),
+    capReasons: asStringArray(triage.capReasons),
+    coverage,
+    rankingStatus,
+    rankingReason: asString(triage.rankingReason),
     summary: asString(triage.summary),
     bedSetup: asString(triage.bedSetup),
     priceTotal: asString(price?.total),
@@ -228,6 +418,7 @@ function parseTriage(listing: ReviewJobListing): ParsedTriage | null {
     evidenceGaps: getTriageEvidenceGaps(listing, triage),
     requirements,
     scores,
+    affordability,
   };
 }
 

--- a/web/src/lib/reviewJobs.ts
+++ b/web/src/lib/reviewJobs.ts
@@ -386,6 +386,8 @@ export function toReviewJobState(
     checkout: job.checkout ?? null,
     adults: job.adults,
     currency: job.currency,
+    analysisBudgetAmount: job.analysisBudgetAmount ?? null,
+    analysisBudgetCurrency: job.analysisBudgetCurrency ?? null,
     filters: asJsonObject(job.filters),
     totalResults: job.totalResults,
     pagesScanned: job.pagesScanned,
@@ -486,6 +488,8 @@ export function buildReviewJobData(
     searchAreaMode?: 'window' | 'rectangle' | 'circle';
     poi?: MapPoint | null;
     prompt?: string | null;
+    analysisBudgetAmount?: number | null;
+    analysisBudgetCurrency?: string | null;
   } = { ownerKey: '' },
 ): Prisma.ReviewJobCreateInput {
   return {
@@ -505,6 +509,8 @@ export function buildReviewJobData(
     checkout: request.checkout ?? null,
     adults: request.adults ?? 2,
     currency: request.currency ?? 'USD',
+    analysisBudgetAmount: options.analysisBudgetAmount ?? null,
+    analysisBudgetCurrency: options.analysisBudgetCurrency ?? null,
     filters: buildSearchFilters(request),
     progress: 0,
   };

--- a/web/src/lib/search-worker.ts
+++ b/web/src/lib/search-worker.ts
@@ -1236,6 +1236,16 @@ async function runReviewJobAnalysis(reviewJobId: string) {
       triage: true,
       aiModel: analysisModel,
       aiPriorities: jobRecord.prompt?.trim() || undefined,
+      analysisBudget:
+        jobRecord.analysisBudgetAmount != null
+        && jobRecord.analysisBudgetCurrency
+          ? {
+              amount: jobRecord.analysisBudgetAmount,
+              currency: jobRecord.analysisBudgetCurrency,
+              basis: 'stay',
+              source: 'explicit',
+            }
+          : undefined,
       aiReviewsExplicit: true,
       aiPhotosExplicit: true,
       triageExplicit: true,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -137,6 +137,8 @@ export interface CreateReviewJobRequest extends FullSearchRequest {
   searchAreaMode?: 'window' | 'rectangle' | 'circle';
   poi?: MapPoint;
   prompt?: string;
+  analysisBudgetAmount?: number;
+  analysisBudgetCurrency?: string;
 }
 
 export interface CreateReviewJobResponse {
@@ -238,6 +240,8 @@ export interface ReviewJobState {
   checkout: string | null;
   adults: number;
   currency: string;
+  analysisBudgetAmount: number | null;
+  analysisBudgetCurrency: string | null;
   filters: Record<string, unknown> | null;
   totalResults: number;
   pagesScanned: number;


### PR DESCRIPTION
Closes #62.

## What changed

- Parse the guest brief once into a canonical, versioned requirement set, persist it per batch, and reuse the same code-generated IDs and resolved numeric weights for every listing.
- Replace model-authored fit verdicts with a pure deterministic scorer: confidence shrinkage, integer half-up rounding, numeric-weight hard caps, tier thresholds, and a 50% known-weight coverage floor.
- Separate affordability from quality. Persist exact comparison inputs and specific unknown reasons; add an explicit full-stay analysis budget to jobs, the CLI, and the web UI. Budget edits recompute only deterministic affordability JSON in the job transaction and never invoke the LLM or mutate legacy verdicts.
- Keep legacy and stale requirement-set verdicts auditable without interleaving them into active peer rankings. Apply the same grouping in the Next results workspace and generated HTML report.
- Document the rubric contract, three numeric worked examples, and the complete issue #62 temp-0/temp-1 stability measurement.

## Why

The previous classifier owned requirements, weights, score, tier, and price/value prose in one stochastic response. Identical inputs could therefore cross tier boundaries or trigger different hard-failure interpretations. This change limits the model to evidence classification against one frozen set; code owns every consequential scoring and ranking decision.

## Impact

Production triage defaults to classification temperature 0. New results expose score source/version, requirement-set ID, raw and capped scores, cap reasons, coverage, ranking eligibility, evidence-bearing requirement cells, and independent affordability. Jobs below 50% known-weight coverage remain visible for audit but are labeled insufficient evidence and grouped outside the ranking.

The Prisma schema adds nullable `ReviewJob.analysisBudgetAmount` and `ReviewJob.analysisBudgetCurrency`. This PR does not mutate the live database; deployment needs the normal safe-window schema push.

## Stability evidence

One frozen set (`reqset_6b9344b3d4089e4bcad6`) was used for 30 classifier calls across the three issue fixtures.

- Temperature 0: 15/15 succeeded. Club Quarters was 44/unlikely x5, Candlewood 79/shortlist x5, and Michelangelo 77/shortlist x5. Maximum absolute deviation was 0; status flips, confidence flips, and deterministic invariant violations were all 0.
- Temperature 1: all scores and tiers remained stable. Weighted status flip rate was 3.08% and confidence flip rate 6.15%, confined to Club Quarters blackout status/confidence and Michelangelo bed confidence.
- Required weight>=3 `unmet/high` <-> `partial/high` audit: 0/90 pairs at temperature 0 and 0/90 at temperature 1. Candlewood Quiet remained `partial/high` in every run.

Full tables and input hashes are in `docs/triage-stability-issue-62.md`.

## Validation

- `pnpm run build`
- `pnpm test` — 121/121 passing
- `pnpm run lint`
- `cd web && npm run build`
- `cd web && npm run test:ui` — 5/5 passing
- `cd web && npm run test:pricing` — 3/3 passing
- `cd web && npm run lint`
- `prisma validate` with the existing web-local database environment
- `git diff --check`

This PR is intentionally left unmerged pending the orchestrator review gate.
