### PR TITLE
Define the partial-vs-unmet triage boundary

### DIFF
--- a/docs/triage-classifier-boundary-issue-69.md
+++ b/docs/triage-classifier-boundary-issue-69.md
@@ -1,0 +1,88 @@
+# Triage classifier boundary evaluation — issue #69
+
+Measured 2026-07-25 with `gemini-3-flash-preview:high`, the frozen issue #62
+requirement set `reqset_6b9344b3d4089e4bcad6`, temperature 0, and the exact stay context
+2026-07-29 → 2026-08-11 (13 nights, 2 adults, New York City).
+
+## Hand-labeled set
+
+The tracked fixture
+`tests/fixtures/triage-boundary-eval.json` contains 15 listing/requirement pairs: all five
+canonical requirements for Candlewood Suites, Club Quarters Midtown, and The Michelangelo. Each
+label includes its adjudication rationale, decisive evidence excerpts, and SHA-256 hashes for the
+original listing, review-analysis, and photo-analysis artifacts.
+
+Five pairs exercise a non-`met` boundary:
+
+| Listing | Requirement | Hand label | Why |
+|---|---|---|---|
+| Candlewood Suites | Quiet environment | `unmet` | 42/250 recurring sleep-disrupting HVAC reports; turning it off is not a usable 13-night summer mitigation |
+| Club Quarters | Quiet environment | `unmet` | 68/250 mechanical/street-noise reports, including noise with AC off |
+| Club Quarters | Blackout conditions | `partial` | naturally dark rooms plus a bounded Roman-shade leakage caveat |
+| The Michelangelo | Quiet environment | `unmet` | recurring tractor-like/whistling HVAC and mechanical noise |
+| The Michelangelo | Bed comfort | `partial` | strong 8.9 aggregate comfort signal plus 8/205 recent sagging/broken-coil complaints |
+
+The other ten positive controls are the clearly supported bed, blackout, walkability, and workspace
+requirements. They prevent a stricter prompt from appearing better merely by changing every
+ambiguous result to `unmet`.
+
+## Before and after
+
+The reproducible runner is `tests/evals/run-triage-boundary-eval.ts`. It calls the exact preserved
+v1 prompt and the candidate v2 prompt over the same artifacts.
+
+| Policy | Overall | Non-`met` boundary | Candlewood | Club Quarters | Michelangelo |
+|---|---:|---:|---|---|---|
+| `triage-classifier-v1` | 13/15 (86.7%) | 3/5 (60%) | 79 / `shortlist` | 44 / `unlikely` | 77 / `shortlist` |
+| `triage-classifier-v2` | 15/15 (100%) | 5/5 (100%) | 44 / `unlikely` | 44 / `unlikely` | 44 / `unlikely` |
+
+The two v1 errors were exactly the issue #69 failures: Candlewood and Michelangelo quietness were
+`partial/high` instead of `unmet/high`. V2 corrected both and retained every positive and genuinely
+mixed control.
+
+V2 makes the decision explicit:
+
+- recurring meaningful or severe confirmed failure is `unmet`; a majority is not required;
+- `partial` requires genuinely mixed evidence or a specific, verifiable, stay-available way to
+  avoid the failure;
+- turning off a needed system, tolerating the problem, or hoping for another room is not avoidance;
+- `unknown` remains the result for missing or too-vague evidence;
+- dates, destination, length, and guest count may condition mitigation relevance without inventing
+  weather, inventory, or provider policy.
+
+The prompt includes three real frozen examples: Candlewood quiet (`unmet`), Club Quarters blackout
+(`partial`), and Michelangelo bed comfort (`partial`).
+
+## Stability rerun
+
+`tests/evals/run-triage-stability.ts` repeated the original issue #62 matrix: three listings × five
+runs at temperature 0 and temperature 1, for 30 completed calls. It also validates the invariant
+that an identical classification signature always yields the same deterministic verdict.
+
+| Temperature | Club Quarters | Candlewood | Michelangelo | Weighted status flips | Weighted confidence flips | `partial/high ↔ unmet/high` | Invariant violations |
+|---:|---|---|---|---:|---:|---:|---:|
+| 0 | 44 × 5 / `unlikely` | 44 × 5 / `unlikely` | 44 × 5 / `unlikely` | 0/390 (0%) | 0/390 (0%) | 0 | 0 |
+| 1 | 44 × 5 / `unlikely` | 44 × 5 / `unlikely` | 44 × 5 / `unlikely` | 0/390 (0%) | 24/390 (6.15%) | 0 | 0 |
+
+Maximum absolute score deviation was 0 for every listing at both temperatures. The production
+temperature-zero acceptance gate passed.
+
+One preliminary temperature-one response returned a duplicate requirement ID and was rejected
+before scoring. The resumed 30-call matrix above contains only valid completed calls. The runner is
+now resumable and records any such rejected attempts; production classification remains
+temperature 0.
+
+## Comparability and migration
+
+V2 verdicts persist:
+
+- `classifierVersion: "triage-classifier-v2"`;
+- `modelId` for audit;
+- the unchanged deterministic rubric version and canonical requirement-set ID.
+
+The sole comparison key is
+`rubricVersion + requirementSetId + classifierVersion`. `modelId` is intentionally excluded.
+Existing deterministic JSON without `classifierVersion` is preserved and shown as classified under
+an older policy, with a triage-only whole-job regrade action and an estimated cost of
+about $0.006/listing. The scope and estimate include every non-hidden listing in the job, not only
+the stale verdicts that triggered the warning.

--- a/docs/triage-rubric.md
+++ b/docs/triage-rubric.md
@@ -13,6 +13,8 @@ New verdicts carry:
   "scoreSource": "deterministic_rubric",
   "rubricVersion": "1",
   "requirementSetId": "reqset_...",
+  "classifierVersion": "triage-classifier-v2",
+  "modelId": "gemini:gemini-3-flash-preview:high",
   "rawFitScore": 70,
   "fitScore": 44,
   "tier": "unlikely",
@@ -29,6 +31,18 @@ Affordability is a separate structured axis.
 `rawFitScore` is the weighted result. `fitScore` is the raw result after every deterministic cap.
 `tier` is derived from `fitScore`. `coverage` and `rankingStatus` decide whether the verdict may be
 ranked alongside its peers.
+
+Peer comparison uses one derived key:
+
+```text
+rubricVersion + requirementSetId + classifierVersion
+```
+
+Code builds this key in one shared helper used by the native results page and CLI report. A missing
+or different classifier version makes a verdict non-comparable even when its requirement
+definitions match. `modelId` is persisted for audit but is deliberately outside the key: provider
+model aliases can change on an external release schedule, and that churn must not silently
+invalidate every saved verdict.
 
 ## Canonical requirement set
 
@@ -105,9 +119,27 @@ The listing classifier receives frozen definitions and returns one outcome for e
 }
 ```
 
-Statuses are `met`, `partial`, `unmet`, and `unknown`. Confidence is `high`, `medium`, or `low`.
-Missing evidence must produce `unknown`; absence in photos is not evidence of absence. The model
-does not output the quality score, tier, definitions, weights, or caps.
+Statuses are `met`, `partial`, `unmet`, and `unknown`. Classifier policy v2 applies these boundaries:
+
+- `met`: clear relevant support with no material contradiction;
+- `partial`: evidence is genuinely mixed, or failure is bounded and avoidable through a specific,
+  verifiable choice that the evidence says is available for this stay;
+- `unmet`: credible actual failure, including a recurring meaningful pattern, a severe confirmed
+  failure directly matching the requirement, or a mitigation that defeats the requirement;
+- `unknown`: no relevant evidence, a missing evidence layer, or evidence too vague to distinguish
+  fit from failure.
+
+Turning off a needed system, tolerating a problem, or merely asking for a better room is not
+guest-controlled avoidance. A majority of reviews is not required for `unmet`, but absence of
+evidence still produces `unknown`; absence in photos is not evidence of absence.
+
+Every batch supplies the exact job check-in, check-out, stay length, guest count, and listing
+destination. Stay context may decide whether a mitigation is usable—for example, disabling a loud
+HVAC for a 13-night July/August stay—but the classifier may not invent weather, live inventory,
+room assignment, or provider policy. Direct CLI callers can provide the same context explicitly.
+
+Confidence is `high`, `medium`, or `low` and measures evidence strength, not requirement
+importance. The model does not output the quality score, tier, definitions, weights, or caps.
 
 ## Scoring math
 
@@ -278,11 +310,16 @@ Stored JSON without `scoreSource`, `rubricVersion`, and `requirementSetId` is
 - Preserve legacy JSON; do not silently mutate it or pay to recompute it.
 - Display `Legacy AI score`.
 - If every result is legacy, preserve the prior score-based display behavior.
-- In a mixed job, only deterministic verdicts for the active requirement set rank together.
-- Insufficient-evidence, legacy, and stale/mismatched-set verdicts appear in labeled unranked
-  groups.
-- Regrading is an explicit whole-job analysis rerun. Never interleave old model-authored scores with
-  rubric scores.
+- In a mixed job, only deterministic verdicts with the same derived comparability key rank
+  together.
+- A deterministic verdict without the current `classifierVersion` remains preserved but appears as
+  `Classified under an older policy`; it never ranks beside current-policy results.
+- Insufficient-evidence, older-policy, legacy, and stale/mismatched-set verdicts appear in labeled
+  unranked groups.
+- The native results page offers an explicit whole-job regrade with an estimated cost. Regrading
+  covers every non-hidden listing, reuses saved review and photo analysis, and runs triage only; at
+  the measured ~$0.006/listing, a 54-listing job is estimated at ~$0.32.
+- Never interleave old model-authored or old-classifier scores with current-policy scores.
 
 CLI/report output follows the same source/version and grouping rules.
 

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -2255,6 +2255,11 @@ export async function runBatch(
             budget: options.analysisBudget,
             priceFreshness:
               entry.details.source === 'network' ? 'fresh' : 'unknown',
+            stayContext: {
+              checkIn: manifest.dates.checkIn,
+              checkOut: manifest.dates.checkOut,
+              adults: manifest.dates.adults,
+            },
           });
 
           if (!result.data || typeof result.data !== 'object' || Array.isArray(result.data)) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -562,6 +562,10 @@ program
   .option('--temperature <n>', 'Evidence-classification temperature (default: 0)', '0')
   .option('--budget <amount>', 'Maximum analysis budget for the full stay')
   .option('--budget-currency <code>', 'Analysis budget currency (default: USD)', 'USD')
+  .option('--checkin <date>', 'Stay check-in date (YYYY-MM-DD)')
+  .option('--checkout <date>', 'Stay check-out date (YYYY-MM-DD)')
+  .option('--adults <n>', 'Number of adults')
+  .option('--destination <text>', 'Stay destination when listing address is unavailable')
   .action(async (listingFile: string, cmdOpts: any) => {
     // Load .env for GEMINI_API_KEY
     try { await import('dotenv/config'); } catch {}
@@ -575,6 +579,13 @@ program
       priorities: cmdOpts.priorities || undefined,
       temperature: Number(cmdOpts.temperature),
       budget: parseAnalysisBudget(cmdOpts),
+      stayContext: {
+        checkIn: cmdOpts.checkin || undefined,
+        checkOut: cmdOpts.checkout || undefined,
+        adults:
+          cmdOpts.adults == null ? undefined : Number(cmdOpts.adults),
+        destination: cmdOpts.destination || undefined,
+      },
     });
     console.log(JSON.stringify(result.data, null, 2));
   });

--- a/src/report.ts
+++ b/src/report.ts
@@ -5,6 +5,11 @@
 
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'fs';
 import { join, resolve } from 'path';
+import {
+  getCurrentTriageComparability,
+  getTriageComparabilityKey,
+  type TriageComparabilityDescriptor,
+} from './triage-comparability.js';
 
 export interface ReportOptions {
   outputDir: string;
@@ -26,6 +31,8 @@ interface TriageData {
   scoreSource?: string;
   rubricVersion?: string;
   requirementSetId?: string;
+  classifierVersion?: string;
+  modelId?: string;
   rawFitScore?: number;
   fitScore: number;
   tier: string;
@@ -65,6 +72,9 @@ interface ListingRow {
   scoreSource: 'deterministic_rubric' | 'model_legacy';
   rubricVersion: string | null;
   requirementSetId: string | null;
+  classifierVersion: string | null;
+  modelId: string | null;
+  comparabilityKey: string | null;
   rankingStatus: 'ranked' | 'insufficient_evidence' | 'legacy_unranked';
   coverage: number | null;
   rawFitScore: number | null;
@@ -271,6 +281,20 @@ export async function generateReport(options: ReportOptions): Promise<string> {
         : 'model_legacy',
       rubricVersion: deterministic ? triage.rubricVersion! : null,
       requirementSetId: deterministic ? triage.requirementSetId! : null,
+      classifierVersion:
+        deterministic && typeof triage.classifierVersion === 'string'
+          ? triage.classifierVersion
+          : null,
+      modelId:
+        typeof triage.modelId === 'string' ? triage.modelId : null,
+      comparabilityKey:
+        deterministic
+          ? getTriageComparabilityKey({
+              rubricVersion: triage.rubricVersion,
+              requirementSetId: triage.requirementSetId,
+              classifierVersion: triage.classifierVersion,
+            })
+          : null,
       rankingStatus,
       coverage,
       rawFitScore:
@@ -325,16 +349,16 @@ export async function generateReport(options: ReportOptions): Promise<string> {
     });
   }
 
-  const activeRequirementSetId = getActiveRequirementSetId(rows);
+  const activeTriageComparison = getActiveTriageComparison(rows);
   rows.sort((a, b) => {
-    if (activeRequirementSetId) {
+    if (activeTriageComparison) {
       const groupA = getReportComparisonGroup(
         a,
-        activeRequirementSetId,
+        activeTriageComparison,
       );
       const groupB = getReportComparisonGroup(
         b,
-        activeRequirementSetId,
+        activeTriageComparison,
       );
       if (groupA !== groupB) return groupA - groupB;
       if (groupA !== 0) return a.sourceOrder - b.sourceOrder;
@@ -396,7 +420,9 @@ function esc(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-function getActiveRequirementSetId(rows: ListingRow[]): string | null {
+function getActiveTriageComparison(
+  rows: ListingRow[],
+): TriageComparabilityDescriptor | null {
   const counts = new Map<string, { count: number; first: number }>();
   for (const row of rows) {
     if (
@@ -411,7 +437,7 @@ function getActiveRequirementSetId(rows: ListingRow[]): string | null {
       first: current?.first ?? row.sourceOrder,
     });
   }
-  return (
+  const requirementSetId = (
     [...counts.entries()]
       .sort(
         (a, b) =>
@@ -419,24 +445,29 @@ function getActiveRequirementSetId(rows: ListingRow[]): string | null {
       )[0]?.[0]
     ?? null
   );
+  return requirementSetId
+    ? getCurrentTriageComparability(requirementSetId)
+    : null;
 }
 
 function getReportComparisonGroup(
   row: ListingRow,
-  activeRequirementSetId: string | null,
+  activeComparison: TriageComparabilityDescriptor | null,
 ): number {
-  if (!activeRequirementSetId) return 0;
+  if (!activeComparison) return 0;
+  if (row.scoreSource === 'model_legacy') return 3;
+  if (row.requirementSetId !== activeComparison.requirementSetId) return 3;
+  if (row.comparabilityKey !== activeComparison.key) return 2;
   if (
     row.scoreSource === 'deterministic_rubric'
-    && row.requirementSetId === activeRequirementSetId
+    && row.comparabilityKey === activeComparison.key
   ) {
     return row.rankingStatus === 'insufficient_evidence' ? 1 : 0;
   }
-  return 2;
+  return 3;
 }
 
 function buildHTML(rows: ListingRow[], dates?: { checkIn: string; checkOut: string; adults: number }, picks?: { liked: string[]; hidden: string[] }): string {
-  const dataJSON = JSON.stringify(rows);
   const picksJSON = JSON.stringify(picks || { liked: [], hidden: [] });
   const poiRow = rows.find((row) => row.poiLat != null && row.poiLng != null);
   const poiJSON = JSON.stringify(
@@ -444,23 +475,37 @@ function buildHTML(rows: ListingRow[], dates?: { checkIn: string; checkOut: stri
   );
   const tierOrder = ['top_pick', 'shortlist', 'consider', 'unlikely', 'no_go'];
   const tierCounts: Record<string, number> = {};
-  const activeRequirementSetId = getActiveRequirementSetId(rows);
-  const comparableRows = activeRequirementSetId
+  const activeTriageComparison = getActiveTriageComparison(rows);
+  const reportRows = rows.map((row) => ({
+    ...row,
+    comparisonGroup: getReportComparisonGroup(
+      row,
+      activeTriageComparison,
+    ),
+  }));
+  const dataJSON = JSON.stringify(reportRows);
+  const comparableRows = activeTriageComparison
     ? rows.filter(
         (row) =>
-          getReportComparisonGroup(row, activeRequirementSetId) === 0,
+          getReportComparisonGroup(row, activeTriageComparison) === 0,
       )
     : rows;
-  const insufficientCount = activeRequirementSetId
+  const insufficientCount = activeTriageComparison
     ? rows.filter(
         (row) =>
-          getReportComparisonGroup(row, activeRequirementSetId) === 1,
+          getReportComparisonGroup(row, activeTriageComparison) === 1,
       ).length
     : 0;
-  const legacyOrStaleCount = activeRequirementSetId
+  const olderPolicyCount = activeTriageComparison
     ? rows.filter(
         (row) =>
-          getReportComparisonGroup(row, activeRequirementSetId) === 2,
+          getReportComparisonGroup(row, activeTriageComparison) === 2,
+      ).length
+    : 0;
+  const legacyOrStaleCount = activeTriageComparison
+    ? rows.filter(
+        (row) =>
+          getReportComparisonGroup(row, activeTriageComparison) === 3,
       ).length
     : 0;
   for (const t of tierOrder) tierCounts[t] = 0;
@@ -492,8 +537,8 @@ ${getCSS()}
 <header>
   <h1>Listing Report</h1>
   <p class="subtitle">${rows.length} listings triaged${dateLabel ? ` · ${esc(dateLabel)}` : ''}</p>
-  ${activeRequirementSetId && (insufficientCount > 0 || legacyOrStaleCount > 0)
-    ? `<p class="subtitle">${insufficientCount} insufficient-evidence and ${legacyOrStaleCount} legacy/stale verdicts are shown outside the peer ranking.</p>`
+  ${activeTriageComparison && (insufficientCount > 0 || olderPolicyCount > 0 || legacyOrStaleCount > 0)
+    ? `<p class="subtitle">${insufficientCount} insufficient-evidence, ${olderPolicyCount} older-policy, and ${legacyOrStaleCount} legacy/stale-set verdicts are shown outside the peer ranking.</p>`
     : ''}
 </header>
 
@@ -501,7 +546,7 @@ ${getCSS()}
 <section id="top-picks">
   <h2>Top Picks</h2>
   <div class="hero-grid">
-${heroRows.map(r => heroCard(r, activeRequirementSetId)).join('\n')}
+${heroRows.map(r => heroCard(r, activeTriageComparison)).join('\n')}
   </div>
 </section>
 
@@ -593,13 +638,16 @@ ${getJS()}
 
 function reportVerdictBadges(
   row: ListingRow,
-  activeRequirementSetId: string | null,
+  activeComparison: TriageComparabilityDescriptor | null,
 ): string {
-  const group = getReportComparisonGroup(row, activeRequirementSetId);
+  const group = getReportComparisonGroup(row, activeComparison);
   if (row.scoreSource === 'model_legacy') {
     return '<span class="source-badge source-legacy">Legacy AI score</span>';
   }
   if (group === 2) {
+    return '<span class="source-badge source-unranked">Older classifier policy</span>';
+  }
+  if (group === 3) {
     return '<span class="source-badge source-unranked">Stale requirement set</span>';
   }
   if (group === 1) {
@@ -628,7 +676,7 @@ function reportAffordabilityBadge(row: ListingRow): string {
 
 function heroCard(
   r: ListingRow,
-  activeRequirementSetId: string | null,
+  activeComparison: TriageComparabilityDescriptor | null,
 ): string {
   const photo = r.photos[0] || '';
   const metaParts = [
@@ -642,12 +690,12 @@ function heroCard(
   ).join('');
   const comparisonGroup = getReportComparisonGroup(
     r,
-    activeRequirementSetId,
+    activeComparison,
   );
   const displayedTier =
     comparisonGroup === 1
       ? 'insufficient evidence'
-      : comparisonGroup === 2
+      : comparisonGroup >= 2
         ? 'unranked'
         : r.tier.replace('_', ' ');
   const displayedTierClass =
@@ -656,7 +704,7 @@ function heroCard(
   return `    <div class="hero-card" data-id="${esc(r.id)}" onclick="scrollToRow('${esc(r.id)}')">
       ${photo ? `<img class="hero-photo" src="${esc(photo)}" alt="${esc(r.title)}" loading="lazy">` : '<div class="hero-photo no-photo"></div>'}
       <div class="hero-body">
-        <div class="hero-badges"><span class="score-badge">${r.fitScore}</span><span class="tier-badge${displayedTierClass}">${displayedTier}</span>${reportVerdictBadges(r, activeRequirementSetId)}${reportAffordabilityBadge(r)}</div>
+        <div class="hero-badges"><span class="score-badge">${r.fitScore}</span><span class="tier-badge${displayedTierClass}">${displayedTier}</span>${reportVerdictBadges(r, activeComparison)}${reportAffordabilityBadge(r)}</div>
         <h3><a href="${esc(r.url)}" target="_blank" rel="noopener">${esc(r.title)}</a></h3>
         <div class="hero-meta">${metaParts.join(' · ')}</div>
         <p class="hero-summary">${esc(r.summary.substring(0, 160))}${r.summary.length > 160 ? '…' : ''}</p>
@@ -901,28 +949,14 @@ function getJS(): string {
   const STATUS_COLORS = {met:'#22c55e',partial:'#f59e0b',unmet:'#ef4444',unknown:'#9ca3af'};
   const SCORE_KEYS = ['fit','location','sleepQuality','cleanliness','modernity','valueForMoney'];
   const SCORE_LABELS = {fit:'Fit',location:'Location',sleepQuality:'Sleep',cleanliness:'Clean',modernity:'Modern',valueForMoney:'Value'};
-  const requirementSetCounts = new Map();
-  DATA.forEach((r, index) => {
-    if (r.scoreSource !== 'deterministic_rubric' || !r.requirementSetId) return;
-    const current = requirementSetCounts.get(r.requirementSetId);
-    requirementSetCounts.set(r.requirementSetId, {
-      count: (current?.count || 0) + 1,
-      first: current?.first ?? index,
-    });
-  });
-  const ACTIVE_REQUIREMENT_SET_ID = [...requirementSetCounts.entries()]
-    .sort((a,b) => b[1].count - a[1].count || a[1].first - b[1].first)[0]?.[0] || null;
   function comparisonGroup(r) {
-    if (!ACTIVE_REQUIREMENT_SET_ID) return 0;
-    if (r.scoreSource === 'deterministic_rubric' && r.requirementSetId === ACTIVE_REQUIREMENT_SET_ID) {
-      return r.rankingStatus === 'insufficient_evidence' ? 1 : 0;
-    }
-    return 2;
+    return typeof r.comparisonGroup === 'number' ? r.comparisonGroup : 0;
   }
   function verdictSourceBadge(r) {
     const group = comparisonGroup(r);
     if (r.scoreSource === 'model_legacy') return '<span class="source-badge source-legacy">Legacy AI score</span>';
-    if (group === 2) return '<span class="source-badge source-unranked">Stale requirement set</span>';
+    if (group === 2) return '<span class="source-badge source-unranked">Older classifier policy</span>';
+    if (group === 3) return '<span class="source-badge source-unranked">Stale requirement set</span>';
     if (group === 1) return '<span class="source-badge source-insufficient">Insufficient evidence · ' + Math.round((r.coverage || 0) * 100) + '% coverage</span>';
     return '<span class="source-badge source-rubric">Rubric v' + esc(r.rubricVersion || '?') + ' · ' + Math.round((r.coverage || 0) * 100) + '% coverage</span>';
   }
@@ -984,7 +1018,7 @@ function getJS(): string {
     const photo = r.photos[0] || '';
     const thumbHtml = photo ? '<img class="thumb" src="' + esc(photo) + '" loading="lazy" alt="">' : '<div class="thumb"></div>';
     const group = comparisonGroup(r);
-    const tierLabel = group === 1 ? 'insufficient evidence' : group === 2 ? 'unranked' : r.tier.replace('_',' ');
+    const tierLabel = group === 1 ? 'insufficient evidence' : group >= 2 ? 'unranked' : r.tier.replace('_',' ');
     const tierClass = group === 0 ? ' tier-' + r.tier : '';
     const tierBadge = '<span class="tier-badge' + tierClass + '">' + tierLabel + '</span>';
     const platBadge = '<span class="platform-badge platform-' + r.platform + '">' + r.platform + '</span>';
@@ -1013,7 +1047,9 @@ function getJS(): string {
     if (showGroupHeader && group > 0) {
       const label = group === 1
         ? 'Insufficient evidence — shown for audit, not ranked with comparable results'
-        : 'Legacy or stale verdicts — regrade the whole job before comparing';
+        : group === 2
+          ? 'Classified under an older policy — regrade the whole job before comparing'
+          : 'Legacy or stale requirement-set verdicts — regrade before comparing';
       html += '<tr><td colspan="12" style="background:#f8fafc;color:#475569;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em">' + label + '</td></tr>';
     }
     html += '<tr class="listing-row' + (expandedId === r.id ? ' expanded' : '') + (isLiked ? ' is-liked' : '') + '" data-id="' + esc(r.id) + '"' + (isHidden ? ' style="opacity:.4"' : '') + '>';

--- a/src/triage-comparability.ts
+++ b/src/triage-comparability.ts
@@ -1,0 +1,80 @@
+export const TRIAGE_RUBRIC_VERSION = '1';
+export const TRIAGE_CLASSIFIER_VERSION = 'triage-classifier-v2';
+export const LEGACY_TRIAGE_CLASSIFIER_VERSION = 'triage-classifier-v1';
+export const ESTIMATED_TRIAGE_COST_USD_PER_LISTING = 0.006;
+
+export type TriageClassifierVersion =
+  | typeof LEGACY_TRIAGE_CLASSIFIER_VERSION
+  | typeof TRIAGE_CLASSIFIER_VERSION;
+
+export interface TriageComparabilityMetadata {
+  rubricVersion?: unknown;
+  requirementSetId?: unknown;
+  classifierVersion?: unknown;
+}
+
+export interface TriageComparabilityDescriptor {
+  key: string;
+  rubricVersion: string;
+  requirementSetId: string;
+  classifierVersion: string;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value
+    : null;
+}
+
+/**
+ * The only key used to decide whether two deterministic triage verdicts may
+ * rank together. Model identity is deliberately excluded: it is audit
+ * metadata, while requirement definitions, scoring policy, and classification
+ * policy define comparability.
+ */
+export function getTriageComparabilityKey(
+  metadata: TriageComparabilityMetadata,
+): string | null {
+  const rubricVersion = nonEmptyString(metadata.rubricVersion);
+  const requirementSetId = nonEmptyString(metadata.requirementSetId);
+  const classifierVersion = nonEmptyString(metadata.classifierVersion);
+  if (!rubricVersion || !requirementSetId || !classifierVersion) {
+    return null;
+  }
+
+  return JSON.stringify([
+    rubricVersion,
+    requirementSetId,
+    classifierVersion,
+  ]);
+}
+
+export function getCurrentTriageComparability(
+  requirementSetId: string,
+): TriageComparabilityDescriptor {
+  const key = getTriageComparabilityKey({
+    rubricVersion: TRIAGE_RUBRIC_VERSION,
+    requirementSetId,
+    classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+  });
+  if (!key) {
+    throw new Error('A current triage comparability key could not be built.');
+  }
+
+  return {
+    key,
+    rubricVersion: TRIAGE_RUBRIC_VERSION,
+    requirementSetId,
+    classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+  };
+}
+
+export function estimateTriageRegradeCostUsd(listingCount: number): number {
+  if (!Number.isFinite(listingCount) || listingCount <= 0) {
+    return 0;
+  }
+  return (
+    Math.ceil(listingCount)
+    * ESTIMATED_TRIAGE_COST_USD_PER_LISTING
+  );
+}

--- a/src/triage-rubric.ts
+++ b/src/triage-rubric.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
+import { TRIAGE_RUBRIC_VERSION } from './triage-comparability.js';
 
-export const TRIAGE_RUBRIC_VERSION = '1';
+export { TRIAGE_RUBRIC_VERSION } from './triage-comparability.js';
 export const REQUIREMENT_SCHEMA_VERSION = '1';
 export const MIN_RANKED_COVERAGE = 0.5;
 

--- a/src/triage.ts
+++ b/src/triage.ts
@@ -18,8 +18,20 @@ import {
   type ParsedAnalysisBudget,
   type RequirementAssessmentInput,
 } from './triage-rubric.js';
+import {
+  LEGACY_TRIAGE_CLASSIFIER_VERSION,
+  TRIAGE_CLASSIFIER_VERSION,
+  type TriageClassifierVersion,
+} from './triage-comparability.js';
 
 // --- Types ---
+
+export interface TriageStayContext {
+  checkIn?: string;
+  checkOut?: string;
+  adults?: number;
+  destination?: string;
+}
 
 export interface TriageOptions {
   listingFile: string;       // Path to listing JSON
@@ -32,6 +44,9 @@ export interface TriageOptions {
   budget?: AffordabilityBudget;
   price?: ComparableStayPrice;
   priceFreshness?: ComparableStayPrice['freshness'];
+  stayContext?: TriageStayContext;
+  /** Evaluation/backfill only. Product calls always use the current policy. */
+  classifierVersion?: TriageClassifierVersion;
 }
 
 export const TRIAGE_EVIDENCE_GAP_ORDER = [
@@ -53,6 +68,8 @@ export interface TriageResult {
   data: any;                 // Parsed triage JSON
   model: string;
   provider: LLMProvider;
+  classifierVersion: TriageClassifierVersion;
+  modelId: string;
   requirementSet: CanonicalRequirementSet;
   evidenceGaps: TriageEvidenceGap[];
   tokensUsed?: number;
@@ -102,7 +119,19 @@ const REQUIREMENT_PARSE_SYSTEM_PROMPT = `Convert one guest brief into a canonica
 - Normalize currency to an ISO 4217 code when the brief makes it clear.
 - Do not inflate the maximum for "slightly over is acceptable"; overage is shown separately.`;
 
-const TRIAGE_SYSTEM_PROMPT = `You are a property evidence classifier helping a specific guest compare rentals. The user message supplies a frozen canonical requirement set. Classify exactly those requirement IDs; never parse, merge, split, rename, reorder, reweight, or add requirements.
+const TRIAGE_REQUIREMENT_RULES_V1 = `## Requirement Evaluation Rules
+1. Return one outcome for every supplied requirement ID.
+2. For each requirement, determine status:
+   - **met**: Clear evidence it's satisfied
+   - **partial**: Partially satisfied or with caveats
+   - **unmet**: Clear evidence it's NOT satisfied
+   - **unknown**: Insufficient data to determine
+3. Be conservative: prefer "unknown" over "unmet" when data is insufficient. Never assume the worst.
+4. Confidence describes evidence strength, not how important the requirement is.
+5. Include the strongest supporting and contradicting evidence. Use exact, concise evidence text from the supplied artifacts when possible.
+6. Frequency and years are evidence metadata only; omit them when unavailable.`;
+
+export const TRIAGE_CLASSIFIER_PROMPT_V1 = `You are a property evidence classifier helping a specific guest compare rentals. The user message supplies a frozen canonical requirement set. Classify exactly those requirement IDs; never parse, merge, split, rename, reorder, reweight, or add requirements.
 
 You have three data sources for each listing:
 
@@ -118,17 +147,7 @@ You have three data sources for each listing:
 - The user message names any missing evidence layers. Never infer facts from a missing layer.
 - Mark requirements that depend only on missing evidence as unknown, and state the limitation in the tier reason and summary.
 
-## Requirement Evaluation Rules
-1. Return one outcome for every supplied requirement ID.
-2. For each requirement, determine status:
-   - **met**: Clear evidence it's satisfied
-   - **partial**: Partially satisfied or with caveats
-   - **unmet**: Clear evidence it's NOT satisfied
-   - **unknown**: Insufficient data to determine
-3. Be conservative: prefer "unknown" over "unmet" when data is insufficient. Never assume the worst.
-4. Confidence describes evidence strength, not how important the requirement is.
-5. Include the strongest supporting and contradicting evidence. Use exact, concise evidence text from the supplied artifacts when possible.
-6. Frequency and years are evidence metadata only; omit them when unavailable.
+${TRIAGE_REQUIREMENT_RULES_V1}
 
 ## Verdict boundary
 - Do not output fitScore, tier, weights, requirement types, caps, or requirement definitions.
@@ -142,6 +161,44 @@ You have three data sources for each listing:
 - **dealBreakers**: Confirmed evidence that makes a weight-3-or-higher requirement fail.
 - **summary**: 2-3 sentences — would you recommend this to this specific guest? Why or why not?
 - **price.valueAssessment**: Compare price to quality/location/amenities. "unknown" if no price data.`;
+
+const TRIAGE_REQUIREMENT_RULES_V2 = `## Requirement Evaluation Rules
+1. Return one outcome for every supplied requirement ID.
+2. Evaluate the factual fit of the supplied criteria. Requirement importance affects neither status nor confidence.
+3. Use these mutually exclusive status boundaries:
+   - **met**: Clear relevant evidence that the requirement is satisfied, with no material contradictory evidence.
+   - **partial**: Evidence is genuinely mixed, or a failure is bounded and conditional in a way this guest can avoid through a specific, verifiable choice that the supplied evidence says is available for this stay. A generic hope of getting a better room is not enough.
+   - **unmet**: Credible actual evidence shows the requirement fails. Use unmet for a recurring pattern affecting a meaningful share of guests, a severe confirmed failure directly matching the requirement, or a failure whose only mitigation defeats the requirement or is incompatible with the supplied stay context. A majority of reviews is not required.
+   - **unknown**: There is no relevant evidence, the relevant layer is missing, or the evidence is too vague to distinguish met from failure.
+4. Turning off a needed system, tolerating the problem, or asking staff without evidence of an available problem-free option is not guest-controlled avoidance.
+5. Apply stay context only to the relevance of evidence and mitigations. Use the supplied dates, destination, stay length, and guest count; do not invent live weather, inventory, room assignments, or provider policies.
+6. Be conservative about absence of evidence: prefer unknown over unmet when no failure is shown. Do not dilute credible recurring or severe failure evidence to partial merely because some positive evidence also exists.
+7. Confidence describes evidence strength, not how important the requirement is.
+8. Include the strongest supporting and contradicting evidence. Use exact, concise evidence text from the supplied artifacts when possible.
+9. Frequency and years are evidence metadata only; omit them when unavailable.
+
+## Boundary examples from the frozen NYC analyses
+- Candlewood Suites, Quiet Environment, 13 nights spanning July/August: 42 of 250 reviews report an excessively loud HVAC that prevents sleep, and guests avoid it only by turning it off. High-floor street-noise relief does not fix the HVAC failure. Classify **unmet/high**.
+- Club Quarters, Blackout Conditions: rooms have Roman shades that may leak at the edges, while many courtyard rooms are naturally dark. The same setup provides real darkness with a bounded caveat rather than a recurring confirmed sleep failure. Classify **partial/medium**.
+- The Michelangelo, Bed Comfort: the platform comfort sub-rating is 8.9, while 8 of 205 recent reviews report sagging or broken-coil mattresses. Strong positive aggregate evidence and a material but minority room-dependent failure are genuinely mixed. Classify **partial/high**.`;
+
+export const TRIAGE_CLASSIFIER_PROMPT_V2 =
+  TRIAGE_CLASSIFIER_PROMPT_V1.replace(
+    TRIAGE_REQUIREMENT_RULES_V1,
+    TRIAGE_REQUIREMENT_RULES_V2,
+  );
+
+export function getTriageClassifierPrompt(
+  version: TriageClassifierVersion,
+): string {
+  if (version === LEGACY_TRIAGE_CLASSIFIER_VERSION) {
+    return TRIAGE_CLASSIFIER_PROMPT_V1;
+  }
+  if (version === TRIAGE_CLASSIFIER_VERSION) {
+    return TRIAGE_CLASSIFIER_PROMPT_V2;
+  }
+  throw new Error(`Unsupported triage classifier version: ${String(version)}`);
+}
 
 // --- JSON response schema for Gemini structured output ---
 
@@ -309,6 +366,66 @@ function trimListingData(listing: any): any {
   }
 
   return trimmed;
+}
+
+export interface NormalizedTriageStayContext {
+  checkIn: string | null;
+  checkOut: string | null;
+  nights: number | null;
+  adults: number | null;
+  destination: string | null;
+}
+
+function optionalText(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function listingDestination(listing: any): string | null {
+  const address = listing?.address;
+  if (typeof address === 'string') return optionalText(address);
+  if (!address || typeof address !== 'object' || Array.isArray(address)) {
+    return null;
+  }
+  return (
+    optionalText(address.full)
+    ?? optionalText(address.city)
+    ?? optionalText(address.region)
+    ?? optionalText(address.country)
+  );
+}
+
+export function normalizeTriageStayContext(
+  input: TriageStayContext | undefined,
+  listing: any,
+): NormalizedTriageStayContext {
+  const checkIn = optionalText(input?.checkIn);
+  const checkOut = optionalText(input?.checkOut);
+  const checkInMs = checkIn ? Date.parse(`${checkIn}T00:00:00Z`) : Number.NaN;
+  const checkOutMs = checkOut ? Date.parse(`${checkOut}T00:00:00Z`) : Number.NaN;
+  const nights =
+    Number.isFinite(checkInMs)
+    && Number.isFinite(checkOutMs)
+    && checkOutMs > checkInMs
+      ? Math.round((checkOutMs - checkInMs) / (24 * 60 * 60 * 1000))
+      : null;
+  const adults =
+    typeof input?.adults === 'number'
+    && Number.isFinite(input.adults)
+    && input.adults > 0
+      ? Math.floor(input.adults)
+      : null;
+
+  return {
+    checkIn,
+    checkOut,
+    nights,
+    adults,
+    destination:
+      optionalText(input?.destination)
+      ?? listingDestination(listing),
+  };
 }
 
 // --- Gemini text call ---
@@ -705,6 +822,9 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
   const { listingFile, aiReviewsFile, aiPhotosFile, priorities } = options;
   const modelStr = options.model || process.env.LLM_MODEL || 'gemini-3-flash-preview:high';
   const temperature = options.temperature ?? 0;
+  const classifierVersion =
+    options.classifierVersion ?? TRIAGE_CLASSIFIER_VERSION;
+  const classifierPrompt = getTriageClassifierPrompt(classifierVersion);
   if (!Number.isFinite(temperature) || temperature < 0 || temperature > 2) {
     throw new Error('Triage temperature must be between 0 and 2.');
   }
@@ -714,6 +834,11 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
   if (modelConfig.provider !== 'gemini') {
     throw new Error(`Triage currently only supports Gemini models (got: ${modelConfig.provider}/${modelConfig.model}).`);
   }
+  const modelId = [
+    modelConfig.provider,
+    modelConfig.model,
+    modelConfig.thinkingLevel || 'default',
+  ].join(':');
 
   const apiKey = getProviderApiKey(modelConfig.provider);
   if (!apiKey) {
@@ -728,6 +853,10 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
   }
   const listingData = JSON.parse(fs.readFileSync(listingPath, 'utf-8'));
   const trimmedListing = trimListingData(listingData);
+  const stayContext = normalizeTriageStayContext(
+    options.stayContext,
+    listingData,
+  );
   const evidenceGaps: TriageEvidenceGap[] = [];
 
   // 3. Read AI reviews (optional)
@@ -792,6 +921,10 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
   );
   sections.push('');
 
+  sections.push('## Stay Context');
+  sections.push(JSON.stringify(stayContext, null, 2));
+  sections.push('');
+
   sections.push('## Listing Details');
   sections.push(JSON.stringify(trimmedListing, null, 2));
   sections.push('');
@@ -813,13 +946,14 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
   console.error(`Triage: ${listingData.title || listingData.id || listingFile}`);
   console.error(`Model: ${modelConfig.model}${modelConfig.thinkingLevel ? `:${modelConfig.thinkingLevel}` : ''}`);
   console.error(`Requirement set: ${requirementSet.id}`);
+  console.error(`Classifier policy: ${classifierVersion}`);
   console.error(`Classification temperature: ${temperature}`);
 
   const result = await callGeminiTriage(
     ai,
     modelConfig.model,
     modelConfig.thinkingLevel,
-    TRIAGE_SYSTEM_PROMPT,
+    classifierPrompt,
     userMessage,
     TRIAGE_JSON_SCHEMA,
     'triage',
@@ -865,8 +999,11 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
   const triageData = {
     ...parsed,
     ...score,
+    classifierVersion,
+    modelId,
     tierReason: deterministicTierReason(score),
     requirementSet,
+    stayContext,
     affordability,
     evidenceGaps: normalizedEvidenceGaps,
   };
@@ -894,6 +1031,8 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
     data: triageData,
     model: modelConfig.model,
     provider: modelConfig.provider,
+    classifierVersion,
+    modelId,
     requirementSet,
     evidenceGaps: normalizedEvidenceGaps,
     tokensUsed: usage.inputTokens,
@@ -906,7 +1045,7 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
 async function main() {
   const args = process.argv.slice(2);
   if (args.length === 0) {
-    console.error('Usage: triage <listing-file> [--ai-reviews <file>] [--ai-photos <file>] [--model <model>] [--priorities <text>] [--temperature <n>] [--budget <amount>] [--budget-currency <code>]');
+    console.error('Usage: triage <listing-file> [--ai-reviews <file>] [--ai-photos <file>] [--model <model>] [--priorities <text>] [--temperature <n>] [--budget <amount>] [--budget-currency <code>] [--checkin <date>] [--checkout <date>] [--adults <n>] [--destination <text>]');
     process.exit(1);
   }
 
@@ -921,6 +1060,10 @@ async function main() {
   let temperature = 0;
   let budgetAmount: number | undefined;
   let budgetCurrency = 'USD';
+  let checkIn: string | undefined;
+  let checkOut: string | undefined;
+  let adults: number | undefined;
+  let destination: string | undefined;
 
   for (let i = 1; i < args.length; i++) {
     if (args[i] === '--ai-reviews' && args[i + 1]) { aiReviewsFile = args[++i]; }
@@ -930,6 +1073,10 @@ async function main() {
     else if (args[i] === '--temperature' && args[i + 1]) { temperature = Number(args[++i]); }
     else if (args[i] === '--budget' && args[i + 1]) { budgetAmount = Number(args[++i]); }
     else if (args[i] === '--budget-currency' && args[i + 1]) { budgetCurrency = args[++i].toUpperCase(); }
+    else if (args[i] === '--checkin' && args[i + 1]) { checkIn = args[++i]; }
+    else if (args[i] === '--checkout' && args[i + 1]) { checkOut = args[++i]; }
+    else if (args[i] === '--adults' && args[i + 1]) { adults = Number(args[++i]); }
+    else if (args[i] === '--destination' && args[i + 1]) { destination = args[++i]; }
   }
 
   const budget =
@@ -949,6 +1096,12 @@ async function main() {
     priorities,
     temperature,
     budget,
+    stayContext: {
+      checkIn,
+      checkOut,
+      adults,
+      destination,
+    },
   });
   console.log(JSON.stringify(result.data, null, 2));
 }

--- a/tests/batch-output-paths.test.ts
+++ b/tests/batch-output-paths.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import test from 'node:test';
 import { resolveBatchOutputDir, runBatch } from '../src/batch.js';
 import { buildCanonicalRequirementSet } from '../src/triage-rubric.js';
+import { TRIAGE_CLASSIFIER_VERSION } from '../src/triage-comparability.js';
 
 const repositoryRoot = process.cwd();
 const bookingUrl =
@@ -162,6 +163,8 @@ test('batch freezes one canonical requirement set and reloads it on rerun', asyn
             data: { tier: 'shortlist', fitScore: 75 },
             model: 'fixture-model',
             provider: 'gemini',
+            classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+            modelId: 'gemini:fixture-model:default',
             requirementSet: options.requirementSet ?? reusableSet,
             evidenceGaps: [],
           };
@@ -211,6 +214,8 @@ test('batch freezes one canonical requirement set and reloads it on rerun', asyn
             data: { tier: 'shortlist', fitScore: 75 },
             model: 'fixture-model',
             provider: 'gemini',
+            classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+            modelId: 'gemini:fixture-model:default',
             requirementSet: options.requirementSet,
             evidenceGaps: [],
           };
@@ -357,6 +362,8 @@ test('default-dir resumed Booking artifacts remain eligible for every AI phase',
             data: { tier: 'shortlist', fitScore: 75 },
             model: 'fixture-model',
             provider: 'gemini',
+            classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+            modelId: 'gemini:fixture-model:default',
             requirementSet:
               options.requirementSet ?? fixtureRequirementSet,
             evidenceGaps: [],
@@ -525,6 +532,8 @@ test('triage records missing review evidence in its artifact and manifest', asyn
             data: { tier: 'consider', fitScore: 55 },
             model: 'fixture-model',
             provider: 'gemini',
+            classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+            modelId: 'gemini:fixture-model:default',
             requirementSet:
               options.requirementSet ?? fixtureRequirementSet,
             evidenceGaps: [],
@@ -644,6 +653,8 @@ test('triage records missing photo evidence in its artifact and manifest', async
             data: { tier: 'consider', fitScore: 55 },
             model: 'fixture-model',
             provider: 'gemini',
+            classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+            modelId: 'gemini:fixture-model:default',
             requirementSet:
               options.requirementSet ?? fixtureRequirementSet,
             evidenceGaps: [],

--- a/tests/evals/run-triage-boundary-eval.ts
+++ b/tests/evals/run-triage-boundary-eval.ts
@@ -1,0 +1,240 @@
+import 'dotenv/config';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+  LEGACY_TRIAGE_CLASSIFIER_VERSION,
+  TRIAGE_CLASSIFIER_VERSION,
+  type TriageClassifierVersion,
+} from '../../src/triage-comparability.js';
+import type {
+  CanonicalRequirementSet,
+  RequirementStatus,
+} from '../../src/triage-rubric.js';
+import { runTriage } from '../../src/triage.js';
+
+interface EvalLabel {
+  requirementId: string;
+  expectedStatus: RequirementStatus;
+  boundaryCase: boolean;
+  rationale: string;
+  evidence: string[];
+}
+
+interface EvalListing {
+  slug: string;
+  label: string;
+  inputSha256: Record<'listing' | 'reviews' | 'photos', string>;
+  labels: EvalLabel[];
+}
+
+interface EvalFixture {
+  issue: number;
+  sourceIssue: number;
+  stayContext: {
+    checkIn: string;
+    checkOut: string;
+    adults: number;
+    destination: string;
+  };
+  requirementSet: {
+    id: string;
+    sha256: string;
+  };
+  listings: EvalListing[];
+}
+
+const argv = process.argv.slice(2);
+
+function argument(name: string): string | null {
+  const index = argv.indexOf(name);
+  return index >= 0 && argv[index + 1] ? argv[index + 1] : null;
+}
+
+function sha256(file: string): string {
+  return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function writeResult(file: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(value, null, 2));
+}
+
+async function main(): Promise<void> {
+const fixtureFile = path.resolve(
+  argument('--fixture')
+  ?? 'tests/fixtures/triage-boundary-eval.json',
+);
+const inputRoot = path.resolve(
+  argument('--input-root')
+  ?? process.env.TRIAGE_EVAL_INPUT_ROOT
+  ?? 'data/experiments/issue-69/inputs',
+);
+const requirementSetFile = path.resolve(
+  argument('--requirement-set')
+  ?? path.join(path.dirname(inputRoot), 'rubric-requirements.json'),
+);
+const outputFile = path.resolve(
+  argument('--output')
+  ?? 'data/experiments/issue-69/boundary-eval-results.json',
+);
+const model =
+  argument('--model')
+  ?? process.env.LLM_MODEL
+  ?? 'gemini-3-flash-preview:high';
+
+const fixture = JSON.parse(
+  fs.readFileSync(fixtureFile, 'utf8'),
+) as EvalFixture;
+const requirementSet = JSON.parse(
+  fs.readFileSync(requirementSetFile, 'utf8'),
+) as CanonicalRequirementSet;
+
+if (requirementSet.id !== fixture.requirementSet.id) {
+  throw new Error(
+    `Requirement set mismatch: ${requirementSet.id} != ${fixture.requirementSet.id}`,
+  );
+}
+if (sha256(requirementSetFile) !== fixture.requirementSet.sha256) {
+  throw new Error('Requirement set hash does not match the labeled fixture.');
+}
+
+const filesByListing = new Map<string, {
+  listingFile: string;
+  aiReviewsFile: string;
+  aiPhotosFile: string;
+}>();
+for (const listing of fixture.listings) {
+  const files = {
+    listingFile: path.join(inputRoot, `${listing.slug}.listing.json`),
+    aiReviewsFile: path.join(inputRoot, `${listing.slug}.reviews.json`),
+    aiPhotosFile: path.join(inputRoot, `${listing.slug}.photos.json`),
+  };
+  for (const [kind, file] of Object.entries(files)) {
+    if (!fs.existsSync(file)) {
+      throw new Error(`Missing ${kind} fixture: ${file}`);
+    }
+  }
+  const actualHashes = {
+    listing: sha256(files.listingFile),
+    reviews: sha256(files.aiReviewsFile),
+    photos: sha256(files.aiPhotosFile),
+  };
+  for (const kind of ['listing', 'reviews', 'photos'] as const) {
+    if (actualHashes[kind] !== listing.inputSha256[kind]) {
+      throw new Error(`${listing.slug} ${kind} hash mismatch.`);
+    }
+  }
+  filesByListing.set(listing.slug, files);
+}
+
+const versions: TriageClassifierVersion[] = [
+  LEGACY_TRIAGE_CLASSIFIER_VERSION,
+  TRIAGE_CLASSIFIER_VERSION,
+];
+const startedAt = new Date().toISOString();
+const runs: Array<Record<string, unknown>> = [];
+
+for (const classifierVersion of versions) {
+  for (const listing of fixture.listings) {
+    const files = filesByListing.get(listing.slug);
+    if (!files) throw new Error(`Missing file map for ${listing.slug}.`);
+    const result = await runTriage({
+      ...files,
+      model,
+      requirementSet,
+      temperature: 0,
+      stayContext: fixture.stayContext,
+      classifierVersion,
+    });
+    const assessments = result.data.requirements as Array<{
+      requirementId: string;
+      status: RequirementStatus;
+      confidence: string;
+      note: string;
+    }>;
+    const actualById = new Map(
+      assessments.map(
+        (assessment) => [assessment.requirementId, assessment] as const,
+      ),
+    );
+    const outcomes = listing.labels.map((label) => {
+      const actual = actualById.get(label.requirementId);
+      return {
+        requirementId: label.requirementId,
+        expectedStatus: label.expectedStatus,
+        boundaryCase: label.boundaryCase,
+        actualStatus: actual?.status ?? null,
+        confidence: actual?.confidence ?? null,
+        note: actual?.note ?? null,
+        correct: actual?.status === label.expectedStatus,
+      };
+    });
+    runs.push({
+      classifierVersion,
+      slug: listing.slug,
+      label: listing.label,
+      fitScore: result.data.fitScore,
+      tier: result.data.tier,
+      outcomes,
+      usage: result.usage ?? null,
+    });
+    writeResult(outputFile, {
+      issue: fixture.issue,
+      startedAt,
+      completed: false,
+      model,
+      runs,
+    });
+  }
+}
+
+const summary = Object.fromEntries(
+  versions.map((classifierVersion) => {
+    const outcomes = runs
+      .filter((run) => run.classifierVersion === classifierVersion)
+      .flatMap((run) => run.outcomes as Array<{
+        boundaryCase: boolean;
+        correct: boolean;
+      }>);
+    const boundary = outcomes.filter((outcome) => outcome.boundaryCase);
+    const correct = outcomes.filter((outcome) => outcome.correct).length;
+    const boundaryCorrect =
+      boundary.filter((outcome) => outcome.correct).length;
+    return [
+      classifierVersion,
+      {
+        correct,
+        total: outcomes.length,
+        accuracy: outcomes.length > 0 ? correct / outcomes.length : null,
+        boundaryCorrect,
+        boundaryTotal: boundary.length,
+        boundaryAccuracy:
+          boundary.length > 0 ? boundaryCorrect / boundary.length : null,
+      },
+    ];
+  }),
+);
+
+writeResult(outputFile, {
+  issue: fixture.issue,
+  sourceIssue: fixture.sourceIssue,
+  startedAt,
+  completedAt: new Date().toISOString(),
+  completed: true,
+  model,
+  fixtureFile,
+  inputRoot,
+  requirementSetFile,
+  summary,
+  runs,
+});
+
+console.log(JSON.stringify(summary, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/tests/evals/run-triage-stability.ts
+++ b/tests/evals/run-triage-stability.ts
@@ -1,0 +1,361 @@
+import 'dotenv/config';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { TRIAGE_CLASSIFIER_VERSION } from '../../src/triage-comparability.js';
+import type {
+  CanonicalRequirementSet,
+  RequirementConfidence,
+  RequirementStatus,
+} from '../../src/triage-rubric.js';
+import { runTriage } from '../../src/triage.js';
+
+const argv = process.argv.slice(2);
+
+function argument(name: string): string | null {
+  const index = argv.indexOf(name);
+  return index >= 0 && argv[index + 1] ? argv[index + 1] : null;
+}
+
+function sha256(file: string): string {
+  return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function writeJson(file: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(value, null, 2));
+}
+
+interface Outcome {
+  requirementId: string;
+  status: RequirementStatus;
+  confidence: RequirementConfidence;
+}
+
+interface StabilityRecord {
+  temperature: number;
+  run: number;
+  slug: string;
+  fitScore: number;
+  rawFitScore: number;
+  tier: string;
+  capReasons: string[];
+  coverage: number;
+  rankingStatus: string;
+  outcomes: Outcome[];
+  classificationSignature: string;
+  usage: unknown;
+  durationMs: number;
+}
+
+function pairs<T>(values: T[], differs: (left: T, right: T) => boolean): number {
+  let count = 0;
+  for (let left = 0; left < values.length; left++) {
+    for (let right = left + 1; right < values.length; right++) {
+      if (differs(values[left], values[right])) count++;
+    }
+  }
+  return count;
+}
+
+function summarize(
+  records: StabilityRecord[],
+  requirementSet: CanonicalRequirementSet,
+) {
+  const temperatures = [0, 1];
+  const listings = [...new Set(records.map((record) => record.slug))];
+  const scoreStats = Object.fromEntries(
+    temperatures.map((temperature) => [
+      String(temperature),
+      Object.fromEntries(
+        listings.map((slug) => {
+          const rows = records.filter(
+            (record) =>
+              record.temperature === temperature && record.slug === slug,
+          );
+          const scores = rows.map((row) => row.fitScore);
+          const mean =
+            scores.reduce((sum, score) => sum + score, 0) / scores.length;
+          const tiers = [...new Set(rows.map((row) => row.tier))];
+          return [
+            slug,
+            {
+              scores,
+              mean,
+              minimum: Math.min(...scores),
+              maximum: Math.max(...scores),
+              maxAbsoluteDeviation: Math.max(
+                ...scores.map((score) => Math.abs(score - mean)),
+              ),
+              tiers,
+              accepted:
+                rows.length === 5
+                && tiers.length === 1
+                && Math.max(
+                  ...scores.map((score) => Math.abs(score - mean)),
+                ) <= 5,
+            },
+          ];
+        }),
+      ),
+    ]),
+  );
+
+  const flipStats = Object.fromEntries(
+    temperatures.map((temperature) => {
+      let weightedPairs = 0;
+      let weightedStatusFlips = 0;
+      let weightedConfidenceFlips = 0;
+      let boundaryFlips = 0;
+      for (const slug of listings) {
+        const rows = records.filter(
+          (record) =>
+            record.temperature === temperature && record.slug === slug,
+        );
+        for (const requirement of requirementSet.definitions) {
+          const outcomes = rows
+            .map((row) =>
+              row.outcomes.find(
+                (outcome) => outcome.requirementId === requirement.id,
+              ))
+            .filter((outcome): outcome is Outcome => outcome != null);
+          const pairCount = (outcomes.length * (outcomes.length - 1)) / 2;
+          weightedPairs += pairCount * requirement.weight;
+          weightedStatusFlips += pairs(
+            outcomes,
+            (left, right) => left.status !== right.status,
+          ) * requirement.weight;
+          weightedConfidenceFlips += pairs(
+            outcomes,
+            (left, right) => left.confidence !== right.confidence,
+          ) * requirement.weight;
+          boundaryFlips += pairs(
+            outcomes,
+            (left, right) =>
+              left.confidence === 'high'
+              && right.confidence === 'high'
+              && (
+                (left.status === 'partial' && right.status === 'unmet')
+                || (left.status === 'unmet' && right.status === 'partial')
+              ),
+          );
+        }
+      }
+      return [
+        String(temperature),
+        {
+          weightedPairs,
+          weightedStatusFlips,
+          weightedStatusFlipRate:
+            weightedPairs > 0 ? weightedStatusFlips / weightedPairs : null,
+          weightedConfidenceFlips,
+          weightedConfidenceFlipRate:
+            weightedPairs > 0 ? weightedConfidenceFlips / weightedPairs : null,
+          partialUnmetHighFlips: boundaryFlips,
+        },
+      ];
+    }),
+  );
+
+  const verdictsByClassification = new Map<string, Set<string>>();
+  for (const record of records) {
+    const key = [
+      record.temperature,
+      record.slug,
+      record.classificationSignature,
+    ].join(':');
+    const verdict = JSON.stringify({
+      rawFitScore: record.rawFitScore,
+      fitScore: record.fitScore,
+      tier: record.tier,
+      capReasons: record.capReasons,
+      coverage: record.coverage,
+      rankingStatus: record.rankingStatus,
+    });
+    const verdicts = verdictsByClassification.get(key) ?? new Set<string>();
+    verdicts.add(verdict);
+    verdictsByClassification.set(key, verdicts);
+  }
+  const deterministicInvariantViolations = [
+    ...verdictsByClassification.entries(),
+  ]
+    .filter(([, verdicts]) => verdicts.size > 1)
+    .map(([key, verdicts]) => ({ key, verdicts: [...verdicts] }));
+
+  return {
+    completedCalls: records.length,
+    scoreStats,
+    flipStats,
+    deterministicInvariantViolations,
+    acceptedAtTemperatureZero:
+      records.filter((record) => record.temperature === 0).length === 15
+      && Object.values(
+        scoreStats['0'] as Record<string, { accepted: boolean }>,
+      ).every((stats) => stats.accepted)
+      && deterministicInvariantViolations.length === 0,
+  };
+}
+
+async function main(): Promise<void> {
+  const inputRoot = path.resolve(
+    argument('--input-root')
+    ?? process.env.TRIAGE_EVAL_INPUT_ROOT
+    ?? 'data/experiments/issue-69/inputs',
+  );
+  const requirementSetFile = path.resolve(
+    argument('--requirement-set')
+    ?? path.join(path.dirname(inputRoot), 'rubric-requirements.json'),
+  );
+  const outputFile = path.resolve(
+    argument('--output')
+    ?? 'data/experiments/issue-69/stability-results.json',
+  );
+  const model =
+    argument('--model')
+    ?? process.env.LLM_MODEL
+    ?? 'gemini-3-flash-preview:high';
+  const requirementSet = JSON.parse(
+    fs.readFileSync(requirementSetFile, 'utf8'),
+  ) as CanonicalRequirementSet;
+  const slugs = [
+    'club-quarters-midtown-nyc',
+    'candlewood-suites-new-york-city',
+    'the-michelangelo',
+  ];
+  const stayContext = {
+    checkIn: '2026-07-29',
+    checkOut: '2026-08-11',
+    adults: 2,
+    destination: 'New York City, USA',
+  };
+  const resumable =
+    argv.includes('--resume') && fs.existsSync(outputFile)
+      ? JSON.parse(fs.readFileSync(outputFile, 'utf8')) as {
+          startedAt?: string;
+          records?: StabilityRecord[];
+          attemptErrors?: Array<Record<string, unknown>>;
+        }
+      : null;
+  const records: StabilityRecord[] = resumable?.records ?? [];
+  const attemptErrors: Array<Record<string, unknown>> =
+    resumable?.attemptErrors ?? [];
+  const startedAt = resumable?.startedAt ?? new Date().toISOString();
+
+  for (const temperature of [0, 1]) {
+    for (let run = 1; run <= 5; run++) {
+      for (const slug of slugs) {
+        if (
+          records.some(
+            (record) =>
+              record.temperature === temperature
+              && record.run === run
+              && record.slug === slug,
+          )
+        ) {
+          continue;
+        }
+        const started = Date.now();
+        let result: Awaited<ReturnType<typeof runTriage>> | null = null;
+        for (let attempt = 1; attempt <= 3; attempt++) {
+          try {
+            result = await runTriage({
+              listingFile: path.join(inputRoot, `${slug}.listing.json`),
+              aiReviewsFile: path.join(inputRoot, `${slug}.reviews.json`),
+              aiPhotosFile: path.join(inputRoot, `${slug}.photos.json`),
+              model,
+              requirementSet,
+              classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+              temperature,
+              stayContext,
+            });
+            break;
+          } catch (error) {
+            attemptErrors.push({
+              temperature,
+              run,
+              slug,
+              attempt,
+              error: error instanceof Error ? error.message : String(error),
+              recordedAt: new Date().toISOString(),
+            });
+            writeJson(outputFile, {
+              issue: 69,
+              startedAt,
+              completed: false,
+              model,
+              classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+              attemptErrors,
+              records,
+            });
+            if (attempt === 3) throw error;
+          }
+        }
+        if (!result) {
+          throw new Error(`No result produced for ${temperature}/${run}/${slug}.`);
+        }
+        const outcomes = result.data.requirements.map(
+          (assessment: Outcome) => ({
+            requirementId: assessment.requirementId,
+            status: assessment.status,
+            confidence: assessment.confidence,
+          }),
+        );
+        records.push({
+          temperature,
+          run,
+          slug,
+          fitScore: result.data.fitScore,
+          rawFitScore: result.data.rawFitScore,
+          tier: result.data.tier,
+          capReasons: result.data.capReasons,
+          coverage: result.data.coverage,
+          rankingStatus: result.data.rankingStatus,
+          outcomes,
+          classificationSignature: JSON.stringify(outcomes),
+          usage: result.usage ?? null,
+          durationMs: Date.now() - started,
+        });
+        writeJson(outputFile, {
+          issue: 69,
+          startedAt,
+          completed: false,
+          model,
+          classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+          attemptErrors,
+          records,
+        });
+      }
+    }
+  }
+
+  const inputHashes = Object.fromEntries(
+    fs.readdirSync(inputRoot)
+      .filter((file) => file.endsWith('.json'))
+      .sort()
+      .map((file) => [file, sha256(path.join(inputRoot, file))]),
+  );
+  const summary = summarize(records, requirementSet);
+  writeJson(outputFile, {
+    issue: 69,
+    sourceMeasurementIssue: 62,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    completed: true,
+    model,
+    classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+    requirementSetId: requirementSet.id,
+    requirementSetSha256: sha256(requirementSetFile),
+    inputHashes,
+    stayContext,
+    summary,
+    attemptErrors,
+    records,
+  });
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/tests/fixtures/triage-boundary-eval.json
+++ b/tests/fixtures/triage-boundary-eval.json
@@ -1,0 +1,190 @@
+{
+  "issue": 69,
+  "sourceIssue": 62,
+  "description": "Hand-adjudicated requirement outcomes from the three frozen NYC analyses used for the issue 62 stability measurement.",
+  "stayContext": {
+    "checkIn": "2026-07-29",
+    "checkOut": "2026-08-11",
+    "adults": 2,
+    "destination": "New York City, USA"
+  },
+  "requirementSet": {
+    "id": "reqset_6b9344b3d4089e4bcad6",
+    "sha256": "cdd51f10fc77835a1496f55fbcc5d84375e1e474a144ebe2ee947bbb2c64cca5"
+  },
+  "listings": [
+    {
+      "slug": "candlewood-suites-new-york-city",
+      "label": "Candlewood Suites",
+      "inputSha256": {
+        "listing": "9a42c0a2fc34309e9b153163f37eacaa29cd651dc8ff748027e440f5814f21b1",
+        "reviews": "d59049edc43c1e2da8b786b868504ef6f2990c125d8e1eb533b8a6628cb1b0dd",
+        "photos": "0b4572f4718fab6897bad4ac44770d803a02e65b3d9a371cc575693417cab296"
+      },
+      "labels": [
+        {
+          "requirementId": "req-01-quiet-environment",
+          "expectedStatus": "unmet",
+          "boundaryCase": true,
+          "rationale": "Recurring HVAC noise prevents sleep for 42 of 250 reviewers. Turning climate control off is not a usable mitigation for this 13-night July/August stay.",
+          "evidence": [
+            "The heater/AC combo was VERY noisy and I couldn't sleep with the heater on.",
+            "AC unit makes a lot of noise when turning on, so we kept it off all stay."
+          ]
+        },
+        {
+          "requirementId": "req-02-bed-comfort",
+          "expectedStatus": "met",
+          "boundaryCase": false,
+          "rationale": "Beds receive strong, repeated praise without material contradictory evidence.",
+          "evidence": [
+            "Beds are widely praised as very comfortable and '1000/10'."
+          ]
+        },
+        {
+          "requirementId": "req-03-blackout-conditions",
+          "expectedStatus": "met",
+          "boundaryCase": false,
+          "rationale": "The photo analysis directly identifies blackout curtains.",
+          "evidence": [
+            "blackout curtains are present"
+          ]
+        },
+        {
+          "requirementId": "req-04-walkable-location",
+          "expectedStatus": "met",
+          "boundaryCase": false,
+          "rationale": "The listing and 210 of 250 review summary both establish walkability.",
+          "evidence": [
+            "Excellent location for visiting tourist attractions. Everything is walkable."
+          ]
+        },
+        {
+          "requirementId": "req-05-in-room-workspace",
+          "expectedStatus": "met",
+          "boundaryCase": false,
+          "rationale": "Details and photos show a large dedicated desk with an ergonomic chair.",
+          "evidence": [
+            "Excellent in-room workspace with ergonomic chairs."
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "club-quarters-midtown-nyc",
+      "label": "Club Quarters Midtown",
+      "inputSha256": {
+        "listing": "11b8291a020f52b4a1ad1f5cfcd9f341432d2c040e6407cd3cb7de3c2a68ab5e",
+        "reviews": "cb2cd46f41cc0f4e6cd509ee32e7c7f167bc7b328398b096a1cc1af99eecb3f3",
+        "photos": "dd084eec987e32c088c142a21af9e484a27c228c93c02fd65b6d0a8b90e1d9b9"
+      },
+      "labels": [
+        {
+          "requirementId": "req-01-quiet-environment",
+          "expectedStatus": "unmet",
+          "boundaryCase": true,
+          "rationale": "Persistent mechanical and street noise affects 68 of 250 reviews and can continue with the AC switched off.",
+          "evidence": [
+            "Constant noise from either some machinery or generator even if the AC was switched off.",
+            "It felt like trucks were passing right through the room."
+          ]
+        },
+        {
+          "requirementId": "req-02-bed-comfort",
+          "expectedStatus": "met",
+          "boundaryCase": false,
+          "rationale": "Renovated premium bedding is consistently praised.",
+          "evidence": [
+            "Mattresses are praised as 'the best'."
+          ]
+        },
+        {
+          "requirementId": "req-03-blackout-conditions",
+          "expectedStatus": "partial",
+          "boundaryCase": true,
+          "rationale": "Courtyard rooms are naturally dark, but Roman shades can leak at the edges. This is a bounded caveat rather than a recurring confirmed failure.",
+          "evidence": [
+            "Roman shades are used rather than full floor-to-ceiling blackout curtains, which may allow light leakage at the edges.",
+            "Windows were facing the building's inner courtyard... spent the entire stay without natural daylight."
+          ]
+        },
+        {
+          "requirementId": "req-04-walkable-location",
+          "expectedStatus": "met",
+          "boundaryCase": false,
+          "rationale": "The location is repeatedly described as walkable to Midtown attractions.",
+          "evidence": [
+            "Location is amazing. We almost walked everywhere."
+          ]
+        },
+        {
+          "requirementId": "req-05-in-room-workspace",
+          "expectedStatus": "met",
+          "boundaryCase": false,
+          "rationale": "Every shown room has a dedicated desk and ergonomic task chair.",
+          "evidence": [
+            "True ergonomic workspaces with leather rolling chairs in every room."
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "the-michelangelo",
+      "label": "The Michelangelo",
+      "inputSha256": {
+        "listing": "0d13115670d8e770368b5dd7fe3b513ebd483bbc4ad3750284a7a68c2254af25",
+        "reviews": "92e25997b04277044d8271d158c41c4cbc0a67db76f63e6eee9407c4bef1d16a",
+        "photos": "a362c9c1fbbfcbdd2de458590b008d3384803e7ac492a6575306ab0448d3573e"
+      },
+      "labels": [
+        {
+          "requirementId": "req-01-quiet-environment",
+          "expectedStatus": "unmet",
+          "boundaryCase": true,
+          "rationale": "Current reviews contain recurring tractor-like HVAC and mechanical noise that can continue while heating is off. Older quiet-room praise does not make that failure avoidable for this stay.",
+          "evidence": [
+            "When you turn it on, it sounds like a tractor.",
+            "Heating made exceptionally loud noise in the evening whilst even when it was off, it was still whistling."
+          ]
+        },
+        {
+          "requirementId": "req-02-bed-comfort",
+          "expectedStatus": "partial",
+          "boundaryCase": true,
+          "rationale": "The 8.9 comfort rating is positive, while 8 of 205 recent reviews identify sagging or broken-coil mattresses. The evidence is genuinely mixed rather than a dominant recurring failure.",
+          "evidence": [
+            "Mattresses had indentations (they were sagging and had dips), which caused me back pain.",
+            "Comfort sub-rating: 8.9."
+          ]
+        },
+        {
+          "requirementId": "req-03-blackout-conditions",
+          "expectedStatus": "met",
+          "boundaryCase": false,
+          "rationale": "Heavy floor-to-ceiling blackout drapes and naturally dark interior rooms directly support the requirement.",
+          "evidence": [
+            "High-quality blackout curtains for sleep quality."
+          ]
+        },
+        {
+          "requirementId": "req-04-walkable-location",
+          "expectedStatus": "met",
+          "boundaryCase": false,
+          "rationale": "The 9.5 location sub-rating and repeated five-minute-walk evidence are clear.",
+          "evidence": [
+            "5-minute walk to Hamilton and Wicked's theaters."
+          ]
+        },
+        {
+          "requirementId": "req-05-in-room-workspace",
+          "expectedStatus": "met",
+          "boundaryCase": false,
+          "rationale": "Details and every bedroom photo show a dedicated desk with seating.",
+          "evidence": [
+            "Every bedroom photo includes a dedicated desk with lighting and an upholstered chair."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/report-poi.test.ts
+++ b/tests/report-poi.test.ts
@@ -5,6 +5,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { generateReport } from '../src/report.js';
+import { TRIAGE_CLASSIFIER_VERSION } from '../src/triage-comparability.js';
 
 test('generateReport surfaces POI distance in the report output', async () => {
   const rootDir = fs.mkdtempSync(
@@ -122,6 +123,7 @@ test('generateReport ranks only the active deterministic set', async () => {
         scoreSource: 'deterministic_rubric',
         rubricVersion: '1',
         requirementSetId: 'reqset_active',
+        classifierVersion: TRIAGE_CLASSIFIER_VERSION,
         rawFitScore: 60,
         fitScore: 60,
         tier: 'consider',
@@ -136,6 +138,7 @@ test('generateReport ranks only the active deterministic set', async () => {
         scoreSource: 'deterministic_rubric',
         rubricVersion: '1',
         requirementSetId: 'reqset_active',
+        classifierVersion: TRIAGE_CLASSIFIER_VERSION,
         rawFitScore: 90,
         fitScore: 90,
         tier: 'top_pick',
@@ -236,7 +239,7 @@ test('generateReport ranks only the active deterministic set', async () => {
     assert.doesNotMatch(heroHtml, /Legacy high score/);
     assert.match(
       html,
-      /1 insufficient-evidence and 1 legacy\/stale verdicts/,
+      /1 insufficient-evidence, 0 older-policy, and 1 legacy\/stale-set verdicts/,
     );
     assert.match(
       html,

--- a/tests/results-rubric.test.ts
+++ b/tests/results-rubric.test.ts
@@ -2,11 +2,17 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  getActiveTriageComparison,
   getActiveRequirementSetId,
   getListingResultsSnapshot,
   getTriageComparisonStatus,
+  getTriageRegradeListingCount,
 } from '../web/src/lib/results.js';
 import type { ReviewJobListing } from '../web/src/types.js';
+import {
+  getCurrentTriageComparability,
+  TRIAGE_CLASSIFIER_VERSION,
+} from '../src/triage-comparability.js';
 
 function listing(
   id: string,
@@ -67,6 +73,8 @@ test('deterministic metadata and affordability reason survive parsing', () => {
       scoreSource: 'deterministic_rubric',
       rubricVersion: '1',
       requirementSetId: 'reqset_a',
+      classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+      modelId: 'gemini:gemini-3-flash-preview:high',
       rawFitScore: 70,
       fitScore: 44,
       tier: 'unlikely',
@@ -116,6 +124,14 @@ test('deterministic metadata and affordability reason survive parsing', () => {
   );
 
   assert.equal(snapshot.triage?.scoreSource, 'deterministic_rubric');
+  assert.equal(
+    snapshot.triage?.classifierVersion,
+    TRIAGE_CLASSIFIER_VERSION,
+  );
+  assert.equal(
+    snapshot.triage?.modelId,
+    'gemini:gemini-3-flash-preview:high',
+  );
   assert.equal(snapshot.triage?.rawFitScore, 70);
   assert.equal(snapshot.triage?.fitScore, 44);
   assert.deepEqual(snapshot.triage?.capReasons, [
@@ -143,6 +159,7 @@ test('coverage below one half is treated as insufficient even for older rubric J
       scoreSource: 'deterministic_rubric',
       rubricVersion: '1',
       requirementSetId: 'reqset_a',
+      classifierVersion: TRIAGE_CLASSIFIER_VERSION,
       fitScore: 50,
       tier: 'consider',
       coverage: 0.49,
@@ -156,6 +173,7 @@ test('active requirement set is the modal set with stable first-seen ties', () =
     scoreSource: 'deterministic_rubric',
     rubricVersion: '1',
     requirementSetId: 'reqset_a',
+    classifierVersion: TRIAGE_CLASSIFIER_VERSION,
     fitScore: 80,
     tier: 'top_pick',
     rankingStatus: 'ranked',
@@ -168,6 +186,10 @@ test('active requirement set is the modal set with stable first-seen ties', () =
     listing('legacy', { fitScore: 99, tier: 'top_pick' }),
   ];
   assert.equal(getActiveRequirementSetId(listings), 'reqset_b');
+  assert.equal(
+    getActiveTriageComparison(listings)?.requirementSetId,
+    'reqset_b',
+  );
 });
 
 test('comparison status separates ranked, insufficient, legacy, and stale sets', () => {
@@ -176,6 +198,7 @@ test('comparison status separates ranked, insufficient, legacy, and stale sets',
       scoreSource: 'deterministic_rubric',
       rubricVersion: '1',
       requirementSetId: 'reqset_active',
+      classifierVersion: TRIAGE_CLASSIFIER_VERSION,
       fitScore: 90,
       tier: 'top_pick',
       rankingStatus: 'ranked',
@@ -186,6 +209,7 @@ test('comparison status separates ranked, insufficient, legacy, and stale sets',
       scoreSource: 'deterministic_rubric',
       rubricVersion: '1',
       requirementSetId: 'reqset_active',
+      classifierVersion: TRIAGE_CLASSIFIER_VERSION,
       fitScore: 50,
       tier: 'consider',
       rankingStatus: 'insufficient_evidence',
@@ -196,6 +220,7 @@ test('comparison status separates ranked, insufficient, legacy, and stale sets',
       scoreSource: 'deterministic_rubric',
       rubricVersion: '1',
       requirementSetId: 'reqset_old',
+      classifierVersion: TRIAGE_CLASSIFIER_VERSION,
       fitScore: 100,
       tier: 'top_pick',
       rankingStatus: 'ranked',
@@ -205,21 +230,101 @@ test('comparison status separates ranked, insufficient, legacy, and stale sets',
     listing('legacy', { fitScore: 100, tier: 'top_pick' }),
   ).triage;
 
+  const activeComparison =
+    getCurrentTriageComparability('reqset_active');
+  assert.equal(getTriageComparisonStatus(ranked, activeComparison), 'ranked');
   assert.equal(
-    getTriageComparisonStatus(ranked, 'reqset_active'),
-    'ranked',
-  );
-  assert.equal(
-    getTriageComparisonStatus(thin, 'reqset_active'),
+    getTriageComparisonStatus(thin, activeComparison),
     'insufficient_evidence',
   );
   assert.equal(
-    getTriageComparisonStatus(stale, 'reqset_active'),
+    getTriageComparisonStatus(stale, activeComparison),
     'stale_requirement_set',
   );
   assert.equal(
-    getTriageComparisonStatus(legacy, 'reqset_active'),
+    getTriageComparisonStatus(legacy, activeComparison),
     'legacy',
   );
-  assert.equal(getTriageComparisonStatus(null, 'reqset_active'), 'unscored');
+  assert.equal(getTriageComparisonStatus(null, activeComparison), 'unscored');
+});
+
+test('older classifier policy is preserved but excluded from comparison', () => {
+  const oldPolicy = getListingResultsSnapshot(
+    listing('old-policy', {
+      scoreSource: 'deterministic_rubric',
+      rubricVersion: '1',
+      requirementSetId: 'reqset_active',
+      fitScore: 79,
+      tier: 'shortlist',
+      rankingStatus: 'ranked',
+      modelId: 'gemini:gemini-3-flash-preview:high',
+    }),
+  ).triage;
+
+  assert.equal(oldPolicy?.scoreSource, 'deterministic_rubric');
+  assert.equal(oldPolicy?.classifierVersion, null);
+  assert.equal(oldPolicy?.comparabilityKey, null);
+  assert.equal(
+    getTriageComparisonStatus(
+      oldPolicy,
+      getCurrentTriageComparability('reqset_active'),
+    ),
+    'stale_classifier_policy',
+  );
+});
+
+test('model identity is audit metadata and does not gate comparison', () => {
+  const first = getListingResultsSnapshot(
+    listing('model-a', {
+      scoreSource: 'deterministic_rubric',
+      rubricVersion: '1',
+      requirementSetId: 'reqset_active',
+      classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+      modelId: 'gemini:model-a:high',
+      fitScore: 80,
+      tier: 'shortlist',
+    }),
+  ).triage;
+  const second = getListingResultsSnapshot(
+    listing('model-b', {
+      scoreSource: 'deterministic_rubric',
+      rubricVersion: '1',
+      requirementSetId: 'reqset_active',
+      classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+      modelId: 'gemini:model-b:high',
+      fitScore: 81,
+      tier: 'shortlist',
+    }),
+  ).triage;
+
+  assert.equal(first?.comparabilityKey, second?.comparabilityKey);
+});
+
+test('whole-job regrade scope counts every non-hidden listing', () => {
+  const stale = listing('stale', {
+    scoreSource: 'deterministic_rubric',
+    rubricVersion: '1',
+    requirementSetId: 'reqset_active',
+    fitScore: 79,
+    tier: 'shortlist',
+    rankingStatus: 'ranked',
+  });
+  const current = listing('current', {
+    scoreSource: 'deterministic_rubric',
+    rubricVersion: '1',
+    requirementSetId: 'reqset_active',
+    classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+    fitScore: 44,
+    tier: 'unlikely',
+    rankingStatus: 'ranked',
+  });
+  const hidden = {
+    ...listing('hidden', null),
+    hidden: true,
+  };
+
+  assert.equal(
+    getTriageRegradeListingCount([stale, current, hidden]),
+    2,
+  );
 });

--- a/tests/review-job-analysis.test.ts
+++ b/tests/review-job-analysis.test.ts
@@ -284,6 +284,43 @@ test('prepareReviewJobRunWorkspace stages a fresh rerun with AI outputs invalida
       fs.existsSync(path.join(staged.rootDir, 'reviews', 'room_12345_reviews.json')),
       true,
     );
+
+    const regrade = prepareReviewJobRunWorkspace({
+      jobId,
+      runId: 'run_2',
+      previousArtifactRoot: sourceRoot,
+      listings: [
+        {
+          platform: 'airbnb',
+          url: 'https://www.airbnb.com/rooms/12345',
+        },
+      ],
+      dates: {
+        checkIn: '2026-03-20',
+        checkOut: '2026-03-29',
+        adults: 4,
+      },
+      mode: 'triage',
+    });
+    const regradeManifest = readJsonFile<AnalysisManifest>(
+      getManifestPathFromRoot(regrade.rootDir),
+    );
+    assert.ok(regradeManifest);
+    assert.equal(regradeManifest.listings.keep.aiReviews.status, 'fetched');
+    assert.equal(regradeManifest.listings.keep.aiPhotos.status, 'fetched');
+    assert.equal(regradeManifest.listings.keep.triage.status, 'not_requested');
+    assert.equal(
+      fs.existsSync(path.join(regrade.rootDir, 'ai-reviews', '12345.json')),
+      true,
+    );
+    assert.equal(
+      fs.existsSync(path.join(regrade.rootDir, 'ai-photos', '12345.json')),
+      true,
+    );
+    assert.equal(
+      fs.existsSync(path.join(regrade.rootDir, 'triage', '12345.json')),
+      false,
+    );
   } finally {
     if (previousArtifactDir == null) {
       delete process.env[REVIEW_JOB_ARTIFACT_DIR_ENV];

--- a/tests/triage-comparability.test.ts
+++ b/tests/triage-comparability.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  ESTIMATED_TRIAGE_COST_USD_PER_LISTING,
+  LEGACY_TRIAGE_CLASSIFIER_VERSION,
+  TRIAGE_CLASSIFIER_VERSION,
+  estimateTriageRegradeCostUsd,
+  getCurrentTriageComparability,
+  getTriageComparabilityKey,
+} from '../src/triage-comparability.js';
+import {
+  getTriageClassifierPrompt,
+  normalizeTriageStayContext,
+} from '../src/triage.js';
+
+test('comparability key requires policy metadata and deliberately ignores model id', () => {
+  const current = getCurrentTriageComparability('reqset_a');
+  assert.equal(
+    current.key,
+    getTriageComparabilityKey({
+      rubricVersion: '1',
+      requirementSetId: 'reqset_a',
+      classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+    }),
+  );
+  assert.equal(
+    getTriageComparabilityKey({
+      rubricVersion: '1',
+      requirementSetId: 'reqset_a',
+    }),
+    null,
+  );
+  const withAuditModel = {
+    rubricVersion: '1',
+    requirementSetId: 'reqset_a',
+    classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+    modelId: 'ignored by the comparability helper',
+  };
+  assert.equal(getTriageComparabilityKey(withAuditModel), current.key);
+});
+
+test('regrade estimate uses the measured per-listing classifier cost', () => {
+  assert.equal(ESTIMATED_TRIAGE_COST_USD_PER_LISTING, 0.006);
+  assert.equal(estimateTriageRegradeCostUsd(54), 0.324);
+  assert.equal(estimateTriageRegradeCostUsd(0), 0);
+});
+
+test('classifier v2 defines the high-leverage boundary without changing v1', () => {
+  const legacy = getTriageClassifierPrompt(
+    LEGACY_TRIAGE_CLASSIFIER_VERSION,
+  );
+  const current = getTriageClassifierPrompt(TRIAGE_CLASSIFIER_VERSION);
+
+  assert.match(legacy, /partial.*Partially satisfied or with caveats/s);
+  assert.doesNotMatch(legacy, /Candlewood Suites/);
+  assert.match(current, /specific, verifiable choice/);
+  assert.match(current, /Candlewood Suites/);
+  assert.match(current, /Club Quarters/);
+  assert.match(current, /Turning off a needed system/);
+});
+
+test('stay context carries exact job dates, length, guests, and destination', () => {
+  assert.deepEqual(
+    normalizeTriageStayContext(
+      {
+        checkIn: '2026-07-29',
+        checkOut: '2026-08-11',
+        adults: 2,
+      },
+      {
+        address: {
+          full: 'Midtown Manhattan, New York, USA',
+        },
+      },
+    ),
+    {
+      checkIn: '2026-07-29',
+      checkOut: '2026-08-11',
+      nights: 13,
+      adults: 2,
+      destination: 'Midtown Manhattan, New York, USA',
+    },
+  );
+});

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -5,17 +5,16 @@ const nextConfig: NextConfig = {
   serverExternalPackages: ['playwright', 'playwright-core'],
   outputFileTracingRoot: path.resolve(__dirname, '..'),
   webpack: (config, { isServer }) => {
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '@cli': path.resolve(__dirname, '../src'),
+    };
     if (isServer) {
       // The CLI code uses .js extensions in imports (Node.js ESM convention)
       // but sources are .ts files. Tell webpack to also try .ts when resolving .js
-      config.resolve = config.resolve || {};
       config.resolve.extensionAlias = {
         '.js': ['.ts', '.js'],
-      };
-      // Allow importing from parent src/ directory
-      config.resolve.alias = {
-        ...config.resolve.alias,
-        '@cli': path.resolve(__dirname, '../src'),
       };
       // Externalize Playwright to avoid webpack bundling issues
       config.externals = config.externals || [];

--- a/web/src/app/api/jobs/[jobId]/analyze/route.ts
+++ b/web/src/app/api/jobs/[jobId]/analyze/route.ts
@@ -9,9 +9,11 @@ interface Params {
   params: Promise<{ jobId: string }>;
 }
 
-export async function POST(_request: Request, { params }: Params) {
+export async function POST(request: Request, { params }: Params) {
   const { jobId } = await params;
   const ownerKey = await getReviewJobOwnerKey();
+  const body = await request.json().catch(() => ({}));
+  const mode = body?.mode === 'triage' ? 'triage' : 'full';
 
   if (!ownerKey) {
     return NextResponse.json({ error: 'Review job not found' }, { status: 404 });
@@ -55,7 +57,14 @@ export async function POST(_request: Request, { params }: Params) {
     );
   }
 
-  const queueJob = await enqueueReviewJobAnalysis(jobId);
+  if (mode === 'triage' && !job.artifactRoot) {
+    return NextResponse.json(
+      { error: 'Saved analysis artifacts are required for a triage-only regrade' },
+      { status: 409 },
+    );
+  }
+
+  const queueJob = await enqueueReviewJobAnalysis(jobId, mode);
 
   await prisma.reviewJob.update({
     where: { id: jobId },
@@ -72,5 +81,6 @@ export async function POST(_request: Request, { params }: Params) {
     jobId,
     status: 'queued',
     analysisStatus: 'pending',
+    mode,
   });
 }

--- a/web/src/components/ResultsWorkspace.tsx
+++ b/web/src/components/ResultsWorkspace.tsx
@@ -17,14 +17,19 @@ import { getPriceDisplayInfo, resolveComparablePrice } from '@/lib/pricing';
 import { buildListingUrl } from '@/lib/listingLinks';
 import {
   formatPoiDistance,
-  getActiveRequirementSetId,
+  getActiveTriageComparison,
   getListingResultsSnapshot,
   getTriageComparisonStatus,
+  getTriageRegradeListingCount,
   getTierRank,
   type ParsedTriage,
   type ParsedTheme,
   type TriageComparisonStatus,
 } from '@/lib/results';
+import {
+  estimateTriageRegradeCostUsd,
+  getCurrentTriageComparability,
+} from '@cli/triage-comparability';
 import {
   fetchReviewJobResponse,
   getStoredReviewJobPriceDisplay,
@@ -87,11 +92,13 @@ function comparisonRank(status: TriageComparisonStatus): number {
       return 0;
     case 'insufficient_evidence':
       return 1;
+    case 'stale_classifier_policy':
+      return 2;
     case 'legacy':
     case 'stale_requirement_set':
-      return 2;
-    case 'unscored':
       return 3;
+    case 'unscored':
+      return 4;
   }
 }
 
@@ -111,7 +118,10 @@ function displayedTier(
   if (status === 'insufficient_evidence') {
     return { label: 'Insufficient evidence', tier: null };
   }
-  if (status === 'stale_requirement_set') {
+  if (
+    status === 'stale_requirement_set'
+    || status === 'stale_classifier_policy'
+  ) {
     return { label: 'Unranked', tier: null };
   }
   return { label: tierLabel(triage?.tier ?? null), tier: triage?.tier ?? null };
@@ -127,7 +137,12 @@ function VerdictSourceBadge({
   if (!triage) return null;
   const status =
     comparisonStatus
-    ?? getTriageComparisonStatus(triage, triage.requirementSetId);
+    ?? getTriageComparisonStatus(
+      triage,
+      triage.requirementSetId
+        ? getCurrentTriageComparability(triage.requirementSetId)
+        : null,
+    );
   if (status === 'legacy') {
     return (
       <span className="rounded-full border border-violet-300/20 bg-violet-300/10 px-2 py-1 text-[10px] font-semibold text-violet-100">
@@ -139,6 +154,13 @@ function VerdictSourceBadge({
     return (
       <span className="rounded-full border border-stone-300/20 bg-stone-300/10 px-2 py-1 text-[10px] font-semibold text-stone-200">
         Stale requirement set
+      </span>
+    );
+  }
+  if (status === 'stale_classifier_policy') {
+    return (
+      <span className="rounded-full border border-stone-300/20 bg-stone-300/10 px-2 py-1 text-[10px] font-semibold text-stone-200">
+        Older classifier policy
       </span>
     );
   }
@@ -1177,6 +1199,8 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
   const [sortKey, setSortKey] = useState<SortKey>('fitScore');
   const [sortAsc, setSortAsc] = useState(false);
   const [isUpdatingSharing, setIsUpdatingSharing] = useState(false);
+  const [isRegrading, setIsRegrading] = useState(false);
+  const [regradeMessage, setRegradeMessage] = useState<string | null>(null);
   const [shareMessage, setShareMessage] = useState<string | null>(null);
   const rowRefs = useRef<Record<string, HTMLTableRowElement | null>>({});
   const resizeFrameRef = useRef<number | null>(null);
@@ -1305,10 +1329,65 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
     }
   }, [applyJobUpdate, data.job.id, data.listings]);
 
-  const activeRequirementSetId = useMemo(
-    () => getActiveRequirementSetId(data.listings),
+  const activeTriageComparison = useMemo(
+    () => getActiveTriageComparison(data.listings),
     [data.listings],
   );
+  const olderPolicyCount = useMemo(
+    () =>
+      data.listings.filter(
+        (listing) =>
+          !listing.hidden
+          && getTriageComparisonStatus(
+            getListingResultsSnapshot(listing).triage,
+            activeTriageComparison,
+          ) === 'stale_classifier_policy',
+      ).length,
+    [activeTriageComparison, data.listings],
+  );
+  const regradeListingCount = useMemo(
+    () => getTriageRegradeListingCount(data.listings),
+    [data.listings],
+  );
+  const estimatedRegradeCostUsd =
+    estimateTriageRegradeCostUsd(regradeListingCount);
+  const regradeLocked =
+    isRegrading
+    || data.job.analysisStatus === 'running'
+    || data.job.analysisCurrentPhase === 'queued';
+
+  const startTriageRegrade = useCallback(async () => {
+    if (!viewerCanEdit || regradeLocked) return;
+    setIsRegrading(true);
+    setRegradeMessage(null);
+    try {
+      const response = await fetch(`/api/jobs/${data.job.id}/analyze`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: 'triage' }),
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        throw new Error(payload?.error || 'Failed to queue regrade');
+      }
+      setRegradeMessage(
+        `Whole-job regrade queued for ${regradeListingCount} listings.`,
+      );
+      await refreshJob();
+    } catch (error) {
+      setRegradeMessage(
+        error instanceof Error ? error.message : 'Failed to queue regrade',
+      );
+    } finally {
+      setIsRegrading(false);
+    }
+  }, [
+    data.job.id,
+    refreshJob,
+    regradeListingCount,
+    regradeLocked,
+    viewerCanEdit,
+  ]);
 
   const baseRankedResults = useMemo(() => {
     const next = [...data.listings];
@@ -1318,12 +1397,12 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
     next.sort((a, b) => {
       const triageA = getListingResultsSnapshot(a).triage;
       const triageB = getListingResultsSnapshot(b).triage;
-      if (activeRequirementSetId) {
+      if (activeTriageComparison) {
         const groupA = comparisonRank(
-          getTriageComparisonStatus(triageA, activeRequirementSetId),
+          getTriageComparisonStatus(triageA, activeTriageComparison),
         );
         const groupB = comparisonRank(
-          getTriageComparisonStatus(triageB, activeRequirementSetId),
+          getTriageComparisonStatus(triageB, activeTriageComparison),
         );
         if (groupA !== groupB) return groupA - groupB;
         if (groupA !== 0) {
@@ -1368,7 +1447,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
     });
     return next;
   }, [
-    activeRequirementSetId,
+    activeTriageComparison,
     data.job.checkin,
     data.job.checkout,
     data.listings,
@@ -1383,32 +1462,32 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
 
     if (sortKey === 'rank') {
       if (!sortAsc) return next;
-      if (!activeRequirementSetId) return [...next].reverse();
+      if (!activeTriageComparison) return [...next].reverse();
       const ranked = next.filter((listing) =>
         getTriageComparisonStatus(
           getListingResultsSnapshot(listing).triage,
-          activeRequirementSetId,
+          activeTriageComparison,
         ) === 'ranked');
       const unranked = next.filter((listing) =>
         getTriageComparisonStatus(
           getListingResultsSnapshot(listing).triage,
-          activeRequirementSetId,
+          activeTriageComparison,
         ) !== 'ranked');
       return [...ranked.reverse(), ...unranked];
     }
 
     next.sort((a, b) => {
-      if (activeRequirementSetId) {
+      if (activeTriageComparison) {
         const groupA = comparisonRank(
           getTriageComparisonStatus(
             getListingResultsSnapshot(a).triage,
-            activeRequirementSetId,
+            activeTriageComparison,
           ),
         );
         const groupB = comparisonRank(
           getTriageComparisonStatus(
             getListingResultsSnapshot(b).triage,
-            activeRequirementSetId,
+            activeTriageComparison,
           ),
         );
         if (groupA !== groupB) return groupA - groupB;
@@ -1460,7 +1539,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
 
     return next;
   }, [
-    activeRequirementSetId,
+    activeTriageComparison,
     baseRankedResults,
     data.job.checkin,
     data.job.checkout,
@@ -1483,11 +1562,11 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
         const triage = getListingResultsSnapshot(listing).triage;
         const comparisonStatus = getTriageComparisonStatus(
           triage,
-          activeRequirementSetId,
+          activeTriageComparison,
         );
         const tier = triage?.tier ?? 'unscored';
         if (
-          (!activeRequirementSetId || comparisonStatus === 'ranked')
+          (!activeTriageComparison || comparisonStatus === 'ranked')
           && !activeTiers.has(tier)
         ) {
           return false;
@@ -1519,7 +1598,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       }),
     [
       activeTiers,
-      activeRequirementSetId,
+      activeTriageComparison,
       data.job.checkin,
       data.job.checkout,
       displayableResults,
@@ -1542,10 +1621,10 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
   const heroResults = useMemo(() => {
     const comparable = filteredResults.filter(
       (listing) =>
-        !activeRequirementSetId
+        !activeTriageComparison
         || getTriageComparisonStatus(
           getListingResultsSnapshot(listing).triage,
-          activeRequirementSetId,
+          activeTriageComparison,
         ) === 'ranked',
     );
     const topPicks = comparable.filter(
@@ -1555,17 +1634,17 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
     return topPicks.length >= 3
       ? topPicks.slice(0, 5)
       : comparable.slice(0, 5);
-  }, [activeRequirementSetId, filteredResults]);
+  }, [activeTriageComparison, filteredResults]);
 
   const tierCounts = useMemo(() => {
     const counts = new Map<string, number>();
     for (const listing of displayableResults) {
       const triage = getListingResultsSnapshot(listing).triage;
       if (
-        activeRequirementSetId
+        activeTriageComparison
         && getTriageComparisonStatus(
           triage,
-          activeRequirementSetId,
+          activeTriageComparison,
         ) !== 'ranked'
       ) {
         continue;
@@ -1574,7 +1653,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       counts.set(tier, (counts.get(tier) ?? 0) + 1);
     }
     return counts;
-  }, [activeRequirementSetId, displayableResults]);
+  }, [activeTriageComparison, displayableResults]);
 
   useEffect(() => {
     if (filteredResults.length === 0) {
@@ -1739,7 +1818,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
         const snapshot = getListingResultsSnapshot(listing);
         const comparisonStatus = getTriageComparisonStatus(
           snapshot.triage,
-          activeRequirementSetId,
+          activeTriageComparison,
         );
         const verdictTier = displayedTier(
           snapshot.triage,
@@ -1751,22 +1830,24 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
             ? comparisonRank(
                 getTriageComparisonStatus(
                   getListingResultsSnapshot(rows[index - 1]).triage,
-                  activeRequirementSetId,
+                  activeTriageComparison,
                 ),
               )
             : null;
         const groupHeader =
-          activeRequirementSetId
+          activeTriageComparison
           && comparisonGroup !== 0
           && comparisonGroup !== previousComparisonGroup
             ? comparisonGroup === 1
               ? 'Insufficient evidence — shown for audit, not ranked with comparable results'
               : comparisonGroup === 2
-                ? 'Legacy or stale verdicts — regrade the whole job before comparing'
+                ? 'Classified under an older policy — regrade the whole job before comparing'
+                : comparisonGroup === 3
+                  ? 'Legacy or stale requirement-set verdicts — regrade before comparing'
                 : 'Unscored listings'
             : null;
         const showPeerRank =
-          !activeRequirementSetId || comparisonStatus === 'ranked';
+          !activeTriageComparison || comparisonStatus === 'ranked';
         const priceInfo = getPriceDisplayInfo(listing, priceDisplay, {
           checkin: data.job.checkin,
           checkout: data.job.checkout,
@@ -1994,7 +2075,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
         );
       }),
     [
-      activeRequirementSetId,
+      activeTriageComparison,
       data.job,
       expandedId,
       handleSelect,
@@ -2075,6 +2156,49 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
           </div>
 
           <AiBudgetNotice job={data.job} variant="results" className="mt-4" />
+
+          {olderPolicyCount > 0 && (
+            <div className="mt-5 rounded-2xl border border-amber-300/20 bg-amber-300/[0.08] p-4">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-amber-100">
+                    Classified under an older policy
+                  </p>
+                  <p className="mt-1 max-w-3xl text-xs leading-5 text-amber-100/75">
+                    {olderPolicyCount} verdict{olderPolicyCount === 1 ? ' is' : 's are'} preserved
+                    for audit but excluded from peer ranking until the whole job is regraded.
+                    This reuses saved review and photo analysis and calls only triage.
+                  </p>
+                  <p className="mt-1 text-xs text-amber-100/65">
+                    Whole-job scope: {regradeListingCount} listing
+                    {regradeListingCount === 1 ? '' : 's'}. Estimated AI cost:{' '}
+                    {formatUsdCost(estimatedRegradeCostUsd)} at about $0.006 per listing.
+                  </p>
+                  {regradeMessage && (
+                    <p className="mt-2 text-xs font-semibold text-amber-100">
+                      {regradeMessage}
+                    </p>
+                  )}
+                </div>
+                {viewerCanEdit ? (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void startTriageRegrade();
+                    }}
+                    disabled={regradeLocked}
+                    className="rounded-2xl border border-amber-200/25 bg-amber-100/10 px-4 py-2 text-sm font-semibold text-amber-50 transition hover:bg-amber-100/15 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {regradeLocked ? 'Regrade queued or running…' : 'Regrade whole job'}
+                  </button>
+                ) : (
+                  <span className="text-xs font-semibold text-amber-100/70">
+                    Ask the job owner to regrade.
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
 
           <div className="mt-5 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">

--- a/web/src/lib/results.ts
+++ b/web/src/lib/results.ts
@@ -2,6 +2,11 @@ import type {
   ReviewJobListing,
   TriageEvidenceGap,
 } from '../types.js';
+import {
+  getCurrentTriageComparability,
+  getTriageComparabilityKey,
+  type TriageComparabilityDescriptor,
+} from '@cli/triage-comparability';
 
 const TRIAGE_EVIDENCE_GAP_ORDER: TriageEvidenceGap[] = [
   'details',
@@ -111,6 +116,9 @@ export interface ParsedTriage {
   scoreSource: 'deterministic_rubric' | 'model_legacy';
   rubricVersion: string | null;
   requirementSetId: string | null;
+  classifierVersion: string | null;
+  modelId: string | null;
+  comparabilityKey: string | null;
   rawFitScore: number | null;
   fitScore: number | null;
   tier: string | null;
@@ -156,7 +164,16 @@ export type TriageComparisonStatus =
   | 'insufficient_evidence'
   | 'legacy'
   | 'stale_requirement_set'
+  | 'stale_classifier_policy'
   | 'unscored';
+
+export type ActiveTriageComparison = TriageComparabilityDescriptor;
+
+export function getTriageRegradeListingCount(
+  listings: Array<Pick<ReviewJobListing, 'hidden'>>,
+): number {
+  return listings.filter((listing) => !listing.hidden).length;
+}
 
 export interface ParsedAiReviews {
   overallSentiment: string | null;
@@ -267,17 +284,32 @@ export function getActiveRequirementSetId(
   );
 }
 
+export function getActiveTriageComparison(
+  listings: ReviewJobListing[],
+): ActiveTriageComparison | null {
+  const requirementSetId = getActiveRequirementSetId(listings);
+  return requirementSetId
+    ? getCurrentTriageComparability(requirementSetId)
+    : null;
+}
+
 export function getTriageComparisonStatus(
   triage: ParsedTriage | null,
-  activeRequirementSetId: string | null,
+  activeComparison: ActiveTriageComparison | null,
 ): TriageComparisonStatus {
   if (!triage) return 'unscored';
   if (triage.scoreSource === 'model_legacy') return 'legacy';
   if (
-    activeRequirementSetId
-    && triage.requirementSetId !== activeRequirementSetId
+    activeComparison
+    && triage.requirementSetId !== activeComparison.requirementSetId
   ) {
     return 'stale_requirement_set';
+  }
+  if (
+    activeComparison
+    && triage.comparabilityKey !== activeComparison.key
+  ) {
+    return 'stale_classifier_policy';
   }
   if (triage.rankingStatus === 'insufficient_evidence') {
     return 'insufficient_evidence';
@@ -297,6 +329,26 @@ function parseTriage(listing: ReviewJobListing): ParsedTriage | null {
     && asString(triage.requirementSetId)
       ? 'deterministic_rubric'
       : 'model_legacy';
+  const rubricVersion =
+    scoreSource === 'deterministic_rubric'
+      ? asString(triage.rubricVersion)
+      : null;
+  const requirementSetId =
+    scoreSource === 'deterministic_rubric'
+      ? asString(triage.requirementSetId)
+      : null;
+  const classifierVersion =
+    scoreSource === 'deterministic_rubric'
+      ? asString(triage.classifierVersion)
+      : null;
+  const comparabilityKey =
+    scoreSource === 'deterministic_rubric'
+      ? getTriageComparabilityKey({
+          rubricVersion,
+          requirementSetId,
+          classifierVersion,
+        })
+      : null;
   const coverage = asNumber(triage.coverage);
   const storedRankingStatus = asString(triage.rankingStatus);
   const rankingStatus: ParsedTriage['rankingStatus'] =
@@ -391,14 +443,11 @@ function parseTriage(listing: ReviewJobListing): ParsedTriage | null {
 
   return {
     scoreSource,
-    rubricVersion:
-      scoreSource === 'deterministic_rubric'
-        ? asString(triage.rubricVersion)
-        : null,
-    requirementSetId:
-      scoreSource === 'deterministic_rubric'
-        ? asString(triage.requirementSetId)
-        : null,
+    rubricVersion,
+    requirementSetId,
+    classifierVersion,
+    modelId: asString(triage.modelId),
+    comparabilityKey,
     rawFitScore: asNumber(triage.rawFitScore),
     fitScore: asNumber(triage.fitScore),
     tier: asString(triage.tier),

--- a/web/src/lib/review-job-analysis.ts
+++ b/web/src/lib/review-job-analysis.ts
@@ -298,12 +298,44 @@ export function invalidateAnalysisOutputsForListings(input: {
   removeFileIfExists(getReportPathFromRoot(input.rootDir));
 }
 
+export function invalidateTriageOutputsForListings(input: {
+  rootDir: string;
+  listings: Array<Pick<ReviewJobListing, 'platform' | 'url'>>;
+}) {
+  const manifestPath = getManifestPathFromRoot(input.rootDir);
+  const manifest = readJsonFile<AnalysisManifest>(manifestPath);
+  if (!manifest) {
+    removeFileIfExists(getReportPathFromRoot(input.rootDir));
+    return;
+  }
+
+  const allowedKeys = new Set(
+    input.listings.map((listing) =>
+      getListingMatchKey(listing.platform, listing.url)),
+  );
+
+  for (const entry of Object.values(manifest.listings)) {
+    if (!allowedKeys.has(getListingMatchKey(entry.platform, entry.url))) {
+      continue;
+    }
+    if (entry.triage.file) {
+      removeFileIfExists(path.join(input.rootDir, entry.triage.file));
+    }
+    entry.triage = { status: 'not_requested' };
+  }
+
+  manifest.updatedAt = new Date().toISOString();
+  writeJsonFile(manifestPath, manifest);
+  removeFileIfExists(getReportPathFromRoot(input.rootDir));
+}
+
 export function prepareReviewJobRunWorkspace(input: {
   jobId: string;
   runId: string;
   previousArtifactRoot?: string | null;
   listings: Array<Pick<ReviewJobListing, 'platform' | 'url'>>;
   dates?: { checkIn?: string; checkOut?: string; adults?: number };
+  mode?: 'full' | 'triage';
 }) {
   const runRoot = getReviewJobRunDir(input.jobId, input.runId);
   removeDirIfExists(runRoot);
@@ -324,10 +356,17 @@ export function prepareReviewJobRunWorkspace(input: {
     listings: input.listings,
     dates: input.dates,
   });
-  invalidateAnalysisOutputsForListings({
-    rootDir: runRoot,
-    listings: input.listings,
-  });
+  if (input.mode === 'triage') {
+    invalidateTriageOutputsForListings({
+      rootDir: runRoot,
+      listings: input.listings,
+    });
+  } else {
+    invalidateAnalysisOutputsForListings({
+      rootDir: runRoot,
+      listings: input.listings,
+    });
+  }
 
   return {
     rootDir: runRoot,

--- a/web/src/lib/review-job-queue.ts
+++ b/web/src/lib/review-job-queue.ts
@@ -6,6 +6,7 @@ export const REVIEW_JOB_QUEUE_NAME = 'stayreviewr-review-job';
 export interface ReviewJobQueueData {
   reviewJobId: string;
   phase: 'search' | 'analyze';
+  analysisMode?: 'full' | 'triage';
 }
 
 export function getReviewJobQueueJobId(
@@ -67,7 +68,10 @@ export async function enqueueReviewJobSearch(reviewJobId: string) {
   });
 }
 
-export async function enqueueReviewJobAnalysis(reviewJobId: string) {
+export async function enqueueReviewJobAnalysis(
+  reviewJobId: string,
+  analysisMode: 'full' | 'triage' = 'full',
+) {
   const queue = getReviewJobQueue();
   const jobId = getReviewJobQueueJobId('analyze', reviewJobId);
   const existing = await queue.getJob(jobId);
@@ -82,6 +86,7 @@ export async function enqueueReviewJobAnalysis(reviewJobId: string) {
   return queue.add('run-review-job-analysis', {
     reviewJobId,
     phase: 'analyze',
+    analysisMode,
   }, {
     jobId,
   });

--- a/web/src/lib/search-worker.ts
+++ b/web/src/lib/search-worker.ts
@@ -1083,7 +1083,10 @@ async function syncReviewJobArtifactsToDb(input: {
   };
 }
 
-async function runReviewJobAnalysis(reviewJobId: string) {
+async function runReviewJobAnalysis(
+  reviewJobId: string,
+  analysisMode: 'full' | 'triage' = 'full',
+) {
   await cleanupExpiredReviewJobArtifactRuns('before-analysis');
   await ensureReviewJobAnalysisRows(reviewJobId);
 
@@ -1107,7 +1110,17 @@ async function runReviewJobAnalysis(reviewJobId: string) {
   }
 
   const selectedListings = jobRecord.listings.filter((listing) => listing.selected);
-  const activeListings = selectedListings.length > 0 ? selectedListings : jobRecord.listings;
+  const activeListings =
+    analysisMode === 'triage'
+      ? jobRecord.listings
+      : selectedListings.length > 0
+        ? selectedListings
+        : jobRecord.listings;
+  if (analysisMode === 'triage' && !jobRecord.artifactRoot) {
+    throw new Error(
+      `Review job ${reviewJobId} has no saved artifacts for a triage-only regrade`,
+    );
+  }
   const startedAt = new Date();
   const runId = startedAt.toISOString().replace(/[:.]/g, '-');
   const { rootDir: artifactRoot, urlsFilePath } = prepareReviewJobRunWorkspace({
@@ -1120,6 +1133,7 @@ async function runReviewJobAnalysis(reviewJobId: string) {
       checkOut: jobRecord.checkout ?? undefined,
       adults: jobRecord.adults,
     },
+    mode: analysisMode,
   });
   const analysisModel = process.env.LLM_MODEL || 'gemini-3-flash-preview:high';
   const aiBudgetUsd = resolveAiJobBudgetUsd();
@@ -1155,7 +1169,8 @@ async function runReviewJobAnalysis(reviewJobId: string) {
     totalAiCostUsd: jobRecord.totalAiCostUsd,
   };
   const activeListingIds = activeListings.map((listing) => listing.id);
-  const hasSelectedSubset = selectedListings.length > 0;
+  const hasSelectedSubset =
+    analysisMode === 'full' && selectedListings.length > 0;
   const inactiveListingIds = hasSelectedSubset
     ? jobRecord.listings
       .filter((listing) => !listing.selected)
@@ -1167,6 +1182,7 @@ async function runReviewJobAnalysis(reviewJobId: string) {
     triageCostUsd: 0,
     totalAiCostUsd: 0,
   };
+  let currentRunAiCostUsd = 0;
 
   fs.writeFileSync(
     urlsFilePath,
@@ -1188,10 +1204,16 @@ async function runReviewJobAnalysis(reviewJobId: string) {
         startedAt,
         completedAt: null,
         durationMs: null,
-        aiReviewsCostUsd: 0,
-        aiPhotosCostUsd: 0,
-        triageCostUsd: 0,
-        totalAiCostUsd: 0,
+        ...(analysisMode === 'full'
+          ? {
+              aiReviewsCostUsd: 0,
+              aiPhotosCostUsd: 0,
+              triageCostUsd: 0,
+              totalAiCostUsd: 0,
+            }
+          : {
+              triageCostUsd: 0,
+            }),
       },
     });
     await tx.reviewJob.update({
@@ -1206,10 +1228,16 @@ async function runReviewJobAnalysis(reviewJobId: string) {
         analysisStartedAt: startedAt,
         analysisCompletedAt: null,
         analysisDurationMs: null,
-        aiReviewsCostUsd: 0,
-        aiPhotosCostUsd: 0,
-        triageCostUsd: 0,
-        totalAiCostUsd: 0,
+        ...(analysisMode === 'full'
+          ? {
+              aiReviewsCostUsd: 0,
+              aiPhotosCostUsd: 0,
+              triageCostUsd: 0,
+              totalAiCostUsd: 0,
+            }
+          : {
+              triageCostUsd: 0,
+            }),
       },
     });
   });
@@ -1217,22 +1245,26 @@ async function runReviewJobAnalysis(reviewJobId: string) {
   await appendReviewJobEvent(reviewJobId, {
     phase: 'analysis',
     level: 'info',
-    message: `Started analysis for ${activeListings.length} listings`,
+    message:
+      analysisMode === 'triage'
+        ? `Started triage-only regrade for ${activeListings.length} listings`
+        : `Started analysis for ${activeListings.length} listings`,
     payload: {
       listingCount: activeListings.length,
       artifactRoot,
       model: analysisModel,
       aiBudgetUsd,
+      analysisMode,
     },
   });
 
   try {
     await runBatch([urlsFilePath], {
-      fetchDetails: true,
-      fetchReviews: true,
-      fetchPhotos: true,
-      aiReviews: true,
-      aiPhotos: true,
+      fetchDetails: analysisMode === 'full',
+      fetchReviews: analysisMode === 'full',
+      fetchPhotos: analysisMode === 'full',
+      aiReviews: analysisMode === 'full',
+      aiPhotos: analysisMode === 'full',
       triage: true,
       aiModel: analysisModel,
       aiPriorities: jobRecord.prompt?.trim() || undefined,
@@ -1246,8 +1278,8 @@ async function runReviewJobAnalysis(reviewJobId: string) {
               source: 'explicit',
             }
           : undefined,
-      aiReviewsExplicit: true,
-      aiPhotosExplicit: true,
+      aiReviewsExplicit: analysisMode === 'full',
+      aiPhotosExplicit: analysisMode === 'full',
       triageExplicit: true,
       checkIn: jobRecord.checkin ?? undefined,
       checkOut: jobRecord.checkout ?? undefined,
@@ -1300,10 +1332,10 @@ async function runReviewJobAnalysis(reviewJobId: string) {
         onBeforeAiCall: async (checkpoint) => {
           if (
             aiBudgetUsd != null
-            && hasReachedAiJobBudget(persistedAiCosts.totalAiCostUsd, aiBudgetUsd)
+            && hasReachedAiJobBudget(currentRunAiCostUsd, aiBudgetUsd)
           ) {
             throw new AiJobBudgetExceededError({
-              totalCostUsd: persistedAiCosts.totalAiCostUsd,
+              totalCostUsd: currentRunAiCostUsd,
               budgetUsd: aiBudgetUsd,
               phase: checkpoint.phase,
             });
@@ -1322,6 +1354,10 @@ async function runReviewJobAnalysis(reviewJobId: string) {
             });
             return costs;
           });
+          currentRunAiCostUsd =
+            analysisMode === 'triage'
+              ? persistedAiCosts.triageCostUsd
+              : persistedAiCosts.totalAiCostUsd;
         },
         onScrapeComplete: async ({ outputDir, manifest }) => {
           injectPoiContextIntoListingArtifacts({
@@ -1412,17 +1448,21 @@ async function runReviewJobAnalysis(reviewJobId: string) {
           ...aggregatedAiCosts,
         },
       });
-      await tx.reviewJobEvent.create({
-        data: buildReviewJobEventData(reviewJobId, {
-          phase: 'analysis',
-          level: overallStatus === 'completed' ? 'info' : 'warning',
-          message: 'Analysis completed',
+        await tx.reviewJobEvent.create({
+          data: buildReviewJobEventData(reviewJobId, {
+            phase: 'analysis',
+            level: overallStatus === 'completed' ? 'info' : 'warning',
+            message:
+              analysisMode === 'triage'
+                ? 'Triage-only regrade completed'
+                : 'Analysis completed',
           payload: {
             status: overallStatus,
             listingCount: activeListings.length,
             resultsReady,
             legacyReportAvailable: !!reportPath,
             selectedSubset: hasSelectedSubset,
+            analysisMode,
             costs: aggregatedAiCosts,
           },
         }),
@@ -1430,7 +1470,7 @@ async function runReviewJobAnalysis(reviewJobId: string) {
     });
 
     console.log(
-      `[review-worker] analysis completed ${reviewJobId} with status ${overallStatus}`,
+      `[review-worker] ${analysisMode} analysis completed ${reviewJobId} with status ${overallStatus}`,
     );
   } catch (error) {
     if (error instanceof AiJobBudgetExceededError) {
@@ -1580,7 +1620,10 @@ const reviewJobWorker = new Worker<ReviewJobQueueData>(
       return;
     }
 
-    await runReviewJobAnalysis(job.data.reviewJobId);
+    await runReviewJobAnalysis(
+      job.data.reviewJobId,
+      job.data.analysisMode ?? 'full',
+    );
   },
   {
     connection: getRedisConnectionOptions(),


### PR DESCRIPTION
Closes #69.

## Summary

- defines classifier policy v2 with explicit `met` / `partial` / `unmet` / `unknown` boundaries and three frozen real-analysis examples
- supplies exact job stay context (dates, nights, adults, destination) without permitting invented weather, inventory, room assignment, or provider policy
- persists `classifierVersion` and audit-only `modelId`; peer comparison derives one key from rubric version + requirement-set ID + classifier version
- preserves older deterministic verdicts as explained, unranked results and offers an owner-only, triage-only whole-job regrade that reuses saved AI review/photo artifacts
- adds a tracked 15-pair hand-labeled fixture plus reproducible boundary and stability runners

## Measured result

Using the frozen #62 NYC artifacts and `gemini-3-flash-preview:high`:

- v1: 13/15 overall (86.7%), 3/5 non-`met` boundary pairs (60%)
- v2: 15/15 overall (100%), 5/5 non-`met` boundary pairs (100%)
- Candlewood and Michelangelo quietness move from `partial/high` to `unmet/high`; all positive and genuinely mixed controls remain correct

The 30-call stability matrix (3 listings x 5 runs x temperatures 0 and 1) produced score 44 / `unlikely` on every completed call, zero weighted status flips, zero `partial/high` to `unmet/high` flips, and zero deterministic invariant violations. Temperature 1 had 24/390 confidence flips (6.15%); production temperature 0 had none. One preliminary temperature-1 response duplicated a requirement ID and was rejected before scoring; the runner is now resumable and records rejected attempts.

## Migration behavior

Existing deterministic verdicts without `classifierVersion` stay preserved but cannot rank beside v2 results. The native UI explains the stale policy and estimates the actual whole-job scope at about $0.006 per non-hidden listing (about $0.32 for 54). Regrade runs triage only, across all non-hidden listings, with existing review/photo analysis retained. `modelId` is stored for audit and intentionally excluded from comparability.

## Validation

- `pnpm run build`
- `pnpm run lint`
- `pnpm test` (128 passed)
- `cd web && npm run lint`
- `cd web && npm run test:pricing`
- `cd web && npm run test:ui` (8 web tests total)
- `cd web && npm run build`
- Prisma schema validation
- `git diff --check`