### PR TITLE
Add exact-stay price and availability snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ output directories:
 
 ```env
 REVIEWR_CACHE_DIR=~/.cache/reviewr/artifacts-v1
-REVIEWR_CACHE_DETAILS_TTL_DAYS=7
+REVIEWR_CACHE_DETAILS_TTL_DAYS=1
 REVIEWR_CACHE_REVIEWS_TTL_DAYS=30
 REVIEWR_CACHE_PHOTOS_TTL_DAYS=180
 ```
@@ -233,7 +233,7 @@ npm run cleanup:artifacts -- --apply  # delete expired runs
 
 An available run can be downloaded as a streamed ZIP from the job or results page. The per-job
 run intentionally duplicates some details/reviews/photos from the cross-job cache: cache freshness
-is bounded by its 7/30/180-day TTLs, while complete run bundles retain for 30 days by default.
+is bounded by its 1/30/180-day TTLs, while complete run bundles retain for 30 days by default.
 Disk therefore grows in two locations; the cache still has no global size cap, and either store
 can be removed without losing the Postgres-backed results.
 

--- a/docs/review-job-analysis-parity.md
+++ b/docs/review-job-analysis-parity.md
@@ -127,7 +127,7 @@ the same temporary file inputs that `runAnalyze`, `runAnalyzePhotos`, and
 - Airbnb keys use room ID. Booking keys use `country_code/hotel_name`. Details additionally
   fingerprint exact dates, guest count, and Booking linked-room selection; Booking photo keys
   fingerprint linked-room versus download-all selection.
-- Default TTLs are 7 days for details, 30 days for reviews, and 180 days for photos. Cache hits
+- Default TTLs are 1 day for details, 30 days for reviews, and 180 days for photos. Cache hits
   are copied into the run's normal v2 artifact layout and recorded with `source = cache`,
   `cachedAt`, and `cacheAgeMs` in the manifest.
 - Only complete `fetched` outputs populate the cache. Partial, failed, stale, corrupt, and
@@ -135,6 +135,22 @@ the same temporary file inputs that `runAnalyze`, `runAnalyzePhotos`, and
   after successful fetches. AI analysis and triage outputs are not cached.
 - The v1 cache has no size bound. Removing the configured `REVIEWR_CACHE_DIR` is always safe;
   later jobs recreate it as needed.
+
+## Details-only price refresh
+
+- A price refresh clones the current run and executes only `details` with `force = true` and
+  `scopeManifestToInput = false`. It bypasses details-cache reads, then publishes successful
+  exact-date details to the normal cache.
+- Reviews, photos, AI review analysis, AI photo analysis, and quality classification are preserved
+  byte-for-byte. The worker recomputes only deterministic affordability and booking eligibility.
+- Failed or structurally unknown provider responses restore the prior details artifact and
+  snapshot, while persisting the separate attempt time and error. Mixed outcomes are `partial`.
+- Airbnb exact-date price quotes update the price but do not prove inventory. Airbnb availability
+  remains `unknown` unless its PDP explicitly refuses the stay or volunteers an alternate range;
+  search inclusion is not promoted to `yes`. Fresh-`no` exclusion is Booking-only in v1 unless
+  stronger Airbnb provider evidence is captured.
+- One review job has one snapshot date range. Run separate jobs for multi-leg trips; issue #70
+  tracks multi-leg support.
 
 ## Persistence Goals For The Web Job
 

--- a/docs/triage-rubric.md
+++ b/docs/triage-rubric.md
@@ -249,6 +249,9 @@ The quality verdict and affordability are independent:
   "freshness": "fresh",
   "rateType": "public",
   "mandatoryChargesResolved": true,
+  "availabilityStatus": "yes",
+  "availabilityCapturedAt": "2026-07-25T12:00:00Z",
+  "availabilityFreshness": "fresh",
   "comparablePrice": {
     "amount": 4950,
     "currency": "USD",
@@ -258,6 +261,12 @@ The quality verdict and affordability are independent:
     "freshness": "fresh",
     "rateType": "public",
     "mandatoryChargesResolved": true
+  },
+  "comparableAvailability": {
+    "status": "yes",
+    "capturedAt": "2026-07-25T12:00:00Z",
+    "freshness": "fresh",
+    "reasonCode": "provider_room_inventory"
   }
 }
 ```
@@ -279,6 +288,14 @@ A comparable price must be a public-rate total for the same stay dates and occup
 currency and stay basis, with mandatory charges resolved. Fresh/stale is consumed from price
 provenance; this rubric does not invent a second TTL.
 
+Availability is an independent booking-eligibility axis. Only a fresh `yes` permits an actionable
+affordability comparison. A fresh `no` is excluded from actionable ranking; `partial`, `unknown`,
+and stale states remain visible as conditional or unknown. Alternate Airbnb ranges are accepted
+only when the provider volunteers them—v1 never probes speculative windows. An Airbnb price quote
+does not by itself verify inventory, so Airbnb remains non-actionable `unknown` unless the PDP
+provides an explicit availability signal. Fresh-`no` exclusion is therefore Booking-only in the
+current v1 evidence set.
+
 Unknown affordability always carries a machine code and user-facing reason. Required examples:
 
 | Code | User-facing reason |
@@ -288,6 +305,10 @@ Unknown affordability always carries a machine code and user-facing reason. Requ
 | `price_stale` | Price is stale (12 days old). |
 | `currency_mismatch` | Price currency PLN does not match budget currency USD. |
 | `mandatory_charges_unresolved` | Mandatory charges are unresolved in this price. |
+| `stay_unavailable` | The property is unavailable for the recorded dates and guest count. |
+| `stay_partially_available` | The provider offered only conditional or alternate availability. |
+| `availability_stale` | Availability is stale (12 days old). |
+| `availability_unknown` | Availability could not be confirmed for the recorded dates and guest count. |
 
 Basis, freshness, invalid-price, and non-public-rate failures have equally specific reasons. The UI
 shows the reason after “Budget unknown”; it does not show a bare unknown state.

--- a/src/airbnb/listing.ts
+++ b/src/airbnb/listing.ts
@@ -13,6 +13,8 @@ import * as path from 'path';
 import fetch from 'node-fetch';
 import { BROWSER_HEADERS, getApiKey, makeRequest } from './scraper.js';
 import { getListingHash, isStaleHash, refreshHashesViaPlaywright, invalidateSessionCache } from './hash-manager.js';
+import { parseAirbnbStaySnapshot } from './stay-snapshot.js';
+import type { StaySnapshot } from '../stay-snapshot.js';
 const OUTPUT_DIR = 'data/airbnb/output';
 
 const API_HEADERS = {
@@ -47,6 +49,7 @@ export interface AirbnbListingDetails {
   checkOut: string | null;
   cancellationPolicy: string | null;
   sleepingArrangements: SleepingArrangement[] | null;
+  staySnapshot: StaySnapshot;
   scrapedAt: string;
 }
 
@@ -261,6 +264,8 @@ export async function fetchListingPageData(
 function buildListingDetails(
   roomId: string,
   parsed: Partial<AirbnbListingDetails>,
+  staySnapshot: StaySnapshot,
+  capturedAt: string,
 ): AirbnbListingDetails {
   return {
     id: roomId,
@@ -286,7 +291,8 @@ function buildListingDetails(
     checkOut: parsed.checkOut || null,
     cancellationPolicy: parsed.cancellationPolicy || null,
     sleepingArrangements: parsed.sleepingArrangements || null,
-    scrapedAt: new Date().toISOString(),
+    staySnapshot,
+    scrapedAt: capturedAt,
   };
 }
 
@@ -546,14 +552,48 @@ export async function fetchListingDetails(
   roomId: string,
   options?: { checkIn?: string; checkOut?: string; adults?: number }
 ): Promise<AirbnbListingDetails> {
+  let htmlFallback: AirbnbListingDetails | null = null;
   try {
     const pageData = await fetchListingPageData(roomId, options);
     const parsedFromHtml = parseSections(pageData.sections, pageData.metadata);
-    return buildListingDetails(roomId, parsedFromHtml);
+    const capturedAt = new Date().toISOString();
+    const staySnapshot = parseAirbnbStaySnapshot({
+      sections: pageData.sections,
+      request: {
+        platform: 'airbnb',
+        listingId: roomId,
+        checkIn: options?.checkIn ?? null,
+        checkOut: options?.checkOut ?? null,
+        adults: options?.adults ?? null,
+        linkedRoomId: null,
+      },
+      capturedAt,
+      currency: 'USD',
+    });
+    const htmlDetails = buildListingDetails(
+      roomId,
+      parsedFromHtml,
+      staySnapshot,
+      capturedAt,
+    );
+    if (
+      !options?.checkIn
+      || !options?.checkOut
+      || staySnapshot.availability.status !== 'unknown'
+      || staySnapshot.priceForStay != null
+    ) {
+      return htmlDetails;
+    }
+    htmlFallback = htmlDetails;
+    console.warn(
+      `Warning: Airbnb HTML did not expose exact-stay availability for `
+      + `${roomId}; trying the PDP API`,
+    );
   } catch (htmlError: any) {
     console.warn(`Warning: Airbnb listing HTML extraction failed for ${roomId}: ${htmlError.message}`);
   }
 
+  try {
   const globalId = Buffer.from(`StayListing:${roomId}`).toString('base64');
   const demandId = Buffer.from(`DemandStayListing:${roomId}`).toString('base64');
 
@@ -660,6 +700,7 @@ export async function fetchListingDetails(
   }
 
   let sections = page.sections?.sections || [];
+  let snapshotSections = sections;
   const metadata = page.sections?.metadata || {};
 
   if (sections.length === 0) {
@@ -682,6 +723,7 @@ export async function fetchListingDetails(
         page = json?.data?.presentation?.stayProductDetailPage;
         if (page) {
           sections = page.sections?.sections || sections;
+          snapshotSections = sections;
         }
       } catch (err: any) {
         console.error(`Warning: Hash refresh failed: ${err.message}`);
@@ -734,6 +776,7 @@ export async function fetchListingDetails(
       const pricingPage = pricingJson?.data?.presentation?.stayProductDetailPage;
       if (pricingPage) {
         const pricingSections = pricingPage.sections?.sections || [];
+        snapshotSections = [...pricingSections, ...sections];
         const pricingParsed = parseSections(pricingSections, {});
         if (pricingParsed.pricing) {
           parsed.pricing = pricingParsed.pricing;
@@ -750,7 +793,35 @@ export async function fetchListingDetails(
     }
   }
 
-  return buildListingDetails(roomId, parsed);
+  const capturedAt = new Date().toISOString();
+  return buildListingDetails(
+    roomId,
+    parsed,
+    parseAirbnbStaySnapshot({
+      sections: snapshotSections,
+      request: {
+        platform: 'airbnb',
+        listingId: roomId,
+        checkIn: options?.checkIn ?? null,
+        checkOut: options?.checkOut ?? null,
+        adults: options?.adults ?? null,
+        linkedRoomId: null,
+      },
+      capturedAt,
+      currency: 'USD',
+    }),
+    capturedAt,
+  );
+  } catch (apiError) {
+    if (htmlFallback) {
+      console.warn(
+        `Warning: Airbnb PDP API fallback failed for ${roomId}; preserving `
+        + `the HTML extraction with unknown availability`,
+      );
+      return htmlFallback;
+    }
+    throw apiError;
+  }
 }
 
 /**

--- a/src/airbnb/stay-snapshot.ts
+++ b/src/airbnb/stay-snapshot.ts
@@ -1,0 +1,275 @@
+import {
+  detectCurrencyFromText,
+  getStayNights,
+} from '../search/pricing.js';
+import { parseAirbnbStructuredDisplayPrice } from './pricing.js';
+import {
+  STAY_SNAPSHOT_SCHEMA_VERSION,
+  type StayDateRange,
+  type StayRequestFingerprint,
+  type StaySnapshot,
+} from '../stay-snapshot.js';
+
+function findSection(sections: any[], sectionId: string): any | null {
+  const match = sections.find((item) => item?.sectionId === sectionId);
+  return match?.section ?? null;
+}
+
+function cleanText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function collectStrings(
+  value: unknown,
+  output: string[],
+  depth = 0,
+): void {
+  if (depth > 8 || value == null) return;
+  if (typeof value === 'string') {
+    const cleaned = cleanText(value);
+    if (cleaned) output.push(cleaned);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, output, depth + 1);
+    return;
+  }
+  if (typeof value === 'object') {
+    for (const item of Object.values(value as Record<string, unknown>)) {
+      collectStrings(item, output, depth + 1);
+    }
+  }
+}
+
+function isIsoDate(value: unknown): value is string {
+  return (
+    typeof value === 'string'
+    && /^\d{4}-\d{2}-\d{2}$/.test(value)
+    && Number.isFinite(Date.parse(`${value}T00:00:00Z`))
+  );
+}
+
+function collectVolunteeredDateRanges(
+  value: unknown,
+  output: StayDateRange[],
+  depth = 0,
+  volunteered = false,
+): void {
+  if (depth > 8 || value == null) return;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectVolunteeredDateRanges(item, output, depth + 1, volunteered);
+    }
+    return;
+  }
+  if (typeof value !== 'object') return;
+
+  const record = value as Record<string, unknown>;
+  const checkIn = record.checkIn ?? record.check_in;
+  const checkOut = record.checkOut ?? record.check_out;
+  if (volunteered && isIsoDate(checkIn) && isIsoDate(checkOut)) {
+    output.push({ checkIn, checkOut });
+  }
+  for (const [key, item] of Object.entries(record)) {
+    const normalizedKey = key.replace(/[_-]/g, '');
+    const isVolunteeredRange =
+      volunteered
+      || /(?:suggest|alternative|alternate|recommend|availablerange|dateoption)/i
+        .test(normalizedKey);
+    collectVolunteeredDateRanges(
+      item,
+      output,
+      depth + 1,
+      isVolunteeredRange,
+    );
+  }
+}
+
+function uniqueRanges(
+  ranges: StayDateRange[],
+  request: StayRequestFingerprint,
+): StayDateRange[] {
+  const requestedKey = `${request.checkIn ?? ''}/${request.checkOut ?? ''}`;
+  const seen = new Set<string>();
+  return ranges.filter((range) => {
+    const key = `${range.checkIn}/${range.checkOut}`;
+    if (key === requestedKey || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function selectAlternativeRange(
+  ranges: StayDateRange[],
+  request: StayRequestFingerprint,
+): StayDateRange | undefined {
+  const requestedNights = getStayNights(request.checkIn, request.checkOut) ?? 0;
+  return [...ranges].sort((left, right) => {
+    const leftSameCheckout = left.checkOut === request.checkOut ? 1 : 0;
+    const rightSameCheckout = right.checkOut === request.checkOut ? 1 : 0;
+    if (leftSameCheckout !== rightSameCheckout) {
+      return rightSameCheckout - leftSameCheckout;
+    }
+    const leftNights = getStayNights(left.checkIn, left.checkOut) ?? 0;
+    const rightNights = getStayNights(right.checkIn, right.checkOut) ?? 0;
+    const leftCovers = leftNights >= requestedNights ? 1 : 0;
+    const rightCovers = rightNights >= requestedNights ? 1 : 0;
+    if (leftCovers !== rightCovers) return rightCovers - leftCovers;
+    return rightNights - leftNights
+      || left.checkIn.localeCompare(right.checkIn);
+  })[0];
+}
+
+function getStructuredPriceEvidence(structuredDisplayPrice: any): {
+  text: string;
+  chargesText: string;
+  mandatoryChargesResolved: boolean;
+} {
+  const strings: string[] = [];
+  collectStrings(structuredDisplayPrice?.primaryLine, strings);
+  collectStrings(structuredDisplayPrice?.secondaryLine, strings);
+
+  const details =
+    structuredDisplayPrice?.explanationData?.priceDetails
+    ?? structuredDisplayPrice?.explanation_data?.price_details
+    ?? [];
+  const chargeLabels: string[] = [];
+  if (Array.isArray(details)) {
+    for (const group of details) {
+      const items = Array.isArray(group?.items) ? group.items : [];
+      for (const item of items) {
+        const description =
+          typeof item?.description === 'string'
+            ? cleanText(item.description)
+            : '';
+        if (description) chargeLabels.push(description);
+      }
+    }
+  }
+
+  const exactTotal = chargeLabels.find(
+    (label) => /^total$/i.test(label),
+  );
+  return {
+    text: [...new Set(strings)].join(' · '),
+    chargesText: [...new Set(chargeLabels)].join(' · '),
+    mandatoryChargesResolved: !!exactTotal,
+  };
+}
+
+export function parseAirbnbStaySnapshot(input: {
+  sections: any[];
+  request: StayRequestFingerprint;
+  capturedAt?: string;
+  currency?: string;
+}): StaySnapshot {
+  const capturedAt = input.capturedAt ?? new Date().toISOString();
+  const hasExactDates = !!(input.request.checkIn && input.request.checkOut);
+  const bookItSection = findSection(input.sections, 'BOOK_IT_SIDEBAR');
+  const relevantSections = input.sections.filter((item) =>
+    /BOOK_IT|AVAILABILITY|CALENDAR|URGENCY_COMMITMENT/i.test(
+      String(item?.sectionId ?? item?.section?.__typename ?? ''),
+    ));
+  const providerStrings: string[] = [];
+  collectStrings(relevantSections, providerStrings);
+  const providerText = [...new Set(providerStrings)].join(' · ');
+  const explicitNoText = providerStrings.find((text) =>
+    /(?:dates? (?:are|is) not available|not available for (?:these|your) dates|unavailable for (?:these|your) dates|no longer available|sold out)/i
+      .test(text));
+  const explicitPartialText = providerStrings.find((text) =>
+    /(?:some dates? (?:are|is) not available|choose different dates|available for part of)/i
+      .test(text));
+
+  const rawRanges: StayDateRange[] = [];
+  for (const section of relevantSections) {
+    collectVolunteeredDateRanges(section, rawRanges);
+  }
+  const alternativeRanges = uniqueRanges(rawRanges, input.request);
+  const availableRange = selectAlternativeRange(
+    alternativeRanges,
+    input.request,
+  );
+
+  const structuredDisplayPrice = bookItSection?.structuredDisplayPrice;
+  const priceEvidence = getStructuredPriceEvidence(structuredDisplayPrice);
+  const detectedCurrency = detectCurrencyFromText(
+    priceEvidence.text,
+    input.currency?.toUpperCase() || 'USD',
+  );
+  const pricing = hasExactDates
+    ? parseAirbnbStructuredDisplayPrice(
+        structuredDisplayPrice,
+        detectedCurrency,
+        getStayNights(input.request.checkIn, input.request.checkOut),
+      )
+    : null;
+  const total = pricing?.total;
+  const priceForStay =
+    total && /^[A-Z]{3}$/.test(total.currency)
+      ? {
+          amount: total.amount,
+          currency: total.currency,
+          basis: 'stay' as const,
+          capturedAt,
+          source: 'airbnb_pdp',
+          rateType: 'public' as const,
+          mandatoryChargesResolved:
+            priceEvidence.mandatoryChargesResolved,
+        }
+      : null;
+
+  let availability: StaySnapshot['availability'];
+  if (!hasExactDates) {
+    availability = {
+      status: 'unknown',
+      capturedAt,
+      reasonCode: 'dates_not_requested',
+    };
+  } else if ((explicitNoText || explicitPartialText) && availableRange) {
+    availability = {
+      status: 'partial',
+      capturedAt,
+      reasonCode: 'provider_alternative_range',
+      availableRange,
+    };
+  } else if (explicitPartialText) {
+    availability = {
+      status: 'partial',
+      capturedAt,
+      reasonCode: 'provider_partial_inventory',
+    };
+  } else if (explicitNoText) {
+    availability = {
+      status: 'no',
+      capturedAt,
+      reasonCode: 'provider_unavailable',
+    };
+  } else {
+    availability = {
+      status: 'unknown',
+      capturedAt,
+      reasonCode: priceForStay
+        ? 'airbnb_inventory_not_verified'
+        : 'availability_extraction_failed',
+    };
+  }
+
+  return {
+    schemaVersion: STAY_SNAPSHOT_SCHEMA_VERSION,
+    request: input.request,
+    priceForStay,
+    availability,
+    providerEvidence: {
+      ...((explicitNoText || explicitPartialText)
+        ? { availabilityText: explicitNoText ?? explicitPartialText }
+        : providerText
+          ? { availabilityText: providerText.slice(0, 1_000) }
+          : {}),
+      ...(priceEvidence.text ? { priceText: priceEvidence.text } : {}),
+      ...(priceEvidence.chargesText
+        ? { chargesText: priceEvidence.chargesText }
+        : {}),
+      ...(alternativeRanges.length > 0 ? { alternativeRanges } : {}),
+    },
+  };
+}

--- a/src/artifact-cache.ts
+++ b/src/artifact-cache.ts
@@ -12,7 +12,7 @@ export const CACHE_TTL_ENV = {
 } as const;
 
 export const DEFAULT_CACHE_TTL_DAYS = {
-  details: 7,
+  details: 1,
   reviews: 30,
   photos: 180,
 } as const;

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -30,10 +30,16 @@ import {
   buildDetailsCacheVariant,
   buildPhotosCacheVariant,
   createArtifactCache,
+  resolveArtifactCachePolicy,
   type ArtifactCache,
   type ArtifactCacheHit,
   type ArtifactCacheKey,
 } from './artifact-cache.js';
+import {
+  deriveStaySnapshotFreshness,
+  isStaySnapshotCacheable,
+  parseStaySnapshot,
+} from './stay-snapshot.js';
 import {
   formatReviewProgressLabel,
   getScrapeProgressFraction,
@@ -987,11 +993,13 @@ export async function runBatch(
                     `listing_${roomId}.json`,
                     listingsDir,
                   );
-                  publishCachedFile({
-                    cache: artifactCache,
-                    key: detailsCacheKey,
-                    sourcePath: detailsFile,
-                  });
+                  if (isStaySnapshotCacheable(details.staySnapshot)) {
+                    publishCachedFile({
+                      cache: artifactCache,
+                      key: detailsCacheKey,
+                      sourcePath: detailsFile,
+                    });
+                  }
                 }
                 statusParts.push(`details \u2713 (${formatDuration(Date.now() - t)})`);
                 airbnbResult.details.fetched++;
@@ -1425,11 +1433,13 @@ export async function runBatch(
               details = await bookingListing.scrapeListingDetails(url, dateOpts);
               if (!options.print) {
                 bookingListing.saveListingDetails(details, `listing_${id}.json`, listingsDir);
-                publishCachedFile({
-                  cache: artifactCache,
-                  key: detailsCacheKey,
-                  sourcePath: detailsFile,
-                });
+                if (isStaySnapshotCacheable(details.staySnapshot)) {
+                  publishCachedFile({
+                    cache: artifactCache,
+                    key: detailsCacheKey,
+                    sourcePath: detailsFile,
+                  });
+                }
               }
               statusParts.push(`details \u2713 (${formatDuration(Date.now() - t)})`);
               bookingResult.details.fetched++;
@@ -2237,6 +2247,20 @@ export async function runBatch(
         ]);
 
         const t = Date.now();
+        const listingData = readJsonFile<Record<string, unknown>>(listingPath);
+        const staySnapshot = parseStaySnapshot(listingData?.staySnapshot);
+        let detailsTtlMs = artifactCache?.policy.ttlMs.details;
+        if (detailsTtlMs == null) {
+          try {
+            detailsTtlMs = resolveArtifactCachePolicy().ttlMs.details;
+          } catch {
+            detailsTtlMs = Number.NaN;
+          }
+        }
+        const staySnapshotFreshness = deriveStaySnapshotFreshness(
+          staySnapshot?.availability.capturedAt,
+          detailsTtlMs,
+        );
         if (!fs.existsSync(triageOutputDir)) fs.mkdirSync(triageOutputDir, { recursive: true });
         await emitBeforeAiCall(options, {
           outputDir: aiOutputDir,
@@ -2253,8 +2277,7 @@ export async function runBatch(
             priorities: options.aiPriorities,
             requirementSet: activeRequirementSet,
             budget: options.analysisBudget,
-            priceFreshness:
-              entry.details.source === 'network' ? 'fresh' : 'unknown',
+            priceFreshness: staySnapshotFreshness,
             stayContext: {
               checkIn: manifest.dates.checkIn,
               checkOut: manifest.dates.checkOut,

--- a/src/booking/listing.ts
+++ b/src/booking/listing.ts
@@ -18,6 +18,8 @@ import * as cheerio from 'cheerio';
 import fetch from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { extractHotelInfo } from './scraper.js';
+import { parseBookingStaySnapshot } from './stay-snapshot.js';
+import type { StaySnapshot } from '../stay-snapshot.js';
 
 const OUTPUT_DIR = 'data/booking/output';
 
@@ -44,6 +46,7 @@ export interface BookingListingDetails {
   linkedRoomId: string | null;
   rooms: BookingRoom[];
   pricing: BookingPricing | null;
+  staySnapshot: StaySnapshot;
   scrapedAt: string;
 }
 
@@ -702,6 +705,20 @@ export async function scrapeListingDetails(
 
   const html = await fetchHotelPageHtml(normalizedUrl, { hasDates });
   const parsed = parseHotelPage(html);
+  const capturedAt = new Date().toISOString();
+  const staySnapshot = parseBookingStaySnapshot({
+    html,
+    request: {
+      platform: 'booking',
+      listingId:
+        `${hotelInfo.country_code.toLowerCase()}/${hotelInfo.hotel_name.toLowerCase()}`,
+      checkIn: checkIn ?? null,
+      checkOut: checkOut ?? null,
+      adults: adults ?? null,
+      linkedRoomId,
+    },
+    capturedAt,
+  });
 
   return {
     id: hotelInfo.hotel_name,
@@ -724,7 +741,8 @@ export async function scrapeListingDetails(
     linkedRoomId,
     rooms: parsed.rooms || [],
     pricing: hasDates ? (parsed.pricing || null) : null,
-    scrapedAt: new Date().toISOString(),
+    staySnapshot,
+    scrapedAt: capturedAt,
   };
 }
 

--- a/src/booking/stay-snapshot.ts
+++ b/src/booking/stay-snapshot.ts
@@ -1,0 +1,242 @@
+import * as cheerio from 'cheerio';
+import {
+  detectCurrencyFromText,
+  parsePriceAmount,
+} from '../search/pricing.js';
+import {
+  STAY_SNAPSHOT_SCHEMA_VERSION,
+  type PriceForStaySnapshot,
+  type StayDateRange,
+  type StayRequestFingerprint,
+  type StaySnapshot,
+} from '../stay-snapshot.js';
+
+function cleanText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function isIsoDate(value: string | null): value is string {
+  return !!value && /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function uniqueRanges(ranges: StayDateRange[]): StayDateRange[] {
+  const seen = new Set<string>();
+  return ranges.filter((range) => {
+    const key = `${range.checkIn}/${range.checkOut}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function getNights(range: StayDateRange): number {
+  const checkIn = Date.parse(`${range.checkIn}T00:00:00Z`);
+  const checkOut = Date.parse(`${range.checkOut}T00:00:00Z`);
+  return Math.max(0, Math.round((checkOut - checkIn) / 86_400_000));
+}
+
+function selectAvailableRange(
+  ranges: StayDateRange[],
+  request: StayRequestFingerprint,
+): StayDateRange | undefined {
+  if (ranges.length === 0) return undefined;
+
+  const requestedRange =
+    request.checkIn && request.checkOut
+      ? { checkIn: request.checkIn, checkOut: request.checkOut }
+      : null;
+  const requestedNights = requestedRange ? getNights(requestedRange) : 0;
+
+  return [...ranges].sort((left, right) => {
+    const leftSameCheckout = left.checkOut === request.checkOut ? 1 : 0;
+    const rightSameCheckout = right.checkOut === request.checkOut ? 1 : 0;
+    if (leftSameCheckout !== rightSameCheckout) {
+      return rightSameCheckout - leftSameCheckout;
+    }
+
+    const leftCoversRequestedLength = getNights(left) >= requestedNights ? 1 : 0;
+    const rightCoversRequestedLength = getNights(right) >= requestedNights ? 1 : 0;
+    if (leftCoversRequestedLength !== rightCoversRequestedLength) {
+      return rightCoversRequestedLength - leftCoversRequestedLength;
+    }
+
+    if (leftSameCheckout && rightSameCheckout) {
+      const lengthDifference = getNights(right) - getNights(left);
+      if (lengthDifference !== 0) return lengthDifference;
+    }
+
+    return left.checkIn.localeCompare(right.checkIn)
+      || left.checkOut.localeCompare(right.checkOut);
+  })[0];
+}
+
+function parseAlternativeRanges($: cheerio.CheerioAPI): StayDateRange[] {
+  const ranges: StayDateRange[] = [];
+  $('.c-next-available-dates__item').each((_, element) => {
+    const href = $(element).attr('href');
+    if (!href) return;
+    try {
+      const parsed = new URL(href, 'https://www.booking.com');
+      const checkIn = parsed.searchParams.get('checkin');
+      const checkOut = parsed.searchParams.get('checkout');
+      if (isIsoDate(checkIn) && isIsoDate(checkOut)) {
+        ranges.push({ checkIn, checkOut });
+      }
+    } catch {
+      // Ignore malformed provider links.
+    }
+  });
+  return uniqueRanges(ranges);
+}
+
+function getFallbackCurrency($: cheerio.CheerioAPI): string {
+  const selectedCurrency = cleanText(
+    $('input[name="selected_currency"]').first().attr('value') ?? '',
+  ).toUpperCase();
+  return /^[A-Z]{3}$/.test(selectedCurrency) ? selectedCurrency : '';
+}
+
+function extractPriceForStay(
+  $: cheerio.CheerioAPI,
+  capturedAt: string,
+): {
+  priceForStay: PriceForStaySnapshot | null;
+  priceText?: string;
+  chargesText?: string;
+} {
+  const fallbackCurrency = getFallbackCurrency($);
+  const candidates: Array<{
+    amount: number;
+    currency: string;
+    priceText: string;
+    chargesText: string;
+  }> = [];
+
+  $('tr[data-block-id]').each((_, element) => {
+    const rowText = cleanText($(element).text());
+    if (/\b(?:genius|member rate|sign(?:ed)? in)\b/i.test(rowText)) {
+      return;
+    }
+
+    const priceText = cleanText(
+      $(element)
+        .find(
+          '.bui-price-display__value, '
+          + '.prco-valign-middle-helper, '
+          + '[data-testid="price-and-discounted-price"]',
+        )
+        .first()
+        .text(),
+    );
+    const amount = parsePriceAmount(priceText);
+    const currency = detectCurrencyFromText(priceText, fallbackCurrency);
+    if (amount == null || !/^[A-Z]{3}$/.test(currency)) {
+      return;
+    }
+
+    const chargesText =
+      rowText.match(/includes taxes and charges/i)?.[0]
+      ?? rowText.match(/excludes taxes and charges/i)?.[0]
+      ?? '';
+    candidates.push({
+      amount,
+      currency,
+      priceText,
+      chargesText,
+    });
+  });
+
+  candidates.sort((left, right) => left.amount - right.amount);
+  const selected = candidates[0];
+  if (!selected) {
+    return { priceForStay: null };
+  }
+
+  return {
+    priceForStay: {
+      amount: selected.amount,
+      currency: selected.currency,
+      basis: 'stay',
+      capturedAt,
+      source: 'booking_property_page',
+      rateType: 'public',
+      mandatoryChargesResolved: /includes taxes and charges/i.test(
+        selected.chargesText,
+      ),
+    },
+    priceText: selected.priceText,
+    ...(selected.chargesText ? { chargesText: selected.chargesText } : {}),
+  };
+}
+
+export function parseBookingStaySnapshot(input: {
+  html: string;
+  request: StayRequestFingerprint;
+  capturedAt?: string;
+}): StaySnapshot {
+  const capturedAt = input.capturedAt ?? new Date().toISOString();
+  const $ = cheerio.load(input.html);
+  const hasExactDates = !!(input.request.checkIn && input.request.checkOut);
+  const price = hasExactDates
+    ? extractPriceForStay($, capturedAt)
+    : { priceForStay: null };
+  const roomCount = $('tr[data-block-id]').length;
+  const availabilityText = cleanText(
+    $('#no_availability_msg .bui-alert__title').first().text(),
+  );
+  const hasExplicitNo =
+    /(?:no availability here between|not available .* for your dates|sold out)/i
+      .test(availabilityText);
+  const alternativeRanges = hasExactDates ? parseAlternativeRanges($) : [];
+  const availableRange = selectAvailableRange(
+    alternativeRanges,
+    input.request,
+  );
+
+  let availability: StaySnapshot['availability'];
+  if (!hasExactDates) {
+    availability = {
+      status: 'unknown',
+      capturedAt,
+      reasonCode: 'dates_not_requested',
+    };
+  } else if (roomCount > 0) {
+    availability = {
+      status: 'yes',
+      capturedAt,
+      reasonCode: 'provider_room_inventory',
+    };
+  } else if (hasExplicitNo && availableRange) {
+    availability = {
+      status: 'partial',
+      capturedAt,
+      reasonCode: 'provider_alternative_range',
+      availableRange,
+    };
+  } else if (hasExplicitNo) {
+    availability = {
+      status: 'no',
+      capturedAt,
+      reasonCode: 'provider_unavailable',
+    };
+  } else {
+    availability = {
+      status: 'unknown',
+      capturedAt,
+      reasonCode: 'availability_extraction_failed',
+    };
+  }
+
+  return {
+    schemaVersion: STAY_SNAPSHOT_SCHEMA_VERSION,
+    request: input.request,
+    priceForStay: price.priceForStay,
+    availability,
+    providerEvidence: {
+      ...(availabilityText ? { availabilityText } : {}),
+      ...(price.priceText ? { priceText: price.priceText } : {}),
+      ...(price.chargesText ? { chargesText: price.chargesText } : {}),
+      ...(alternativeRanges.length > 0 ? { alternativeRanges } : {}),
+    },
+  };
+}

--- a/src/stay-snapshot.ts
+++ b/src/stay-snapshot.ts
@@ -1,0 +1,406 @@
+export const STAY_SNAPSHOT_SCHEMA_VERSION = 1;
+
+export type StaySnapshotPlatform = 'airbnb' | 'booking';
+export type StaySnapshotFreshness = 'fresh' | 'stale' | 'unknown';
+export type StayAvailabilityStatus = 'yes' | 'no' | 'partial' | 'unknown';
+
+export interface StayDateRange {
+  checkIn: string;
+  checkOut: string;
+}
+
+export interface StayRequestFingerprint {
+  platform: StaySnapshotPlatform;
+  listingId: string;
+  checkIn: string | null;
+  checkOut: string | null;
+  adults: number | null;
+  linkedRoomId: string | null;
+}
+
+export interface PriceForStaySnapshot {
+  amount: number;
+  currency: string;
+  basis: 'stay';
+  capturedAt: string;
+  source: string;
+  rateType: 'public';
+  mandatoryChargesResolved: boolean;
+}
+
+export interface StayAvailabilitySnapshot {
+  status: StayAvailabilityStatus;
+  capturedAt: string | null;
+  reasonCode: string;
+  availableRange?: StayDateRange;
+}
+
+export interface StayProviderEvidence {
+  availabilityText?: string;
+  priceText?: string;
+  chargesText?: string;
+  alternativeRanges?: StayDateRange[];
+}
+
+export interface StaySnapshot {
+  schemaVersion: typeof STAY_SNAPSHOT_SCHEMA_VERSION;
+  request: StayRequestFingerprint;
+  priceForStay: PriceForStaySnapshot | null;
+  availability: StayAvailabilitySnapshot;
+  providerEvidence: StayProviderEvidence;
+}
+
+export interface StaySnapshotRefreshAttempt {
+  attemptedAt: string;
+  status: 'succeeded' | 'failed';
+  error: string | null;
+}
+
+export interface StayBookingEligibility {
+  status: 'eligible' | 'excluded' | 'conditional' | 'unknown';
+  actionable: boolean;
+  reasonCode: string;
+  reason: string;
+}
+
+export interface StaySnapshotReadModel extends StaySnapshot {
+  legacy: boolean;
+  freshness: {
+    price: StaySnapshotFreshness;
+    availability: StaySnapshotFreshness;
+  };
+  bookingEligibility: StayBookingEligibility;
+  refreshAttempt: StaySnapshotRefreshAttempt | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isIsoDate(value: unknown): value is string {
+  return (
+    typeof value === 'string'
+    && /^\d{4}-\d{2}-\d{2}$/.test(value)
+    && Number.isFinite(Date.parse(`${value}T00:00:00Z`))
+  );
+}
+
+function parseDateRange(value: unknown): StayDateRange | null {
+  if (!isRecord(value) || !isIsoDate(value.checkIn) || !isIsoDate(value.checkOut)) {
+    return null;
+  }
+  return {
+    checkIn: value.checkIn,
+    checkOut: value.checkOut,
+  };
+}
+
+function parseRequestFingerprint(value: unknown): StayRequestFingerprint | null {
+  if (!isRecord(value)) return null;
+  if (
+    (value.platform !== 'airbnb' && value.platform !== 'booking')
+    || typeof value.listingId !== 'string'
+    || (value.checkIn !== null && !isIsoDate(value.checkIn))
+    || (value.checkOut !== null && !isIsoDate(value.checkOut))
+    || (value.adults !== null
+      && (typeof value.adults !== 'number'
+        || !Number.isInteger(value.adults)
+        || value.adults <= 0))
+    || (value.linkedRoomId !== null && typeof value.linkedRoomId !== 'string')
+  ) {
+    return null;
+  }
+
+  return {
+    platform: value.platform,
+    listingId: value.listingId,
+    checkIn: value.checkIn,
+    checkOut: value.checkOut,
+    adults: value.adults,
+    linkedRoomId: value.linkedRoomId,
+  };
+}
+
+function parsePriceForStay(value: unknown): PriceForStaySnapshot | null {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.amount !== 'number'
+    || !Number.isFinite(value.amount)
+    || value.amount < 0
+    || typeof value.currency !== 'string'
+    || !/^[A-Z]{3}$/.test(value.currency)
+    || value.basis !== 'stay'
+    || typeof value.capturedAt !== 'string'
+    || !Number.isFinite(Date.parse(value.capturedAt))
+    || typeof value.source !== 'string'
+    || value.rateType !== 'public'
+    || typeof value.mandatoryChargesResolved !== 'boolean'
+  ) {
+    return null;
+  }
+
+  return {
+    amount: value.amount,
+    currency: value.currency,
+    basis: 'stay',
+    capturedAt: value.capturedAt,
+    source: value.source,
+    rateType: 'public',
+    mandatoryChargesResolved: value.mandatoryChargesResolved,
+  };
+}
+
+function parseAvailability(value: unknown): StayAvailabilitySnapshot | null {
+  if (!isRecord(value)) return null;
+  if (
+    value.status !== 'yes'
+    && value.status !== 'no'
+    && value.status !== 'partial'
+    && value.status !== 'unknown'
+  ) {
+    return null;
+  }
+  if (
+    (value.capturedAt !== null
+      && (typeof value.capturedAt !== 'string'
+        || !Number.isFinite(Date.parse(value.capturedAt))))
+    || typeof value.reasonCode !== 'string'
+  ) {
+    return null;
+  }
+
+  const availableRange = parseDateRange(value.availableRange);
+  return {
+    status: value.status,
+    capturedAt: value.capturedAt,
+    reasonCode: value.reasonCode,
+    ...(availableRange ? { availableRange } : {}),
+  };
+}
+
+function parseProviderEvidence(value: unknown): StayProviderEvidence {
+  if (!isRecord(value)) return {};
+
+  const alternativeRanges = Array.isArray(value.alternativeRanges)
+    ? value.alternativeRanges
+        .map(parseDateRange)
+        .filter((range): range is StayDateRange => range != null)
+    : [];
+
+  return {
+    ...(typeof value.availabilityText === 'string'
+      ? { availabilityText: value.availabilityText }
+      : {}),
+    ...(typeof value.priceText === 'string'
+      ? { priceText: value.priceText }
+      : {}),
+    ...(typeof value.chargesText === 'string'
+      ? { chargesText: value.chargesText }
+      : {}),
+    ...(alternativeRanges.length > 0 ? { alternativeRanges } : {}),
+  };
+}
+
+export function parseStaySnapshot(value: unknown): StaySnapshot | null {
+  if (!isRecord(value) || value.schemaVersion !== STAY_SNAPSHOT_SCHEMA_VERSION) {
+    return null;
+  }
+
+  const request = parseRequestFingerprint(value.request);
+  const availability = parseAvailability(value.availability);
+  if (!request || !availability) return null;
+
+  const priceForStay =
+    value.priceForStay === null ? null : parsePriceForStay(value.priceForStay);
+  if (value.priceForStay !== null && !priceForStay) return null;
+
+  return {
+    schemaVersion: STAY_SNAPSHOT_SCHEMA_VERSION,
+    request,
+    priceForStay,
+    availability,
+    providerEvidence: parseProviderEvidence(value.providerEvidence),
+  };
+}
+
+/**
+ * A dated details artifact is reusable only when it contains provider evidence
+ * that can improve the exact-stay read model. Undated details remain reusable
+ * because they are not an inventory assertion.
+ */
+export function isStaySnapshotCacheable(snapshot: StaySnapshot): boolean {
+  const requestsDates =
+    snapshot.request.checkIn != null || snapshot.request.checkOut != null;
+  if (!requestsDates) return true;
+
+  return (
+    snapshot.priceForStay != null
+    || (
+      snapshot.availability.status !== 'unknown'
+      && snapshot.availability.capturedAt != null
+    )
+  );
+}
+
+export function parseStaySnapshotRefreshAttempt(
+  value: unknown,
+): StaySnapshotRefreshAttempt | null {
+  if (!isRecord(value)) return null;
+  if (
+    (value.status !== 'succeeded' && value.status !== 'failed')
+    || typeof value.attemptedAt !== 'string'
+    || !Number.isFinite(Date.parse(value.attemptedAt))
+    || (value.error !== null && typeof value.error !== 'string')
+  ) {
+    return null;
+  }
+  return {
+    attemptedAt: value.attemptedAt,
+    status: value.status,
+    error: value.error,
+  };
+}
+
+export function deriveStaySnapshotFreshness(
+  capturedAt: string | null | undefined,
+  ttlMs: number,
+  now: Date | number = Date.now(),
+): StaySnapshotFreshness {
+  if (!capturedAt) return 'unknown';
+  const capturedMs = Date.parse(capturedAt);
+  if (!Number.isFinite(capturedMs) || !Number.isFinite(ttlMs) || ttlMs < 0) {
+    return 'unknown';
+  }
+  if (ttlMs === 0) return 'stale';
+
+  const nowMs = typeof now === 'number' ? now : now.getTime();
+  if (!Number.isFinite(nowMs)) return 'unknown';
+  return Math.max(0, nowMs - capturedMs) <= ttlMs ? 'fresh' : 'stale';
+}
+
+export function getStayBookingEligibility(
+  availability: StayAvailabilitySnapshot,
+  freshness: StaySnapshotFreshness,
+): StayBookingEligibility {
+  if (freshness === 'stale') {
+    return {
+      status: 'conditional',
+      actionable: false,
+      reasonCode: 'availability_stale',
+      reason: `Last known availability (${availability.status}) is stale.`,
+    };
+  }
+  if (freshness === 'unknown') {
+    return {
+      status: 'unknown',
+      actionable: false,
+      reasonCode: 'availability_freshness_unknown',
+      reason: 'Availability freshness is unknown.',
+    };
+  }
+
+  if (availability.status === 'yes') {
+    return {
+      status: 'eligible',
+      actionable: true,
+      reasonCode: 'available',
+      reason: 'Available for the recorded dates and guest count.',
+    };
+  }
+  if (availability.status === 'no') {
+    return {
+      status: 'excluded',
+      actionable: false,
+      reasonCode: availability.reasonCode || 'provider_unavailable',
+      reason: 'Not available for the recorded dates and guest count.',
+    };
+  }
+  if (availability.status === 'partial') {
+    return {
+      status: 'conditional',
+      actionable: false,
+      reasonCode: availability.reasonCode || 'provider_alternative_range',
+      reason: availability.availableRange
+        ? (
+            `Requested stay is unavailable; provider offered `
+            + `${availability.availableRange.checkIn} to `
+            + `${availability.availableRange.checkOut}.`
+          )
+        : 'Requested stay is unavailable; the provider offered different dates.',
+    };
+  }
+  return {
+    status: 'unknown',
+    actionable: false,
+    reasonCode: availability.reasonCode || 'availability_unknown',
+    reason:
+      availability.reasonCode === 'airbnb_inventory_not_verified'
+        ? (
+            'Airbnb public price was captured, but exact-stay inventory '
+            + 'could not be independently verified.'
+          )
+        : 'Availability could not be confirmed.',
+  };
+}
+
+export function buildLegacyStaySnapshot(
+  request: StayRequestFingerprint,
+): StaySnapshot {
+  return {
+    schemaVersion: STAY_SNAPSHOT_SCHEMA_VERSION,
+    request,
+    priceForStay: null,
+    availability: {
+      status: 'unknown',
+      capturedAt: null,
+      reasonCode: 'legacy_snapshot_missing',
+    },
+    providerEvidence: {},
+  };
+}
+
+export function getStaySnapshotReadModel(input: {
+  snapshot: unknown;
+  fallbackRequest: StayRequestFingerprint;
+  refreshAttempt?: unknown;
+  ttlMs: number;
+  now?: Date | number;
+}): StaySnapshotReadModel {
+  const parsed = parseStaySnapshot(input.snapshot);
+  const snapshot = parsed ?? buildLegacyStaySnapshot(input.fallbackRequest);
+  const priceFreshness = deriveStaySnapshotFreshness(
+    snapshot.priceForStay?.capturedAt,
+    input.ttlMs,
+    input.now,
+  );
+  const availabilityFreshness = deriveStaySnapshotFreshness(
+    snapshot.availability.capturedAt,
+    input.ttlMs,
+    input.now,
+  );
+
+  return {
+    ...snapshot,
+    legacy: !parsed,
+    freshness: {
+      price: priceFreshness,
+      availability: availabilityFreshness,
+    },
+    bookingEligibility: getStayBookingEligibility(
+      snapshot.availability,
+      availabilityFreshness,
+    ),
+    refreshAttempt: parseStaySnapshotRefreshAttempt(input.refreshAttempt),
+  };
+}
+
+export function getStaySnapshotAgeMs(
+  capturedAt: string | null | undefined,
+  now: Date | number = Date.now(),
+): number | null {
+  if (!capturedAt) return null;
+  const capturedMs = Date.parse(capturedAt);
+  const nowMs = typeof now === 'number' ? now : now.getTime();
+  if (!Number.isFinite(capturedMs) || !Number.isFinite(nowMs)) return null;
+  return Math.max(0, nowMs - capturedMs);
+}

--- a/src/triage-rubric.ts
+++ b/src/triage-rubric.ts
@@ -1,5 +1,10 @@
 import { createHash } from 'node:crypto';
 import { TRIAGE_RUBRIC_VERSION } from './triage-comparability.js';
+import type {
+  StayAvailabilityStatus,
+  StayDateRange,
+  StaySnapshotFreshness,
+} from './stay-snapshot.js';
 
 export { TRIAGE_RUBRIC_VERSION } from './triage-comparability.js';
 export const REQUIREMENT_SCHEMA_VERSION = '1';
@@ -117,6 +122,14 @@ export interface ComparableStayPrice {
   mandatoryChargesResolved: boolean;
 }
 
+export interface ComparableStayAvailability {
+  status: StayAvailabilityStatus;
+  capturedAt?: string | null;
+  freshness: StaySnapshotFreshness;
+  reasonCode: string;
+  availableRange?: StayDateRange;
+}
+
 export type AffordabilityUnknownReasonCode =
   | 'no_budget_given'
   | 'invalid_budget'
@@ -127,7 +140,12 @@ export type AffordabilityUnknownReasonCode =
   | 'currency_mismatch'
   | 'stay_basis_unresolved'
   | 'mandatory_charges_unresolved'
-  | 'rate_not_public';
+  | 'rate_not_public'
+  | 'stay_unavailable'
+  | 'stay_partially_available'
+  | 'availability_unknown'
+  | 'availability_stale'
+  | 'availability_freshness_unknown';
 
 export interface AffordabilityResult {
   status: 'within' | 'over' | 'unknown';
@@ -149,6 +167,10 @@ export interface AffordabilityResult {
   rateType: ComparableStayPrice['rateType'] | null;
   mandatoryChargesResolved: boolean | null;
   comparablePrice: ComparableStayPrice | null;
+  availabilityStatus: StayAvailabilityStatus | null;
+  availabilityCapturedAt: string | null;
+  availabilityFreshness: StaySnapshotFreshness | null;
+  comparableAvailability: ComparableStayAvailability | null;
 }
 
 const REQUIREMENT_TYPES = new Set<RequirementType>([
@@ -673,10 +695,12 @@ function staleAgeLabel(
 export function computeAffordability(input: {
   budget?: AffordabilityBudget | null;
   price?: ComparableStayPrice | null;
+  availability?: ComparableStayAvailability | null;
   now?: Date;
 }): AffordabilityResult {
   const budget = input.budget ?? null;
   const price = input.price ?? null;
+  const availability = input.availability ?? null;
   const now = input.now ?? new Date();
   const budgetCurrencySnapshot = budget
     ? normalizedCurrency(budget.currency) || null
@@ -696,6 +720,18 @@ export function computeAffordability(input: {
         mandatoryChargesResolved: price.mandatoryChargesResolved,
       }
     : null;
+  const comparableAvailability: ComparableStayAvailability | null =
+    availability
+      ? {
+          status: availability.status,
+          capturedAt: availability.capturedAt ?? null,
+          freshness: availability.freshness,
+          reasonCode: availability.reasonCode,
+          ...(availability.availableRange
+            ? { availableRange: availability.availableRange }
+            : {}),
+        }
+      : null;
 
   const unknown = (
     reasonCode: AffordabilityUnknownReasonCode,
@@ -721,6 +757,10 @@ export function computeAffordability(input: {
     rateType: price?.rateType ?? null,
     mandatoryChargesResolved: price?.mandatoryChargesResolved ?? null,
     comparablePrice,
+    availabilityStatus: availability?.status ?? null,
+    availabilityCapturedAt: availability?.capturedAt ?? null,
+    availabilityFreshness: availability?.freshness ?? null,
+    comparableAvailability,
     ...values,
   });
 
@@ -746,6 +786,54 @@ export function computeAffordability(input: {
     );
   }
   const budgetAmount = minorUnitsToNumber(budgetMinor, budgetDigits);
+
+  if (availability) {
+    const availabilityValues = {
+      budgetAmount,
+      currency: budgetCurrency,
+    };
+    if (availability.freshness === 'stale') {
+      return unknown(
+        'availability_stale',
+        `Availability is stale (${staleAgeLabel(availability.capturedAt, now)}).`,
+        availabilityValues,
+      );
+    }
+    if (availability.freshness !== 'fresh') {
+      return unknown(
+        'availability_freshness_unknown',
+        'Availability freshness is unknown.',
+        availabilityValues,
+      );
+    }
+    if (availability.status === 'no') {
+      return unknown(
+        'stay_unavailable',
+        'The property is unavailable for the recorded dates and guest count.',
+        availabilityValues,
+      );
+    }
+    if (availability.status === 'partial') {
+      return unknown(
+        'stay_partially_available',
+        availability.availableRange
+          ? (
+              `The requested stay is unavailable; the provider offered `
+              + `${availability.availableRange.checkIn} to `
+              + `${availability.availableRange.checkOut}.`
+            )
+          : 'The provider offered only conditional or alternate availability.',
+        availabilityValues,
+      );
+    }
+    if (availability.status !== 'yes') {
+      return unknown(
+        'availability_unknown',
+        'Availability could not be confirmed for the recorded dates and guest count.',
+        availabilityValues,
+      );
+    }
+  }
 
   if (!price) {
     return unknown(
@@ -845,6 +933,10 @@ export function computeAffordability(input: {
       rateType: price.rateType,
       mandatoryChargesResolved: price.mandatoryChargesResolved,
       comparablePrice,
+      availabilityStatus: availability?.status ?? null,
+      availabilityCapturedAt: availability?.capturedAt ?? null,
+      availabilityFreshness: availability?.freshness ?? null,
+      comparableAvailability,
     };
   }
 
@@ -873,6 +965,10 @@ export function computeAffordability(input: {
     rateType: price.rateType,
     mandatoryChargesResolved: price.mandatoryChargesResolved,
     comparablePrice,
+    availabilityStatus: availability?.status ?? null,
+    availabilityCapturedAt: availability?.capturedAt ?? null,
+    availabilityFreshness: availability?.freshness ?? null,
+    comparableAvailability,
   };
 }
 
@@ -926,6 +1022,47 @@ function parseStoredComparablePrice(
   };
 }
 
+function parseStoredComparableAvailability(
+  value: unknown,
+): ComparableStayAvailability | null | undefined {
+  if (value === null) return null;
+  const record = asStoredRecord(value);
+  if (!record) return undefined;
+  const status = record.status;
+  const capturedAt = record.capturedAt;
+  const freshness = record.freshness;
+  const reasonCode = record.reasonCode;
+  const availableRange = asStoredRecord(record.availableRange);
+  if (
+    (status !== 'yes' && status !== 'no'
+      && status !== 'partial' && status !== 'unknown')
+    || (capturedAt !== null && capturedAt !== undefined
+      && typeof capturedAt !== 'string')
+    || (freshness !== 'fresh' && freshness !== 'stale'
+      && freshness !== 'unknown')
+    || typeof reasonCode !== 'string'
+  ) {
+    return undefined;
+  }
+
+  const parsedRange =
+    availableRange
+    && typeof availableRange.checkIn === 'string'
+    && typeof availableRange.checkOut === 'string'
+      ? {
+          checkIn: availableRange.checkIn,
+          checkOut: availableRange.checkOut,
+        }
+      : undefined;
+  return {
+    status,
+    capturedAt: typeof capturedAt === 'string' ? capturedAt : null,
+    freshness,
+    reasonCode,
+    ...(parsedRange ? { availableRange: parsedRange } : {}),
+  };
+}
+
 /**
  * Recalculate only the affordability dimension from a persisted rubric result.
  * Returns null for pre-snapshot records so callers preserve old JSON rather than
@@ -945,9 +1082,17 @@ export function recomputeStoredAffordability(input: {
   }
   const price = parseStoredComparablePrice(stored.comparablePrice);
   if (price === undefined) return null;
+  const availability = Object.prototype.hasOwnProperty.call(
+    stored,
+    'comparableAvailability',
+  )
+    ? parseStoredComparableAvailability(stored.comparableAvailability)
+    : null;
+  if (availability === undefined) return null;
   return computeAffordability({
     budget: input.budget ?? null,
     price,
+    availability,
     now: input.now,
   });
 }

--- a/src/triage.ts
+++ b/src/triage.ts
@@ -14,10 +14,12 @@ import {
   type AffordabilityBudget,
   type CanonicalRequirementInput,
   type CanonicalRequirementSet,
+  type ComparableStayAvailability,
   type ComparableStayPrice,
   type ParsedAnalysisBudget,
   type RequirementAssessmentInput,
 } from './triage-rubric.js';
+import { parseStaySnapshot } from './stay-snapshot.js';
 import {
   LEGACY_TRIAGE_CLASSIFIER_VERSION,
   TRIAGE_CLASSIFIER_VERSION,
@@ -43,6 +45,7 @@ export interface TriageOptions {
   temperature?: number;      // Classification temperature. Default: 0
   budget?: AffordabilityBudget;
   price?: ComparableStayPrice;
+  availability?: ComparableStayAvailability;
   priceFreshness?: ComparableStayPrice['freshness'];
   stayContext?: TriageStayContext;
   /** Evaluation/backfill only. Product calls always use the current policy. */
@@ -714,6 +717,14 @@ export function extractComparableStayPrice(
   listing: any,
   freshness: ComparableStayPrice['freshness'] = 'unknown',
 ): ComparableStayPrice | null {
+  const staySnapshot = parseStaySnapshot(listing?.staySnapshot);
+  if (staySnapshot?.priceForStay) {
+    return {
+      ...staySnapshot.priceForStay,
+      freshness,
+    };
+  }
+
   const pricing = listing?.pricing;
   if (!pricing || typeof pricing !== 'object') return null;
 
@@ -797,6 +808,26 @@ export function extractComparableStayPrice(
     }
   }
   return null;
+}
+
+export function extractComparableStayAvailability(
+  listing: any,
+  freshness: ComparableStayAvailability['freshness'] = 'unknown',
+): ComparableStayAvailability {
+  const staySnapshot = parseStaySnapshot(listing?.staySnapshot);
+  if (!staySnapshot) {
+    return {
+      status: 'unknown',
+      capturedAt: null,
+      freshness: 'unknown',
+      reasonCode: 'legacy_snapshot_missing',
+    };
+  }
+
+  return {
+    ...staySnapshot.availability,
+    freshness,
+  };
 }
 
 function deterministicTierReason(
@@ -995,7 +1026,17 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
       listingData,
       options.priceFreshness ?? 'unknown',
     );
-  const affordability = computeAffordability({ budget, price });
+  const availability =
+    options.availability
+    ?? extractComparableStayAvailability(
+      listingData,
+      options.priceFreshness ?? 'unknown',
+    );
+  const affordability = computeAffordability({
+    budget,
+    price,
+    availability,
+  });
   const triageData = {
     ...parsed,
     ...score,

--- a/tests/artifact-cache.test.ts
+++ b/tests/artifact-cache.test.ts
@@ -29,7 +29,7 @@ test('cache policy uses the approved TTLs and supports per-artifact opt-out', ()
   assert.equal(policy.ttlMs.photos, 365 * DAY_MS);
 
   const defaults = resolveArtifactCachePolicy({});
-  assert.equal(defaults.ttlMs.details, 7 * DAY_MS);
+  assert.equal(defaults.ttlMs.details, DAY_MS);
   assert.equal(defaults.ttlMs.reviews, 30 * DAY_MS);
   assert.equal(defaults.ttlMs.photos, 180 * DAY_MS);
   assert.match(defaults.rootDir, /\.cache[/\\]reviewr[/\\]artifacts-v1$/);
@@ -66,9 +66,9 @@ test('details cache isolates request variants and expires from metadata time', (
     const metadata = cache.publishFile(key, sourcePath);
     assert.equal(metadata?.cachedAt, '2026-07-23T10:00:00.000Z');
 
-    now += 6 * DAY_MS;
+    now += DAY_MS / 2;
     const hit = cache.restoreFile(key, restoredPath);
-    assert.equal(hit?.ageMs, 6 * DAY_MS);
+    assert.equal(hit?.ageMs, DAY_MS / 2);
     assert.deepEqual(JSON.parse(fs.readFileSync(restoredPath, 'utf-8')), {
       title: 'Fresh details',
     });
@@ -84,7 +84,7 @@ test('details cache isolates request variants and expires from metadata time', (
     };
     assert.equal(cache.restoreFile(differentDates, restoredPath), null);
 
-    now += DAY_MS + 1;
+    now += DAY_MS / 2 + 1;
     assert.equal(cache.restoreFile(key, restoredPath), null);
     assert.equal(fs.existsSync(cache.getEntryPath(key)), false);
   } finally {

--- a/tests/fixtures/booking-stay-snapshots/conrad-sold-out.html
+++ b/tests/fixtures/booking-stay-snapshots/conrad-sold-out.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!--
+  Provider evidence captured from the public Booking.com property page on
+  2026-07-26 for Conrad New York Downtown, 2026-07-29 through 2026-08-11,
+  two adults. The fixture is intentionally reduced to the availability DOM.
+-->
+<html>
+  <body>
+    <div id="available_rooms">
+      <div id="no_availability_msg" class="highlight_msg no_availability_msg_light">
+        <div class="bui-alert bui-alert--error bui-alert--large" role="status">
+          <div class="bui-alert__description">
+            <span class="bui-alert__title">
+              We have no availability here between Wed 29 Jul 2026 and Tue 11 Aug 2026
+            </span>
+            <p class="bui-alert__text">
+              Select different dates to see more availability
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/booking-stay-snapshots/extraction-unknown.html
+++ b/tests/fixtures/booking-stay-snapshots/extraction-unknown.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <section data-testid="property-description">
+      Property details loaded, but the exact-date inventory component did not.
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/booking-stay-snapshots/residence-inn-available.html
+++ b/tests/fixtures/booking-stay-snapshots/residence-inn-available.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<!--
+  Provider evidence captured from the public Booking.com property page on
+  2026-07-26 for Residence Inn New York Manhattan/Central Park,
+  2026-07-31 through 2026-08-11, two adults.
+-->
+<html>
+  <body>
+    <div>Prices converted to PLN</div>
+    <table id="hprt-table" class="hprt-table">
+      <thead>
+        <tr>
+          <th>Price for 11 nights</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr data-block-id="58743903_356520370_0_41_0">
+          <th>
+            <a class="hprt-roomtype-link">Deluxe Studio with Times Square View</a>
+          </th>
+          <td>Max persons: 2</td>
+          <td>
+            <div class="prco-valign-middle-helper">18,627 zł</div>
+            <div>Price 18,627 zł</div>
+            <div>Includes taxes and charges</div>
+          </td>
+          <td>We have 5 left</td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/tests/fixtures/booking-stay-snapshots/residence-inn-partial.html
+++ b/tests/fixtures/booking-stay-snapshots/residence-inn-partial.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<!--
+  Provider evidence captured from the public Booking.com property page on
+  2026-07-26 for Residence Inn New York Manhattan/Central Park. Booking
+  refused 2026-08-02 through 2026-08-11 and volunteered alternate ranges,
+  including the approved 2026-07-31 through 2026-08-11 boundary fixture.
+-->
+<html>
+  <body>
+    <div id="available_rooms">
+      <div id="no_availability_msg" class="highlight_msg no_availability_msg_light">
+        <div class="bui-alert bui-alert--error bui-alert--large" role="status">
+          <div class="bui-alert__description">
+            <span class="bui-alert__title">
+              We have no availability here between Sun 2 Aug 2026 and Tue 11 Aug 2026
+            </span>
+            <p class="bui-alert__text">
+              Select different dates to see more availability
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="change_dates">
+        <div
+          class="c-next-available-dates--pp"
+          data-param-checkin="2026-08-02"
+          data-param-checkout="2026-08-11"
+        >
+          <div>Alternative dates</div>
+          <div>
+            If you’re flexible, these dates are available for Residence Inn by Marriott
+            New York Manhattan/Central Park:
+          </div>
+          <a
+            class="c-next-available-dates__item"
+            href="/searchresults.en-gb.html?checkin=2026-07-31&amp;checkout=2026-08-06&amp;highlighted_hotels=587439"
+          >
+            31 Jul – 6 Aug
+          </a>
+          <a
+            class="c-next-available-dates__item"
+            href="/searchresults.en-gb.html?checkin=2026-08-01&amp;checkout=2026-08-11&amp;highlighted_hotels=587439"
+          >
+            1 Aug – 11 Aug
+          </a>
+          <a
+            class="c-next-available-dates__item"
+            href="/searchresults.en-gb.html?checkin=2026-07-31&amp;checkout=2026-08-11&amp;highlighted_hotels=587439"
+          >
+            31 Jul – 11 Aug
+          </a>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/results-rubric.test.ts
+++ b/tests/results-rubric.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   getActiveTriageComparison,
   getActiveRequirementSetId,
+  getBookingEligibilityRank,
   getListingResultsSnapshot,
   getTriageComparisonStatus,
   getTriageRegradeListingCount,
@@ -65,6 +66,20 @@ test('missing rubric metadata is explicitly parsed as a legacy AI score', () => 
   assert.equal(snapshot.triage?.requirementSetId, null);
   assert.equal(snapshot.triage?.requirements[0].label, 'Quiet');
   assert.equal(snapshot.triage?.requirements[0].requirementId, null);
+});
+
+test('booking eligibility groups fresh unavailable listings after conditional results', () => {
+  const rank = (status: 'eligible' | 'conditional' | 'unknown' | 'excluded') =>
+    getBookingEligibilityRank({
+      staySnapshot: {
+        bookingEligibility: { status },
+      },
+    } as unknown as Pick<ReviewJobListing, 'staySnapshot'>);
+
+  assert.equal(rank('eligible'), 0);
+  assert.equal(rank('conditional'), 1);
+  assert.equal(rank('unknown'), 1);
+  assert.equal(rank('excluded'), 2);
 });
 
 test('deterministic metadata and affordability reason survive parsing', () => {

--- a/tests/review-job-analysis.test.ts
+++ b/tests/review-job-analysis.test.ts
@@ -6,14 +6,18 @@ import * as path from 'node:path';
 
 import {
   getPoiDistanceMeters,
+  getListingMatchKey,
   getManifestPathFromRoot,
   getReviewJobRunDir,
   injectPoiContextIntoListingArtifacts,
+  prepareReviewJobPriceRefreshWorkspace,
   prepareReviewJobRunWorkspace,
   pruneAnalysisManifestToListings,
   readJsonFile,
+  reconcilePriceRefreshManifest,
   summarizeAnalysisStatus,
   summarizeManifestEntryStatus,
+  writeJsonFile,
   type AnalysisManifest,
 } from '../web/src/lib/review-job-analysis.js';
 import { REVIEW_JOB_ARTIFACT_DIR_ENV } from '../web/src/lib/reviewJobArtifacts.js';
@@ -329,5 +333,218 @@ test('prepareReviewJobRunWorkspace stages a fresh rerun with AI outputs invalida
     }
     fs.rmSync(sourceRoot, { recursive: true, force: true });
     fs.rmSync(artifactStore, { recursive: true, force: true });
+  }
+});
+
+test('price refresh staging preserves non-detail artifacts and restores last known details on failure', () => {
+  const artifactStore = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'review-job-price-refresh-store-'),
+  );
+  const sourceRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'review-job-price-refresh-source-'),
+  );
+  const previousArtifactDir = process.env[REVIEW_JOB_ARTIFACT_DIR_ENV];
+  process.env[REVIEW_JOB_ARTIFACT_DIR_ENV] = artifactStore;
+
+  const url = 'https://www.booking.com/hotel/us/example.en-gb.html';
+  const entry: AnalysisManifest['listings'][string] = {
+    platform: 'booking',
+    id: 'example',
+    url,
+    details: {
+      status: 'fetched',
+      file: 'listings/listing_example.json',
+      source: 'network',
+    },
+    reviews: {
+      status: 'fetched',
+      file: 'reviews/example_reviews.json',
+    },
+    photos: { status: 'fetched', dir: 'photos/example' },
+    aiReviews: { status: 'fetched', file: 'ai-reviews/example.json' },
+    aiPhotos: { status: 'fetched', file: 'ai-photos/example.json' },
+    triage: { status: 'fetched', file: 'triage/example.json' },
+  };
+  const manifest: AnalysisManifest = {
+    version: 2,
+    createdAt: '2026-07-25T12:00:00.000Z',
+    updatedAt: '2026-07-25T12:00:00.000Z',
+    dates: {
+      checkIn: '2026-08-02',
+      checkOut: '2026-08-11',
+      adults: 2,
+    },
+    listings: { 'booking/example': entry },
+  };
+  const oldDetails = {
+    title: 'Last known details',
+    staySnapshot: {
+      schemaVersion: 1,
+      request: {
+        platform: 'booking',
+        listingId: 'us/example',
+        checkIn: '2026-08-02',
+        checkOut: '2026-08-11',
+        adults: 2,
+        linkedRoomId: null,
+      },
+      priceForStay: {
+        amount: 900,
+        currency: 'USD',
+        basis: 'stay',
+        capturedAt: '2026-07-25T12:00:00.000Z',
+        source: 'booking_property_page',
+        rateType: 'public',
+        mandatoryChargesResolved: true,
+      },
+      availability: {
+        status: 'yes',
+        capturedAt: '2026-07-25T12:00:00.000Z',
+        reasonCode: 'provider_room_inventory',
+      },
+      providerEvidence: {},
+    },
+  };
+
+  try {
+    for (const dir of [
+      'listings',
+      'reviews',
+      'photos/example',
+      'ai-reviews',
+      'ai-photos',
+      'triage',
+    ]) {
+      fs.mkdirSync(path.join(sourceRoot, dir), { recursive: true });
+    }
+    writeJsonFile(getManifestPathFromRoot(sourceRoot), manifest);
+    writeJsonFile(path.join(sourceRoot, entry.details.file!), oldDetails);
+    writeJsonFile(path.join(sourceRoot, entry.reviews.file!), []);
+    writeJsonFile(path.join(sourceRoot, entry.aiReviews.file!), { kept: true });
+    writeJsonFile(path.join(sourceRoot, entry.aiPhotos.file!), { kept: true });
+    writeJsonFile(path.join(sourceRoot, entry.triage.file!), { kept: true });
+    fs.writeFileSync(path.join(sourceRoot, 'photos/example/01.jpg'), 'photo');
+
+    const staged = prepareReviewJobPriceRefreshWorkspace({
+      jobId: 'job_price_refresh',
+      runId: 'run_failed',
+      previousArtifactRoot: sourceRoot,
+      dates: {
+        checkIn: '2026-08-02',
+        checkOut: '2026-08-11',
+        adults: 2,
+      },
+    });
+    const failedManifest = readJsonFile<AnalysisManifest>(
+      getManifestPathFromRoot(staged.rootDir),
+    );
+    assert.ok(failedManifest);
+    failedManifest.listings['booking/example'].details = {
+      status: 'failed',
+      error: 'provider timeout',
+    };
+    writeJsonFile(getManifestPathFromRoot(staged.rootDir), failedManifest);
+    writeJsonFile(
+      path.join(staged.rootDir, entry.details.file!),
+      { title: 'corrupt replacement' },
+    );
+
+    const outcomes = reconcilePriceRefreshManifest({
+      rootDir: staged.rootDir,
+      previousArtifactRoot: sourceRoot,
+      previousManifest: staged.previousManifest,
+      targetKeys: new Set([getListingMatchKey('booking', url)]),
+    });
+    assert.equal(outcomes[0].status, 'failed');
+    assert.match(outcomes[0].error ?? '', /provider timeout/);
+    assert.deepEqual(
+      readJsonFile(path.join(staged.rootDir, entry.details.file!)),
+      oldDetails,
+    );
+    assert.deepEqual(
+      readJsonFile(path.join(staged.rootDir, entry.aiReviews.file!)),
+      { kept: true },
+    );
+    assert.deepEqual(
+      readJsonFile(path.join(staged.rootDir, entry.aiPhotos.file!)),
+      { kept: true },
+    );
+    assert.deepEqual(
+      readJsonFile(path.join(staged.rootDir, entry.triage.file!)),
+      { kept: true },
+    );
+    assert.equal(
+      fs.readFileSync(
+        path.join(staged.rootDir, 'photos/example/01.jpg'),
+        'utf8',
+      ),
+      'photo',
+    );
+
+    const successful = prepareReviewJobPriceRefreshWorkspace({
+      jobId: 'job_price_refresh',
+      runId: 'run_successful',
+      previousArtifactRoot: sourceRoot,
+      dates: {
+        checkIn: '2026-08-02',
+        checkOut: '2026-08-11',
+        adults: 2,
+      },
+    });
+    const nextDetails = {
+      ...oldDetails,
+      title: 'Refreshed details',
+      staySnapshot: {
+        ...oldDetails.staySnapshot,
+        priceForStay: {
+          ...oldDetails.staySnapshot.priceForStay,
+          amount: 950,
+          capturedAt: '2026-07-26T18:00:00.000Z',
+        },
+        availability: {
+          status: 'no',
+          capturedAt: '2026-07-26T18:00:00.000Z',
+          reasonCode: 'provider_unavailable',
+        },
+      },
+    };
+    writeJsonFile(
+      path.join(successful.rootDir, entry.details.file!),
+      nextDetails,
+    );
+    const successfulManifest = readJsonFile<AnalysisManifest>(
+      getManifestPathFromRoot(successful.rootDir),
+    );
+    assert.ok(successfulManifest);
+    successfulManifest.listings['booking/example'].details = {
+      status: 'fetched',
+      file: entry.details.file,
+      source: 'network',
+    };
+    writeJsonFile(
+      getManifestPathFromRoot(successful.rootDir),
+      successfulManifest,
+    );
+    const successfulOutcomes = reconcilePriceRefreshManifest({
+      rootDir: successful.rootDir,
+      previousArtifactRoot: sourceRoot,
+      previousManifest: successful.previousManifest,
+      targetKeys: new Set([getListingMatchKey('booking', url)]),
+    });
+    assert.equal(successfulOutcomes[0].status, 'succeeded');
+    assert.equal(successfulOutcomes[0].snapshot?.priceForStay?.amount, 950);
+    assert.equal(successfulOutcomes[0].snapshot?.availability.status, 'no');
+    assert.deepEqual(
+      readJsonFile(path.join(successful.rootDir, entry.aiReviews.file!)),
+      { kept: true },
+    );
+  } finally {
+    if (previousArtifactDir == null) {
+      delete process.env[REVIEW_JOB_ARTIFACT_DIR_ENV];
+    } else {
+      process.env[REVIEW_JOB_ARTIFACT_DIR_ENV] = previousArtifactDir;
+    }
+    fs.rmSync(artifactStore, { recursive: true, force: true });
+    fs.rmSync(sourceRoot, { recursive: true, force: true });
   }
 });

--- a/tests/review-job-persistence.test.ts
+++ b/tests/review-job-persistence.test.ts
@@ -18,6 +18,8 @@ function makeJob(overrides: Record<string, unknown> = {}) {
     currentPhase: 'results-ready',
     analysisStatus: 'completed',
     analysisCurrentPhase: 'completed',
+    priceRefreshStatus: 'pending',
+    priceRefreshCurrentPhase: null,
     location: 'London',
     prompt: 'quiet and close to POI',
     boundingBox: null,
@@ -40,6 +42,7 @@ function makeJob(overrides: Record<string, unknown> = {}) {
     errorMessage: null,
     queueJobId: null,
     analysisQueueJobId: null,
+    priceRefreshQueueJobId: null,
     artifactRoot: null,
     reportPath: null,
     createdAt: new Date('2026-03-14T00:00:00.000Z'),
@@ -51,6 +54,12 @@ function makeJob(overrides: Record<string, unknown> = {}) {
     analysisStartedAt: new Date('2026-03-14T00:03:00.000Z'),
     analysisCompletedAt: new Date('2026-03-14T00:04:00.000Z'),
     analysisDurationMs: 60000,
+    priceRefreshProgress: 0,
+    priceRefreshErrorMessage: null,
+    priceRefreshSummary: null,
+    priceRefreshStartedAt: null,
+    priceRefreshCompletedAt: null,
+    priceRefreshDurationMs: null,
     aiReviewsCostUsd: 0.0142,
     aiPhotosCostUsd: 0.0061,
     triageCostUsd: 0.0027,
@@ -87,8 +96,11 @@ function makeListing(overrides: Record<string, unknown> = {}) {
     stars: null,
     freeCancellation: null,
     selected: true,
+    liked: false,
     hidden: false,
     poiDistanceMeters: 42,
+    staySnapshot: null,
+    priceRefreshAttempt: null,
     createdAt: new Date('2026-03-14T00:00:00.000Z'),
     analysis: {
       id: 'analysis_1',
@@ -203,6 +215,121 @@ test('explicit full-stay analysis budget is exposed independently of search curr
   assert.equal(response.job.currency, 'PLN');
   assert.equal(response.job.analysisBudgetAmount, 4500);
   assert.equal(response.job.analysisBudgetCurrency, 'USD');
+});
+
+test('exact-stay snapshots override search pricing and fresh unavailability is excluded', () => {
+  const capturedAt = new Date().toISOString();
+  const staySnapshot = {
+    schemaVersion: 1,
+    request: {
+      platform: 'booking',
+      listingId: 'us/test-listing',
+      checkIn: '2026-03-20',
+      checkOut: '2026-03-29',
+      adults: 2,
+      linkedRoomId: null,
+    },
+    priceForStay: {
+      amount: 1500,
+      currency: 'USD',
+      basis: 'stay',
+      capturedAt,
+      source: 'booking_property_page',
+      rateType: 'public',
+      mandatoryChargesResolved: true,
+    },
+    availability: {
+      status: 'no',
+      capturedAt,
+      reasonCode: 'provider_unavailable',
+    },
+    providerEvidence: {
+      availabilityText: 'No availability for the requested dates',
+    },
+  };
+  const response = toReviewJobResponse({
+    job: makeJob({
+      analysisBudgetAmount: 2000,
+      analysisBudgetCurrency: 'USD',
+    }),
+    listings: [
+      makeListing({
+        platform: 'booking',
+        staySnapshot,
+        priceRefreshAttempt: {
+          attemptedAt: capturedAt,
+          status: 'succeeded',
+          error: null,
+        },
+      }),
+    ],
+    events: [],
+  });
+
+  assert.equal(response.listings[0].pricing?.total?.amount, 1500);
+  assert.equal(response.listings[0].staySnapshot.freshness.price, 'fresh');
+  assert.equal(
+    response.listings[0].staySnapshot.bookingEligibility.status,
+    'excluded',
+  );
+  assert.equal(response.listings[0].affordability.reasonCode, 'stay_unavailable');
+});
+
+test('legacy listing details expose unknown freshness without inventing a capture time', () => {
+  const response = toReviewJobResponse({
+    job: makeJob(),
+    listings: [
+      makeListing({
+        staySnapshot: null,
+        analysis: {
+          ...makeListing().analysis,
+          details: { title: 'Legacy details' },
+        },
+      }),
+    ],
+    events: [],
+  });
+
+  assert.equal(response.listings[0].staySnapshot.legacy, true);
+  assert.equal(response.listings[0].staySnapshot.availability.capturedAt, null);
+  assert.equal(
+    response.listings[0].staySnapshot.freshness.availability,
+    'unknown',
+  );
+  assert.equal(
+    response.listings[0].staySnapshot.bookingEligibility.status,
+    'unknown',
+  );
+});
+
+test('price refresh progress and partial counts serialize independently of analysis', () => {
+  const response = toReviewJobResponse({
+    job: makeJob({
+      priceRefreshStatus: 'partial',
+      priceRefreshCurrentPhase: 'completed',
+      priceRefreshProgress: 1,
+      priceRefreshErrorMessage:
+        '1 of 2 price refreshes failed; last known snapshots were preserved.',
+      priceRefreshSummary: {
+        requested: 2,
+        succeeded: 1,
+        failed: 1,
+      },
+      priceRefreshStartedAt: new Date('2026-07-26T18:00:00.000Z'),
+      priceRefreshCompletedAt: new Date('2026-07-26T18:01:00.000Z'),
+      priceRefreshDurationMs: 60000,
+    }),
+    listings: [makeListing()],
+    events: [],
+  });
+
+  assert.equal(response.job.priceRefreshStatus, 'partial');
+  assert.deepEqual(response.job.priceRefreshSummary, {
+    requested: 2,
+    succeeded: 1,
+    failed: 1,
+  });
+  assert.equal(response.job.priceRefreshDurationMs, 60000);
 });
 
 test('legacy html export availability remains separate from native results readiness', () => {

--- a/tests/review-job-queue.test.ts
+++ b/tests/review-job-queue.test.ts
@@ -14,6 +14,10 @@ test('review-job queue ids are deterministic per phase and job', () => {
     getReviewJobQueueJobId('analyze', 'job_123'),
     'review-job:analyze:job_123',
   );
+  assert.equal(
+    getReviewJobQueueJobId('refresh-prices', 'job_123'),
+    'review-job:refresh-prices:job_123',
+  );
 });
 
 test('review-job queue reuses only active queued states', () => {

--- a/tests/stay-snapshot.test.ts
+++ b/tests/stay-snapshot.test.ts
@@ -1,0 +1,343 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { parseAirbnbStaySnapshot } from '../src/airbnb/stay-snapshot.js';
+import { parseBookingStaySnapshot } from '../src/booking/stay-snapshot.js';
+import {
+  deriveStaySnapshotFreshness,
+  getStayBookingEligibility,
+  getStaySnapshotReadModel,
+  isStaySnapshotCacheable,
+  type StayRequestFingerprint,
+} from '../src/stay-snapshot.js';
+
+const CAPTURED_AT = '2026-07-26T18:00:00.000Z';
+const DAY_MS = 24 * 60 * 60 * 1000;
+const fixtureDir = path.resolve('tests/fixtures/booking-stay-snapshots');
+
+function fixture(name: string): string {
+  return fs.readFileSync(path.join(fixtureDir, name), 'utf8');
+}
+
+function bookingRequest(
+  overrides: Partial<StayRequestFingerprint> = {},
+): StayRequestFingerprint {
+  return {
+    platform: 'booking',
+    listingId: 'us/example-property',
+    checkIn: '2026-07-29',
+    checkOut: '2026-08-11',
+    adults: 2,
+    linkedRoomId: '58743903',
+    ...overrides,
+  };
+}
+
+function airbnbRequest(
+  overrides: Partial<StayRequestFingerprint> = {},
+): StayRequestFingerprint {
+  return {
+    platform: 'airbnb',
+    listingId: '123456789',
+    checkIn: '2026-08-02',
+    checkOut: '2026-08-11',
+    adults: 2,
+    linkedRoomId: null,
+    ...overrides,
+  };
+}
+
+test('Booking fixture records a fresh public stay price and exact request identity', () => {
+  const request = bookingRequest({
+    listingId: 'us/residence-inn-by-marriott-new-york-manhattan-central-park-new-york',
+    checkIn: '2026-07-31',
+  });
+  const snapshot = parseBookingStaySnapshot({
+    html: fixture('residence-inn-available.html'),
+    request,
+    capturedAt: CAPTURED_AT,
+  });
+
+  assert.deepEqual(snapshot.request, request);
+  assert.deepEqual(snapshot.priceForStay, {
+    amount: 18627,
+    currency: 'PLN',
+    basis: 'stay',
+    capturedAt: CAPTURED_AT,
+    source: 'booking_property_page',
+    rateType: 'public',
+    mandatoryChargesResolved: true,
+  });
+  assert.deepEqual(snapshot.availability, {
+    status: 'yes',
+    capturedAt: CAPTURED_AT,
+    reasonCode: 'provider_room_inventory',
+  });
+});
+
+test('Booking fixture distinguishes sold out from extraction failure', () => {
+  const soldOut = parseBookingStaySnapshot({
+    html: fixture('conrad-sold-out.html'),
+    request: bookingRequest({
+      listingId: 'us/e-suites-new-york-new-york-new-york',
+    }),
+    capturedAt: CAPTURED_AT,
+  });
+  assert.equal(soldOut.availability.status, 'no');
+  assert.equal(soldOut.availability.reasonCode, 'provider_unavailable');
+  assert.equal(soldOut.priceForStay, null);
+
+  const extractionFailure = parseBookingStaySnapshot({
+    html: fixture('extraction-unknown.html'),
+    request: bookingRequest(),
+    capturedAt: CAPTURED_AT,
+  });
+  assert.equal(extractionFailure.availability.status, 'unknown');
+  assert.equal(
+    extractionFailure.availability.reasonCode,
+    'availability_extraction_failed',
+  );
+  assert.equal(isStaySnapshotCacheable(extractionFailure), false);
+});
+
+test('Booking partial inventory uses only provider-volunteered alternate ranges', () => {
+  const snapshot = parseBookingStaySnapshot({
+    html: fixture('residence-inn-partial.html'),
+    request: bookingRequest({
+      listingId: 'us/residence-inn-by-marriott-new-york-manhattan-central-park-new-york',
+      checkIn: '2026-08-02',
+    }),
+    capturedAt: CAPTURED_AT,
+  });
+
+  assert.deepEqual(snapshot.availability, {
+    status: 'partial',
+    capturedAt: CAPTURED_AT,
+    reasonCode: 'provider_alternative_range',
+    availableRange: {
+      checkIn: '2026-07-31',
+      checkOut: '2026-08-11',
+    },
+  });
+  assert.deepEqual(snapshot.providerEvidence.alternativeRanges, [
+    { checkIn: '2026-07-31', checkOut: '2026-08-06' },
+    { checkIn: '2026-08-01', checkOut: '2026-08-11' },
+    { checkIn: '2026-07-31', checkOut: '2026-08-11' },
+  ]);
+});
+
+test('Airbnb price quote stays availability-unknown and an explicit refusal is unavailable', () => {
+  const quoted = parseAirbnbStaySnapshot({
+    request: airbnbRequest(),
+    capturedAt: CAPTURED_AT,
+    currency: 'USD',
+    sections: [
+      {
+        sectionId: 'BOOK_IT_SIDEBAR',
+        section: {
+          structuredDisplayPrice: {
+            primaryLine: {
+              price: '$1,234',
+              priceQualifier: 'total',
+              accessibilityLabel: '$1,234 total',
+            },
+            explanationData: {
+              priceDetails: [
+                {
+                  items: [
+                    { description: '9 nights x $120', priceString: '$1,080' },
+                    { description: 'Total', priceString: '$1,234' },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  });
+  assert.equal(quoted.availability.status, 'unknown');
+  assert.equal(
+    quoted.availability.reasonCode,
+    'airbnb_inventory_not_verified',
+  );
+  assert.deepEqual(quoted.priceForStay, {
+    amount: 1234,
+    currency: 'USD',
+    basis: 'stay',
+    capturedAt: CAPTURED_AT,
+    source: 'airbnb_pdp',
+    rateType: 'public',
+    mandatoryChargesResolved: true,
+  });
+  assert.equal(isStaySnapshotCacheable(quoted), true);
+  const quotedReadModel = getStaySnapshotReadModel({
+    snapshot: quoted,
+    fallbackRequest: airbnbRequest(),
+    ttlMs: DAY_MS,
+    now: Date.parse(CAPTURED_AT),
+  });
+  assert.equal(quotedReadModel.bookingEligibility.status, 'unknown');
+  assert.match(
+    quotedReadModel.bookingEligibility.reason,
+    /inventory could not be independently verified/,
+  );
+
+  const refused = parseAirbnbStaySnapshot({
+    request: airbnbRequest(),
+    capturedAt: CAPTURED_AT,
+    sections: [
+      {
+        sectionId: 'AVAILABILITY_CALENDAR',
+        section: {
+          title: 'These dates are not available',
+        },
+      },
+    ],
+  });
+  assert.equal(refused.availability.status, 'no');
+  assert.equal(refused.availability.reasonCode, 'provider_unavailable');
+  assert.equal(refused.priceForStay, null);
+});
+
+test('undated details remain cacheable without inventory evidence', () => {
+  const snapshot = parseBookingStaySnapshot({
+    html: fixture('extraction-unknown.html'),
+    request: bookingRequest({
+      checkIn: null,
+      checkOut: null,
+      adults: null,
+      linkedRoomId: null,
+    }),
+    capturedAt: CAPTURED_AT,
+  });
+
+  assert.equal(snapshot.availability.status, 'unknown');
+  assert.equal(snapshot.priceForStay, null);
+  assert.equal(isStaySnapshotCacheable(snapshot), true);
+});
+
+test('Airbnb marks partial only when the provider volunteers alternate evidence', () => {
+  const volunteered = parseAirbnbStaySnapshot({
+    request: airbnbRequest(),
+    capturedAt: CAPTURED_AT,
+    sections: [
+      {
+        sectionId: 'AVAILABILITY_CALENDAR',
+        section: {
+          title: 'Choose different dates',
+          suggestedDates: {
+            checkIn: '2026-07-31',
+            checkOut: '2026-08-11',
+          },
+        },
+      },
+    ],
+  });
+  assert.equal(volunteered.availability.status, 'partial');
+  assert.deepEqual(volunteered.availability.availableRange, {
+    checkIn: '2026-07-31',
+    checkOut: '2026-08-11',
+  });
+
+  const rangeWithoutProviderStatement = parseAirbnbStaySnapshot({
+    request: airbnbRequest(),
+    capturedAt: CAPTURED_AT,
+    sections: [
+      {
+        sectionId: 'AVAILABILITY_CALENDAR',
+        section: {
+          calendarWindow: {
+            checkIn: '2026-07-31',
+            checkOut: '2026-08-11',
+          },
+        },
+      },
+    ],
+  });
+  assert.equal(rangeWithoutProviderStatement.availability.status, 'unknown');
+
+  const genericCalendarWindow = parseAirbnbStaySnapshot({
+    request: airbnbRequest(),
+    capturedAt: CAPTURED_AT,
+    sections: [
+      {
+        sectionId: 'AVAILABILITY_CALENDAR',
+        section: {
+          title: 'Choose different dates',
+          calendarWindow: {
+            checkIn: '2026-07-31',
+            checkOut: '2026-08-11',
+          },
+        },
+      },
+    ],
+  });
+  assert.equal(genericCalendarWindow.availability.status, 'partial');
+  assert.equal(genericCalendarWindow.availability.availableRange, undefined);
+  assert.equal(
+    genericCalendarWindow.providerEvidence.alternativeRanges,
+    undefined,
+  );
+});
+
+test('freshness and booking eligibility are derived at read time from one TTL', () => {
+  assert.equal(
+    deriveStaySnapshotFreshness(CAPTURED_AT, DAY_MS, Date.parse(CAPTURED_AT) + DAY_MS),
+    'fresh',
+  );
+  assert.equal(
+    deriveStaySnapshotFreshness(
+      CAPTURED_AT,
+      DAY_MS,
+      Date.parse(CAPTURED_AT) + DAY_MS + 1,
+    ),
+    'stale',
+  );
+
+  const unavailable = {
+    status: 'no' as const,
+    capturedAt: CAPTURED_AT,
+    reasonCode: 'provider_unavailable',
+  };
+  assert.deepEqual(
+    getStayBookingEligibility(unavailable, 'fresh'),
+    {
+      status: 'excluded',
+      actionable: false,
+      reasonCode: 'provider_unavailable',
+      reason: 'Not available for the recorded dates and guest count.',
+    },
+  );
+  assert.equal(
+    getStayBookingEligibility(unavailable, 'stale').status,
+    'conditional',
+  );
+});
+
+test('legacy details invent neither capture time nor availability', () => {
+  const request = bookingRequest();
+  const readModel = getStaySnapshotReadModel({
+    snapshot: {
+      oldPriceText: '$500',
+    },
+    fallbackRequest: request,
+    ttlMs: DAY_MS,
+    now: Date.parse(CAPTURED_AT),
+  });
+
+  assert.equal(readModel.legacy, true);
+  assert.equal(readModel.priceForStay, null);
+  assert.deepEqual(readModel.availability, {
+    status: 'unknown',
+    capturedAt: null,
+    reasonCode: 'legacy_snapshot_missing',
+  });
+  assert.deepEqual(readModel.freshness, {
+    price: 'unknown',
+    availability: 'unknown',
+  });
+  assert.equal(readModel.bookingEligibility.status, 'unknown');
+});

--- a/tests/triage-rubric.test.ts
+++ b/tests/triage-rubric.test.ts
@@ -629,6 +629,62 @@ test('affordability rejects unknown freshness, non-stay basis, and non-public ra
   assert.equal(memberRate.reasonCode, 'rate_not_public');
 });
 
+test('availability gates affordability without changing the quality verdict', () => {
+  const baseAvailability = {
+    status: 'yes' as const,
+    capturedAt: '2026-07-26T12:00:00.000Z',
+    freshness: 'fresh' as const,
+    reasonCode: 'provider_room_inventory',
+  };
+  const cases = [
+    {
+      availability: { ...baseAvailability, status: 'no' as const },
+      code: 'stay_unavailable',
+    },
+    {
+      availability: {
+        ...baseAvailability,
+        status: 'partial' as const,
+        availableRange: {
+          checkIn: '2026-07-31',
+          checkOut: '2026-08-11',
+        },
+      },
+      code: 'stay_partially_available',
+    },
+    {
+      availability: { ...baseAvailability, status: 'unknown' as const },
+      code: 'availability_unknown',
+    },
+    {
+      availability: {
+        ...baseAvailability,
+        status: 'no' as const,
+        freshness: 'stale' as const,
+      },
+      code: 'availability_stale',
+    },
+  ];
+
+  for (const item of cases) {
+    const result = computeAffordability({
+      budget: usdBudget,
+      price: freshPublicPrice,
+      availability: item.availability,
+      now: new Date('2026-07-26T18:00:00.000Z'),
+    });
+    assert.equal(result.status, 'unknown');
+    assert.equal(result.reasonCode, item.code);
+  }
+
+  const available = computeAffordability({
+    budget: usdBudget,
+    price: freshPublicPrice,
+    availability: baseAvailability,
+  });
+  assert.equal(available.status, 'within');
+});
+
 test('affordability never changes a deterministic quality verdict', () => {
   const set = makeSet([
     { label: 'Quiet', type: 'priority', rank: 1 },

--- a/web/README.md
+++ b/web/README.md
@@ -60,7 +60,7 @@ CLI:
 
 ```dotenv
 REVIEWR_CACHE_DIR=~/.cache/reviewr/artifacts-v1
-REVIEWR_CACHE_DETAILS_TTL_DAYS=7
+REVIEWR_CACHE_DETAILS_TTL_DAYS=1
 REVIEWR_CACHE_REVIEWS_TTL_DAYS=30
 REVIEWR_CACHE_PHOTOS_TTL_DAYS=180
 ```
@@ -94,10 +94,42 @@ npm run cleanup:artifacts -- --apply  # remove expired runs
 ```
 
 Per-job runs deliberately duplicate some scrape files held by the cross-job cache. Cache freshness
-uses 7-day details, 30-day reviews, and 180-day photos; full run bundles retain for 30 days. Disk
+uses 1-day details, 30-day reviews, and 180-day photos; full run bundles retain for 30 days. Disk
 therefore grows in both the cache and `STAYREVIEWR_ARTIFACT_DIR`. The cache has no global size cap,
 but both stores are disposable because Postgres holds product state and live scraping can recreate
 inputs.
+
+## Exact-stay price and availability snapshots
+
+Each analyzed listing stores one public snapshot for the job's exact check-in, check-out, adult
+count, platform listing ID, and Booking room selection. The snapshot contains a numeric
+platform-currency full-stay price when available plus an independent provider availability state:
+`yes`, `no`, `partial`, or `unknown`. `unknown` means the request or extraction did not confirm
+inventory; it is never silently converted to `no`.
+
+Freshness is derived when a job is read from the snapshot's `capturedAt` and the same
+`REVIEWR_CACHE_DETAILS_TTL_DAYS` policy used by the details cache. There is no separate price TTL
+or stored expiry. Legacy details without snapshot timestamps remain visibly unknown.
+
+Owners can refresh every listing or the current shortlist from either job page. This queue action
+bypasses only details-cache reads, publishes successful details to the normal cache, and does not
+rerun reviews, photos, AI review/photo analysis, or quality classification. A failed listing keeps
+its last known snapshot and records the attempt time and error. Partial runs report succeeded and
+failed counts. Affordability is recomputed deterministically from the refreshed public stay price
+and availability; the independent quality score and tier remain unchanged.
+
+A fresh `no` is excluded from actionable ranking. `partial`, `unknown`, and stale availability
+remain visible as conditional or unknown. Signed-in and Genius rates may be lower than the public
+snapshot.
+
+Airbnb v1 is deliberately conservative: an exact-date PDP price quote is retained as price
+evidence but is not promoted to verified inventory. Airbnb availability therefore remains
+`unknown` unless Airbnb itself emits an explicit refusal or a provider-volunteered alternate
+range. Search inclusion is not treated as proof. In current fixtures, fresh-`no` exclusion is
+therefore exercised by Booking.
+
+One job represents one date range. Multi-leg trips require a separate job for each leg; issue #70
+tracks first-class multi-leg support.
 
 `web/.env.local` remains supported as a compatibility fallback for direct `web/` commands, but
 the root `.env` takes precedence. Proxy settings also fall back to

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -99,6 +99,8 @@ model ReviewJob {
   currentPhase   String          @default("search")
   analysisStatus PhaseStatus     @default(pending)
   analysisCurrentPhase String?
+  priceRefreshStatus PhaseStatus @default(pending)
+  priceRefreshCurrentPhase String?
   location       String?
   prompt         String?
   boundingBox    Json?
@@ -121,6 +123,7 @@ model ReviewJob {
   errorMessage   String?
   queueJobId     String?
   analysisQueueJobId String?
+  priceRefreshQueueJobId String?
   artifactRoot   String?
   reportPath     String?
   createdAt      DateTime        @default(now())
@@ -132,6 +135,12 @@ model ReviewJob {
   analysisStartedAt DateTime?
   analysisCompletedAt DateTime?
   analysisDurationMs Int?
+  priceRefreshProgress Float     @default(0)
+  priceRefreshErrorMessage String?
+  priceRefreshSummary Json?
+  priceRefreshStartedAt DateTime?
+  priceRefreshCompletedAt DateTime?
+  priceRefreshDurationMs Int?
   aiReviewsCostUsd Float         @default(0)
   aiPhotosCostUsd  Float         @default(0)
   triageCostUsd    Float         @default(0)
@@ -173,6 +182,8 @@ model ReviewJobListing {
   liked            Boolean   @default(false)
   hidden           Boolean   @default(false)
   poiDistanceMeters Float?
+  staySnapshot     Json?
+  priceRefreshAttempt Json?
   createdAt        DateTime  @default(now())
   analysis         ReviewJobListingAnalysis?
 

--- a/web/src/app/api/jobs/[jobId]/analyze/route.ts
+++ b/web/src/app/api/jobs/[jobId]/analyze/route.ts
@@ -57,6 +57,16 @@ export async function POST(request: Request, { params }: Params) {
     );
   }
 
+  if (
+    job.priceRefreshStatus === 'running'
+    || job.priceRefreshCurrentPhase === 'queued'
+  ) {
+    return NextResponse.json(
+      { error: 'Wait for the current price refresh to finish before starting analysis' },
+      { status: 409 },
+    );
+  }
+
   if (mode === 'triage' && !job.artifactRoot) {
     return NextResponse.json(
       { error: 'Saved analysis artifacts are required for a triage-only regrade' },

--- a/web/src/app/api/jobs/[jobId]/refresh-prices/route.ts
+++ b/web/src/app/api/jobs/[jobId]/refresh-prices/route.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { enqueueReviewJobPriceRefresh } from '@/lib/review-job-queue';
+import { getReviewJobOwnerKey } from '@/lib/reviewJobOwner';
+import type { Platform } from '@/types';
+
+export const runtime = 'nodejs';
+
+interface Params {
+  params: Promise<{ jobId: string }>;
+}
+
+interface ListingRef {
+  id: string;
+  platform: Platform;
+}
+
+function parseListingRefs(value: unknown): ListingRef[] | null {
+  if (value == null) return [];
+  if (!Array.isArray(value)) return null;
+  const refs = value.filter(
+    (item): item is ListingRef =>
+      !!item
+      && typeof item === 'object'
+      && typeof (item as ListingRef).id === 'string'
+      && (
+        (item as ListingRef).platform === 'airbnb'
+        || (item as ListingRef).platform === 'booking'
+      ),
+  );
+  return refs.length === value.length ? refs : null;
+}
+
+export async function POST(request: Request, { params }: Params) {
+  const { jobId } = await params;
+  const ownerKey = await getReviewJobOwnerKey();
+  if (!ownerKey) {
+    return NextResponse.json({ error: 'Review job not found' }, { status: 404 });
+  }
+
+  let parsedBody: unknown;
+  try {
+    parsedBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  if (
+    !parsedBody
+    || typeof parsedBody !== 'object'
+    || Array.isArray(parsedBody)
+  ) {
+    return NextResponse.json(
+      { error: 'JSON body must be an object' },
+      { status: 400 },
+    );
+  }
+  const body = parsedBody as {
+    scope?: 'all' | 'selected';
+    listings?: unknown;
+  };
+  if (body.scope != null && body.scope !== 'all' && body.scope !== 'selected') {
+    return NextResponse.json(
+      { error: 'scope must be "all" or "selected"' },
+      { status: 400 },
+    );
+  }
+  const scope = body.scope ?? 'all';
+  const listingRefs = parseListingRefs(body?.listings);
+  if (!listingRefs) {
+    return NextResponse.json(
+      { error: 'listings must contain only { id, platform } values' },
+      { status: 400 },
+    );
+  }
+
+  const job = await prisma.reviewJob.findFirst({
+    where: { id: jobId, ownerKey },
+    include: {
+      listings: {
+        where: { hidden: false },
+        select: {
+          id: true,
+          listingId: true,
+          platform: true,
+          selected: true,
+        },
+      },
+    },
+  });
+  if (!job) {
+    return NextResponse.json({ error: 'Review job not found' }, { status: 404 });
+  }
+  if (!job.checkin || !job.checkout) {
+    return NextResponse.json(
+      { error: 'Exact check-in and check-out dates are required to refresh prices' },
+      { status: 409 },
+    );
+  }
+  if (!job.artifactRoot) {
+    return NextResponse.json(
+      { error: 'Run analysis once before refreshing its price snapshots' },
+      { status: 409 },
+    );
+  }
+  if (job.status === 'pending' || job.status === 'running') {
+    return NextResponse.json(
+      { error: 'Wait for the current search or analysis run to finish' },
+      { status: 409 },
+    );
+  }
+  if (
+    job.analysisStatus === 'running'
+    || job.analysisCurrentPhase === 'queued'
+  ) {
+    return NextResponse.json(
+      { error: 'Wait for the current analysis run to finish' },
+      { status: 409 },
+    );
+  }
+  if (
+    job.priceRefreshStatus === 'running'
+    || job.priceRefreshCurrentPhase === 'queued'
+  ) {
+    return NextResponse.json(
+      { error: 'A price refresh is already running for this job' },
+      { status: 409 },
+    );
+  }
+
+  const requestedKeys = new Set(
+    listingRefs.map((item) => `${item.platform}:${item.id}`),
+  );
+  const targetListings =
+    scope === 'all'
+      ? job.listings
+      : job.listings.filter((listing) =>
+          listingRefs.length > 0
+            ? requestedKeys.has(`${listing.platform}:${listing.listingId}`)
+            : listing.selected);
+  if (targetListings.length === 0) {
+    return NextResponse.json(
+      { error: 'No visible listings matched the requested refresh scope' },
+      { status: 400 },
+    );
+  }
+
+  const queueJob = await enqueueReviewJobPriceRefresh(
+    jobId,
+    targetListings.map((listing) => listing.id),
+  );
+  await prisma.reviewJob.update({
+    where: { id: jobId },
+    data: {
+      priceRefreshStatus: 'pending',
+      priceRefreshCurrentPhase: 'queued',
+      priceRefreshProgress: 0,
+      priceRefreshErrorMessage: null,
+      priceRefreshSummary: {
+        requested: targetListings.length,
+        succeeded: 0,
+        failed: 0,
+      },
+      priceRefreshQueueJobId:
+        queueJob.id != null ? String(queueJob.id) : null,
+    },
+  });
+
+  return NextResponse.json({
+    jobId,
+    status: 'queued',
+    scope,
+    listingCount: targetListings.length,
+  }, { status: 202 });
+}

--- a/web/src/app/api/jobs/[jobId]/route.ts
+++ b/web/src/app/api/jobs/[jobId]/route.ts
@@ -1,9 +1,5 @@
 import { NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
-import {
-  recomputeStoredAffordability,
-  type AffordabilityBudget,
-} from '@cli/triage-rubric.js';
 import { prisma } from '@/lib/prisma';
 import { getReviewJobOwnerKey } from '@/lib/reviewJobOwner';
 import {
@@ -12,6 +8,11 @@ import {
   toReviewJobResponseRecordForViewer,
 } from '@/lib/reviewJobs';
 import type { Platform, ReviewJobResponse } from '@/types';
+import {
+  computeReviewJobSnapshotAffordability,
+  getReviewJobStaySnapshotReadModel,
+  resolveStaySnapshotTtlMs,
+} from '@/lib/staySnapshots';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -26,38 +27,13 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function getStoredBriefBudget(
-  triage: Record<string, unknown>,
-): AffordabilityBudget | null {
-  const requirementSet = asRecord(triage.requirementSet);
-  const parsedBudget = asRecord(requirementSet?.parsedBudget);
-  const maximumAmount = Number(parsedBudget?.maximumAmount);
-  const currency =
-    typeof parsedBudget?.currency === 'string'
-      ? parsedBudget.currency.trim().toUpperCase()
-      : '';
-  if (
-    parsedBudget?.basis !== 'stay'
-    || parsedBudget?.source !== 'brief'
-    || !Number.isFinite(maximumAmount)
-    || maximumAmount <= 0
-    || !/^[A-Z]{3}$/.test(currency)
-  ) {
-    return null;
-  }
-  return {
-    amount: maximumAmount,
-    currency,
-    basis: 'stay',
-    source: 'brief',
-  };
-}
-
 async function recomputeJobAffordability(
   tx: Prisma.TransactionClient,
   jobId: string,
-  explicitBudget: AffordabilityBudget | null,
 ) {
+  const job = await tx.reviewJob.findUniqueOrThrow({
+    where: { id: jobId },
+  });
   const analyses = await tx.reviewJobListingAnalysis.findMany({
     where: {
       jobListing: { jobId },
@@ -65,18 +41,38 @@ async function recomputeJobAffordability(
     select: {
       id: true,
       triage: true,
+      details: true,
+      jobListing: {
+        select: {
+          platform: true,
+          listingId: true,
+          url: true,
+          staySnapshot: true,
+          priceRefreshAttempt: true,
+        },
+      },
     },
   });
+  const ttlMs = resolveStaySnapshotTtlMs();
+  const now = new Date();
 
   for (const analysis of analyses) {
     const triage = asRecord(analysis.triage);
     if (triage?.scoreSource !== 'deterministic_rubric') continue;
 
-    const affordability = recomputeStoredAffordability({
-      affordability: triage.affordability,
-      budget: explicitBudget ?? getStoredBriefBudget(triage),
+    const snapshot = getReviewJobStaySnapshotReadModel({
+      job,
+      listing: analysis.jobListing,
+      analysis,
+      ttlMs,
+      now,
     });
-    if (!affordability) continue;
+    const affordability = computeReviewJobSnapshotAffordability({
+      job,
+      triage,
+      snapshot,
+      now,
+    });
 
     await tx.reviewJobListingAnalysis.update({
       where: { id: analysis.id },
@@ -150,6 +146,8 @@ export async function PATCH(request: Request, { params }: Params) {
       currency: true,
       analysisBudgetAmount: true,
       analysisBudgetCurrency: true,
+      priceRefreshStatus: true,
+      priceRefreshCurrentPhase: true,
     },
   });
 
@@ -160,9 +158,11 @@ export async function PATCH(request: Request, { params }: Params) {
   if (
     existingJob.analysisStatus === 'running'
     || existingJob.analysisCurrentPhase === 'queued'
+    || existingJob.priceRefreshStatus === 'running'
+    || existingJob.priceRefreshCurrentPhase === 'queued'
   ) {
     return NextResponse.json(
-      { error: 'Wait for the current analysis run to finish before changing brief, budget, or selection' },
+      { error: 'Wait for the current analysis or price refresh to finish before changing brief, budget, or selection' },
       { status: 409 },
     );
   }
@@ -225,16 +225,7 @@ export async function PATCH(request: Request, { params }: Params) {
     }
 
     if (normalizedBudgetAmount !== undefined) {
-      const explicitBudget: AffordabilityBudget | null =
-        normalizedBudgetAmount != null && normalizedBudgetCurrency
-          ? {
-              amount: normalizedBudgetAmount,
-              currency: normalizedBudgetCurrency,
-              basis: 'stay',
-              source: 'explicit',
-            }
-          : null;
-      await recomputeJobAffordability(tx, jobId, explicitBudget);
+      await recomputeJobAffordability(tx, jobId);
     }
 
     if (selectedListings) {

--- a/web/src/components/JobWorkspace.tsx
+++ b/web/src/components/JobWorkspace.tsx
@@ -9,7 +9,10 @@ import type {
 } from '@/types';
 import { resolveComparablePrice } from '@/lib/pricing';
 import { formatUsdCost, hasAiCosts } from '@/lib/aiCosts';
-import { getListingResultsSnapshot } from '@/lib/results';
+import {
+  getBookingEligibilityRank,
+  getListingResultsSnapshot,
+} from '@/lib/results';
 import {
   fetchReviewJobResponse,
   getStoredReviewJobPriceDisplay,
@@ -18,6 +21,8 @@ import { useReviewJobPolling } from '@/hooks/useReviewJobPolling';
 import AiBudgetNotice from './AiBudgetNotice';
 import EvidenceGapBadge from './EvidenceGapBadge';
 import ResultCard from './ResultCard';
+import StaySnapshotStatus from './StaySnapshotStatus';
+import PriceRefreshControls from './PriceRefreshControls';
 
 const JobMap = dynamic(() => import('./JobMap'), {
   ssr: false,
@@ -209,6 +214,11 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
   const sortedResults = useMemo(() => {
     const nextResults = data.listings.filter((result) => !result.hidden);
     nextResults.sort((a, b) => {
+      const eligibilityA = getBookingEligibilityRank(a);
+      const eligibilityB = getBookingEligibilityRank(b);
+      if (eligibilityA !== eligibilityB) {
+        return eligibilityA - eligibilityB;
+      }
       const aAmount = resolveComparablePrice(a, priceDisplay, {
         checkin: data.job.checkin,
         checkout: data.job.checkout,
@@ -247,7 +257,9 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
     !viewerCanEdit
     || isStartingAnalysis
     || data.job.analysisStatus === 'running'
-    || analysisQueued;
+    || analysisQueued
+    || data.job.priceRefreshStatus === 'running'
+    || data.job.priceRefreshCurrentPhase === 'queued';
   const isPromptDirty =
     prompt !== savedPrompt
     || budgetAmount !== savedBudgetAmount
@@ -500,6 +512,8 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
     && (data.job.status === 'completed' || data.job.status === 'failed')
     && data.job.analysisStatus !== 'running'
     && !analysisQueued
+    && data.job.priceRefreshStatus !== 'running'
+    && data.job.priceRefreshCurrentPhase !== 'queued'
     && !isSavingSelection;
   const analysisButtonLabel =
     analysisQueued
@@ -759,6 +773,11 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
           </div>
 
           <AiBudgetNotice job={data.job} />
+          <PriceRefreshControls
+            job={data.job}
+            selectedListings={selectedListings}
+            onQueued={refreshJob}
+          />
 
           <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -920,6 +939,12 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
                     <> · {Math.round(selectedResult.poiDistanceMeters)}m from POI</>
                   )}
                 </p>
+                <div className="mt-3">
+                  <StaySnapshotStatus
+                    snapshot={selectedResult.staySnapshot}
+                    compact
+                  />
+                </div>
 
                 {selectedAnalysisSummary ? (
                   <div className="mt-4 space-y-3">

--- a/web/src/components/PriceRefreshControls.test.tsx
+++ b/web/src/components/PriceRefreshControls.test.tsx
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { ReviewJobListing, ReviewJobResponse } from '@/types';
+import PriceRefreshControls from './PriceRefreshControls.js';
+
+test('price refresh controls show scope, progress, and details-only boundary', () => {
+  const html = renderToStaticMarkup(
+    <PriceRefreshControls
+      job={{
+        id: 'job_1',
+        viewerCanEdit: true,
+        status: 'completed',
+        analysisStatus: 'completed',
+        analysisCurrentPhase: 'completed',
+        checkin: '2026-07-29',
+        checkout: '2026-08-11',
+        artifactArchiveAvailable: true,
+        priceRefreshStatus: 'running',
+        priceRefreshCurrentPhase: 'booking:example',
+        priceRefreshProgress: 0.5,
+        priceRefreshSummary: {
+          requested: 2,
+          succeeded: 1,
+          failed: 0,
+        },
+      } as ReviewJobResponse['job']}
+      selectedListings={[{
+        id: 'example',
+        platform: 'booking',
+      } as ReviewJobListing]}
+      onQueued={async () => {}}
+    />,
+  );
+
+  assert.match(html, /Refresh all/);
+  assert.match(html, /Refresh selected \(1\)/);
+  assert.match(html, /Reviews, photos, AI, and quality scores are left untouched/);
+  assert.match(html, /50%/);
+  assert.match(html, /single date range/);
+});

--- a/web/src/components/PriceRefreshControls.tsx
+++ b/web/src/components/PriceRefreshControls.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import React, { useState } from 'react';
+import type { ReviewJobListing, ReviewJobResponse } from '@/types';
+
+export default function PriceRefreshControls({
+  job,
+  selectedListings,
+  onQueued,
+}: {
+  job: ReviewJobResponse['job'];
+  selectedListings: ReviewJobListing[];
+  onQueued: () => Promise<void>;
+}) {
+  const [isQueueing, setIsQueueing] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const running =
+    job.priceRefreshStatus === 'running'
+    || job.priceRefreshCurrentPhase === 'queued';
+  const locked =
+    !job.viewerCanEdit
+    || isQueueing
+    || running
+    || job.status === 'pending'
+    || job.status === 'running'
+    || job.analysisStatus === 'running'
+    || job.analysisCurrentPhase === 'queued'
+    || !job.checkin
+    || !job.checkout
+    || !job.artifactArchiveAvailable;
+
+  async function queueRefresh(scope: 'all' | 'selected') {
+    setIsQueueing(true);
+    setMessage(null);
+    try {
+      const response = await fetch(`/api/jobs/${job.id}/refresh-prices`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          scope,
+          listings:
+            scope === 'selected'
+              ? selectedListings.map((listing) => ({
+                  id: listing.id,
+                  platform: listing.platform,
+                }))
+              : undefined,
+        }),
+      });
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Failed to queue price refresh');
+      }
+      setMessage(
+        `Queued exact-stay price refresh for ${payload.listingCount} listings.`,
+      );
+      await onQueued();
+    } catch (error) {
+      setMessage(
+        error instanceof Error ? error.message : 'Failed to queue price refresh',
+      );
+    } finally {
+      setIsQueueing(false);
+    }
+  }
+
+  const summary = job.priceRefreshSummary;
+  return (
+    <section className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-white">Price & availability</p>
+          <p className="mt-1 text-xs text-stone-500">
+            Refreshes public exact-stay details only. Reviews, photos, AI, and
+            quality scores are left untouched.
+          </p>
+        </div>
+        {job.viewerCanEdit && (
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              disabled={locked}
+              onClick={() => void queueRefresh('all')}
+              className="rounded-xl border border-white/10 bg-white/[0.06] px-3 py-2 text-xs font-semibold text-stone-200 transition hover:bg-white/[0.1] disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Refresh all
+            </button>
+            <button
+              type="button"
+              disabled={locked || selectedListings.length === 0}
+              onClick={() => void queueRefresh('selected')}
+              className="rounded-xl border border-sky-300/20 bg-sky-300/10 px-3 py-2 text-xs font-semibold text-sky-100 transition hover:bg-sky-300/15 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Refresh selected ({selectedListings.length})
+            </button>
+          </div>
+        )}
+      </div>
+
+      {running && (
+        <div className="mt-3">
+          <div className="flex items-center justify-between text-xs text-stone-400">
+            <span>{job.priceRefreshCurrentPhase ?? 'refreshing details'}</span>
+            <span>{Math.round(job.priceRefreshProgress * 100)}%</span>
+          </div>
+          <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/[0.08]">
+            <div
+              className="h-full rounded-full bg-[linear-gradient(90deg,#38bdf8,#6ee7b7)] transition-all"
+              style={{
+                width: `${Math.max(
+                  4,
+                  Math.round(job.priceRefreshProgress * 100),
+                )}%`,
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      <p className="mt-3 text-xs text-stone-500" aria-live="polite">
+        {message
+          ?? (summary
+            ? (
+                `Last refresh: ${summary.succeeded}/${summary.requested} succeeded`
+                + (summary.failed > 0
+                  ? `; ${summary.failed} failed with last known snapshots preserved.`
+                  : '.')
+              )
+            : 'No price refresh has run yet.')}
+      </p>
+      <p className="mt-1 text-[11px] leading-5 text-stone-600">
+        One snapshot covers this job’s single date range. Create separate jobs
+        for separate trip legs.
+      </p>
+    </section>
+  );
+}

--- a/web/src/components/ResultsWorkspace.tsx
+++ b/web/src/components/ResultsWorkspace.tsx
@@ -18,6 +18,7 @@ import { buildListingUrl } from '@/lib/listingLinks';
 import {
   formatPoiDistance,
   getActiveTriageComparison,
+  getBookingEligibilityRank,
   getListingResultsSnapshot,
   getTriageComparisonStatus,
   getTriageRegradeListingCount,
@@ -39,6 +40,8 @@ import PlatformBadge from './PlatformBadge';
 import ResultsJobMap from './ResultsJobMap';
 import AiBudgetNotice from './AiBudgetNotice';
 import EvidenceGapBadge from './EvidenceGapBadge';
+import StaySnapshotStatus from './StaySnapshotStatus';
+import PriceRefreshControls from './PriceRefreshControls';
 
 const MIN_MAP_HEIGHT = 280;
 const TIER_ORDER = ['top_pick', 'shortlist', 'consider', 'unlikely', 'no_go'] as const;
@@ -734,6 +737,9 @@ function ListingDetailPanel({
               </button>
             ))}
           </div>
+          <div className="pt-4">
+            <StaySnapshotStatus snapshot={listing.staySnapshot} />
+          </div>
 
           {activeTab === 'triage' && (
             <div className="space-y-4 pt-4">
@@ -1354,7 +1360,9 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
   const regradeLocked =
     isRegrading
     || data.job.analysisStatus === 'running'
-    || data.job.analysisCurrentPhase === 'queued';
+    || data.job.analysisCurrentPhase === 'queued'
+    || data.job.priceRefreshStatus === 'running'
+    || data.job.priceRefreshCurrentPhase === 'queued';
 
   const startTriageRegrade = useCallback(async () => {
     if (!viewerCanEdit || regradeLocked) return;
@@ -1395,6 +1403,11 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       next.map((listing, index) => [listingKey(listing), index]),
     );
     next.sort((a, b) => {
+      const eligibilityA = getBookingEligibilityRank(a);
+      const eligibilityB = getBookingEligibilityRank(b);
+      if (eligibilityA !== eligibilityB) {
+        return eligibilityA - eligibilityB;
+      }
       const triageA = getListingResultsSnapshot(a).triage;
       const triageB = getListingResultsSnapshot(b).triage;
       if (activeTriageComparison) {
@@ -1477,6 +1490,11 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
     }
 
     next.sort((a, b) => {
+      const eligibilityA = getBookingEligibilityRank(a);
+      const eligibilityB = getBookingEligibilityRank(b);
+      if (eligibilityA !== eligibilityB) {
+        return eligibilityA - eligibilityB;
+      }
       if (activeTriageComparison) {
         const groupA = comparisonRank(
           getTriageComparisonStatus(
@@ -1621,11 +1639,14 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
   const heroResults = useMemo(() => {
     const comparable = filteredResults.filter(
       (listing) =>
+        listing.staySnapshot.bookingEligibility.actionable
+        && (
         !activeTriageComparison
         || getTriageComparisonStatus(
           getListingResultsSnapshot(listing).triage,
           activeTriageComparison,
-        ) === 'ranked',
+        ) === 'ranked'
+        ),
     );
     const topPicks = comparable.filter(
       (listing) =>
@@ -2156,6 +2177,15 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
           </div>
 
           <AiBudgetNotice job={data.job} variant="results" className="mt-4" />
+          <div className="mt-4">
+            <PriceRefreshControls
+              job={data.job}
+              selectedListings={data.listings.filter(
+                (listing) => listing.liked && !listing.hidden,
+              )}
+              onQueued={refreshJob}
+            />
+          </div>
 
           {olderPolicyCount > 0 && (
             <div className="mt-5 rounded-2xl border border-amber-300/20 bg-amber-300/[0.08] p-4">

--- a/web/src/components/StaySnapshotStatus.test.tsx
+++ b/web/src/components/StaySnapshotStatus.test.tsx
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { StaySnapshotReadModel } from '@cli/stay-snapshot';
+import StaySnapshotStatus, { formatSnapshotAge } from './StaySnapshotStatus.js';
+
+function snapshot(
+  overrides: Partial<StaySnapshotReadModel> = {},
+): StaySnapshotReadModel {
+  return {
+    schemaVersion: 1,
+    request: {
+      platform: 'booking',
+      listingId: 'us/example',
+      checkIn: '2026-07-29',
+      checkOut: '2026-08-11',
+      adults: 2,
+      linkedRoomId: null,
+    },
+    priceForStay: {
+      amount: 18627,
+      currency: 'PLN',
+      basis: 'stay',
+      capturedAt: '2026-07-26T18:00:00.000Z',
+      source: 'booking_property_page',
+      rateType: 'public',
+      mandatoryChargesResolved: true,
+    },
+    availability: {
+      status: 'yes',
+      capturedAt: '2026-07-26T18:00:00.000Z',
+      reasonCode: 'provider_room_inventory',
+    },
+    providerEvidence: {},
+    legacy: false,
+    freshness: {
+      price: 'fresh',
+      availability: 'fresh',
+    },
+    bookingEligibility: {
+      status: 'eligible',
+      actionable: true,
+      reasonCode: 'available',
+      reason: 'Available for the recorded dates and guest count.',
+    },
+    refreshAttempt: null,
+    ...overrides,
+  };
+}
+
+test('stay snapshot shows exact dates, public total, availability, and disclaimer', () => {
+  const html = renderToStaticMarkup(
+    <StaySnapshotStatus snapshot={snapshot()} />,
+  );
+
+  assert.match(html, /2026-07-29/);
+  assert.match(html, /2026-08-11/);
+  assert.match(html, /2 adults/);
+  assert.match(html, /PLN/);
+  assert.match(html, /18,627/);
+  assert.match(html, /public rate/);
+  assert.match(html, /Availability:/);
+  assert.match(html, /Signed-in or Genius prices may be lower/);
+});
+
+test('failed refresh explains that the last known stale snapshot was preserved', () => {
+  const html = renderToStaticMarkup(
+    <StaySnapshotStatus
+      snapshot={snapshot({
+        freshness: {
+          price: 'stale',
+          availability: 'stale',
+        },
+        bookingEligibility: {
+          status: 'conditional',
+          actionable: false,
+          reasonCode: 'availability_stale',
+          reason: 'Last known availability (yes) is stale.',
+        },
+        refreshAttempt: {
+          attemptedAt: '2026-07-26T19:00:00.000Z',
+          status: 'failed',
+          error: 'provider timeout',
+        },
+      })}
+    />,
+  );
+
+  assert.match(html, /Last known price/);
+  assert.match(html, /Latest refresh failed/);
+  assert.match(html, /provider timeout/);
+  assert.match(html, /last known snapshot preserved/i);
+});
+
+test('snapshot age uses compact user-facing units', () => {
+  assert.equal(
+    formatSnapshotAge(
+      '2026-07-26T18:00:00.000Z',
+      Date.parse('2026-07-26T21:00:00.000Z'),
+    ),
+    '3h ago',
+  );
+  assert.equal(formatSnapshotAge(null), null);
+});

--- a/web/src/components/StaySnapshotStatus.tsx
+++ b/web/src/components/StaySnapshotStatus.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import type { StaySnapshotReadModel } from '@cli/stay-snapshot';
+
+function formatPrice(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `${currency} ${amount.toLocaleString('en-US')}`;
+  }
+}
+
+export function formatSnapshotAge(
+  capturedAt: string | null | undefined,
+  now = Date.now(),
+): string | null {
+  if (!capturedAt) return null;
+  const capturedMs = Date.parse(capturedAt);
+  if (!Number.isFinite(capturedMs)) return null;
+  const ageMs = Math.max(0, now - capturedMs);
+  const minutes = Math.floor(ageMs / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function availabilityTone(status: StaySnapshotReadModel['availability']['status']) {
+  if (status === 'yes') {
+    return 'border-emerald-300/20 bg-emerald-300/10 text-emerald-100';
+  }
+  if (status === 'no') {
+    return 'border-rose-300/20 bg-rose-300/10 text-rose-100';
+  }
+  if (status === 'partial') {
+    return 'border-amber-300/20 bg-amber-300/10 text-amber-100';
+  }
+  return 'border-stone-300/20 bg-stone-300/10 text-stone-200';
+}
+
+export default function StaySnapshotStatus({
+  snapshot,
+  compact = false,
+}: {
+  snapshot: StaySnapshotReadModel;
+  compact?: boolean;
+}) {
+  const priceAge = formatSnapshotAge(snapshot.priceForStay?.capturedAt);
+  const availabilityAge = formatSnapshotAge(snapshot.availability.capturedAt);
+  const pricePrefix =
+    snapshot.freshness.price === 'fresh'
+      ? 'Price'
+      : snapshot.priceForStay
+        ? 'Last known price'
+        : 'Price';
+  const availabilityLabel =
+    snapshot.freshness.availability === 'fresh'
+      ? snapshot.availability.status
+      : `${snapshot.availability.status} · ${snapshot.freshness.availability}`;
+
+  return (
+    <section
+      className={`rounded-2xl border border-white/10 bg-white/[0.03] ${
+        compact ? 'p-3' : 'p-4'
+      }`}
+      data-testid="stay-snapshot"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-stone-500">
+            Exact-stay public snapshot
+          </p>
+          <p className="mt-1 text-xs text-stone-300">
+            {snapshot.request.checkIn ?? 'Dates missing'} →{' '}
+            {snapshot.request.checkOut ?? 'Dates missing'} ·{' '}
+            {snapshot.request.adults ?? '?'} adult
+            {snapshot.request.adults === 1 ? '' : 's'}
+          </p>
+        </div>
+        <span
+          className={`rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] ${availabilityTone(
+            snapshot.availability.status,
+          )}`}
+        >
+          Availability: {availabilityLabel}
+        </span>
+      </div>
+
+      <div className="mt-3 text-sm text-stone-200">
+        {snapshot.priceForStay ? (
+          <p>
+            <span className="font-semibold text-white">
+              {pricePrefix}:{' '}
+              {formatPrice(
+                snapshot.priceForStay.amount,
+                snapshot.priceForStay.currency,
+              )}{' '}
+              total
+            </span>{' '}
+            <span className="text-xs text-stone-500">
+              · public rate · full stay
+              {priceAge ? ` · as of ${priceAge}` : ''}
+            </span>
+          </p>
+        ) : (
+          <p className="font-semibold text-stone-300">
+            Price unknown
+            <span className="ml-2 text-xs font-normal text-stone-500">
+              No numeric public full-stay price was captured.
+            </span>
+          </p>
+        )}
+        {snapshot.priceForStay
+          && !snapshot.priceForStay.mandatoryChargesResolved && (
+            <p className="mt-1 text-xs text-amber-200">
+              Mandatory charges could not be resolved, so affordability is conditional.
+            </p>
+          )}
+        <p className="mt-2 text-xs text-stone-400">
+          {snapshot.bookingEligibility.reason}
+          {availabilityAge ? ` Availability checked ${availabilityAge}.` : ''}
+        </p>
+        {snapshot.availability.availableRange && (
+          <p className="mt-1 text-xs text-amber-200">
+            Provider-offered range:{' '}
+            {snapshot.availability.availableRange.checkIn} →{' '}
+            {snapshot.availability.availableRange.checkOut}
+          </p>
+        )}
+        {snapshot.refreshAttempt?.status === 'failed' && (
+          <p className="mt-2 text-xs text-rose-200" role="alert">
+            Latest refresh failed; last known snapshot preserved.{' '}
+            {snapshot.refreshAttempt.error ?? 'Provider failure.'}
+          </p>
+        )}
+      </div>
+
+      {!compact && (
+        <p className="mt-3 border-t border-white/5 pt-3 text-[11px] leading-5 text-stone-500">
+          Signed-in or Genius prices may be lower. This snapshot applies only to
+          the dates and guest count shown above.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/web/src/lib/results.ts
+++ b/web/src/lib/results.ts
@@ -232,6 +232,20 @@ export function getTierRank(tier: string | null): number {
   }
 }
 
+export function getBookingEligibilityRank(
+  listing: Pick<ReviewJobListing, 'staySnapshot'>,
+): number {
+  switch (listing.staySnapshot.bookingEligibility.status) {
+    case 'eligible':
+      return 0;
+    case 'conditional':
+    case 'unknown':
+      return 1;
+    case 'excluded':
+      return 2;
+  }
+}
+
 export function formatPoiDistance(meters: number | null): string | null {
   if (meters == null || !Number.isFinite(meters)) {
     return null;
@@ -414,7 +428,9 @@ function parseTriage(listing: ReviewJobListing): ParsedTriage | null {
     : [];
 
   const price = asRecord(triage.price);
-  const affordabilityRecord = asRecord(triage.affordability);
+  const affordabilityRecord =
+    asRecord(listing.affordability)
+    ?? asRecord(triage.affordability);
   const affordabilityStatus = asString(affordabilityRecord?.status);
   const affordability: ParsedTriage['affordability'] =
     affordabilityStatus === 'within'

--- a/web/src/lib/review-job-analysis.ts
+++ b/web/src/lib/review-job-analysis.ts
@@ -12,6 +12,11 @@ import {
   getReviewJobArtifactRunDir,
   getReviewJobArtifactWorkspaceDir,
 } from './reviewJobArtifacts.js';
+import {
+  isStaySnapshotCacheable,
+  parseStaySnapshot,
+  type StaySnapshot,
+} from '@cli/stay-snapshot';
 
 function sanitize(value: string): string {
   return value.replace(/[^a-zA-Z0-9_-]+/g, '-');
@@ -372,6 +377,216 @@ export function prepareReviewJobRunWorkspace(input: {
     rootDir: runRoot,
     urlsFilePath: path.join(runRoot, 'job_urls.txt'),
   };
+}
+
+export function prepareReviewJobPriceRefreshWorkspace(input: {
+  jobId: string;
+  runId: string;
+  previousArtifactRoot: string;
+  dates: { checkIn: string; checkOut: string; adults: number };
+}) {
+  if (!fs.existsSync(input.previousArtifactRoot)) {
+    throw new Error(
+      `Saved analysis artifacts are unavailable: ${input.previousArtifactRoot}`,
+    );
+  }
+
+  const runRoot = getReviewJobRunDir(input.jobId, input.runId);
+  removeDirIfExists(runRoot);
+  fs.mkdirSync(runRoot, { recursive: true });
+  fs.cpSync(input.previousArtifactRoot, runRoot, {
+    recursive: true,
+    force: true,
+    filter(src) {
+      return path.basename(src) !== 'runs';
+    },
+  });
+
+  const manifestPath = getManifestPathFromRoot(runRoot);
+  const manifest = readJsonFile<AnalysisManifest>(manifestPath);
+  if (!manifest) {
+    throw new Error(`Batch manifest not found: ${manifestPath}`);
+  }
+  manifest.dates = input.dates;
+  manifest.updatedAt = new Date().toISOString();
+  writeJsonFile(manifestPath, manifest);
+
+  return {
+    rootDir: runRoot,
+    urlsFilePath: path.join(runRoot, 'price_refresh_urls.txt'),
+    previousManifest: manifest,
+  };
+}
+
+export interface PriceRefreshManifestOutcome {
+  key: string;
+  platform: Platform;
+  id: string;
+  url: string;
+  status: 'succeeded' | 'failed';
+  error: string | null;
+  snapshot: StaySnapshot | null;
+  details: Record<string, unknown> | null;
+}
+
+function sameRefreshRequest(
+  snapshot: StaySnapshot,
+  manifest: AnalysisManifest,
+  entry: AnalysisManifestEntry,
+): boolean {
+  let expectedListingId: string | null = null;
+  let expectedLinkedRoomId: string | null = null;
+  try {
+    const parsed = new URL(entry.url);
+    if (entry.platform === 'airbnb') {
+      expectedListingId = parsed.pathname.match(/\/rooms\/(\d+)/i)?.[1] ?? null;
+    } else {
+      const match = parsed.pathname.match(
+        /\/hotel\/([^/]+)\/([^/.]+)(?:\.[a-z-]+)?\.html/i,
+      );
+      expectedListingId = match
+        ? `${match[1].toLowerCase()}/${match[2].toLowerCase()}`
+        : null;
+      const blockId =
+        parsed.searchParams.get('matching_block_id')
+        ?? parsed.searchParams.get('highlighted_blocks');
+      expectedLinkedRoomId = blockId?.match(/^(\d+)/)?.[1] ?? null;
+    }
+  } catch {
+    // A malformed URL will fail the listing-id comparison below.
+  }
+
+  return (
+    snapshot.request.platform === entry.platform
+    && expectedListingId != null
+    && snapshot.request.listingId === expectedListingId
+    && snapshot.request.checkIn === (manifest.dates.checkIn ?? null)
+    && snapshot.request.checkOut === (manifest.dates.checkOut ?? null)
+    && snapshot.request.adults === (manifest.dates.adults ?? null)
+    && snapshot.request.linkedRoomId === expectedLinkedRoomId
+  );
+}
+
+export function reconcilePriceRefreshManifest(input: {
+  rootDir: string;
+  previousArtifactRoot: string;
+  previousManifest: AnalysisManifest;
+  targetKeys: Set<string>;
+}): PriceRefreshManifestOutcome[] {
+  const manifestPath = getManifestPathFromRoot(input.rootDir);
+  const refreshedManifest = readJsonFile<AnalysisManifest>(manifestPath);
+  if (!refreshedManifest) {
+    throw new Error(`Batch manifest not found: ${manifestPath}`);
+  }
+
+  const outcomes: PriceRefreshManifestOutcome[] = [];
+  for (const [key, refreshedEntry] of Object.entries(
+    refreshedManifest.listings,
+  )) {
+    if (!input.targetKeys.has(getListingMatchKey(
+      refreshedEntry.platform,
+      refreshedEntry.url,
+    ))) {
+      continue;
+    }
+
+    const details = refreshedEntry.details.file
+      ? readJsonFile<Record<string, unknown>>(
+          path.join(input.rootDir, refreshedEntry.details.file),
+        )
+      : null;
+    const snapshot = parseStaySnapshot(details?.staySnapshot);
+    let error: string | null = null;
+    if (
+      refreshedEntry.details.status !== 'fetched'
+      || !details
+      || !snapshot
+    ) {
+      error =
+        refreshedEntry.details.error
+        ?? 'The provider response did not yield a structured stay snapshot.';
+    } else if (!sameRefreshRequest(snapshot, refreshedManifest, refreshedEntry)) {
+      error = 'The provider response did not match the requested stay.';
+    } else if (!isStaySnapshotCacheable(snapshot)) {
+      error = 'The provider response did not confirm availability.';
+    }
+
+    if (!error) {
+      outcomes.push({
+        key,
+        platform: refreshedEntry.platform,
+        id: refreshedEntry.id,
+        url: refreshedEntry.url,
+        status: 'succeeded',
+        error: null,
+        snapshot,
+        details,
+      });
+      continue;
+    }
+
+    const previousEntry =
+      input.previousManifest.listings[key]
+      ?? Object.values(input.previousManifest.listings).find((entry) =>
+        getListingMatchKey(entry.platform, entry.url)
+        === getListingMatchKey(refreshedEntry.platform, refreshedEntry.url));
+    if (previousEntry) {
+      refreshedEntry.details = { ...previousEntry.details };
+      if (previousEntry.details.file) {
+        const sourcePath = path.join(
+          input.previousArtifactRoot,
+          previousEntry.details.file,
+        );
+        const destinationPath = path.join(
+          input.rootDir,
+          previousEntry.details.file,
+        );
+        if (fs.existsSync(sourcePath)) {
+          fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+          fs.copyFileSync(sourcePath, destinationPath);
+        }
+      }
+    }
+
+    outcomes.push({
+      key,
+      platform: refreshedEntry.platform,
+      id: refreshedEntry.id,
+      url: refreshedEntry.url,
+      status: 'failed',
+      error,
+      snapshot: null,
+      details: null,
+    });
+  }
+
+  const seenKeys = new Set(
+    outcomes.map((outcome) =>
+      getListingMatchKey(outcome.platform, outcome.url)),
+  );
+  for (const previousEntry of Object.values(input.previousManifest.listings)) {
+    const matchKey = getListingMatchKey(
+      previousEntry.platform,
+      previousEntry.url,
+    );
+    if (!input.targetKeys.has(matchKey) || seenKeys.has(matchKey)) {
+      continue;
+    }
+    outcomes.push({
+      key: matchKey,
+      platform: previousEntry.platform,
+      id: previousEntry.id,
+      url: previousEntry.url,
+      status: 'failed',
+      error: 'The refresh run did not return this listing.',
+      snapshot: null,
+      details: null,
+    });
+  }
+
+  refreshedManifest.updatedAt = new Date().toISOString();
+  writeJsonFile(manifestPath, refreshedManifest);
+  return outcomes;
 }
 
 export function getListingMatchKey(

--- a/web/src/lib/review-job-queue.ts
+++ b/web/src/lib/review-job-queue.ts
@@ -5,8 +5,9 @@ export const REVIEW_JOB_QUEUE_NAME = 'stayreviewr-review-job';
 
 export interface ReviewJobQueueData {
   reviewJobId: string;
-  phase: 'search' | 'analyze';
+  phase: 'search' | 'analyze' | 'refresh-prices';
   analysisMode?: 'full' | 'triage';
+  listingRowIds?: string[];
 }
 
 export function getReviewJobQueueJobId(
@@ -87,6 +88,30 @@ export async function enqueueReviewJobAnalysis(
     reviewJobId,
     phase: 'analyze',
     analysisMode,
+  }, {
+    jobId,
+  });
+}
+
+export async function enqueueReviewJobPriceRefresh(
+  reviewJobId: string,
+  listingRowIds: string[],
+) {
+  const queue = getReviewJobQueue();
+  const jobId = getReviewJobQueueJobId('refresh-prices', reviewJobId);
+  const existing = await queue.getJob(jobId);
+  if (existing) {
+    const state = await existing.getState();
+    if (shouldReuseReviewJobQueueState(state)) {
+      return existing;
+    }
+    await existing.remove().catch(() => {});
+  }
+
+  return queue.add('run-review-job-price-refresh', {
+    reviewJobId,
+    phase: 'refresh-prices',
+    listingRowIds,
   }, {
     jobId,
   });

--- a/web/src/lib/reviewJobStatus.ts
+++ b/web/src/lib/reviewJobStatus.ts
@@ -6,5 +6,7 @@ export function shouldPollReviewJob(job: ReviewJobResponse['job']): boolean {
     || job.status === 'running'
     || job.analysisStatus === 'running'
     || job.analysisCurrentPhase === 'queued'
+    || job.priceRefreshStatus === 'running'
+    || job.priceRefreshCurrentPhase === 'queued'
   );
 }

--- a/web/src/lib/reviewJobs.ts
+++ b/web/src/lib/reviewJobs.ts
@@ -33,8 +33,24 @@ import {
   isReviewJobArtifactFileAvailable,
   isReviewJobArtifactRootAvailable,
 } from './reviewJobArtifacts.js';
+import {
+  computeReviewJobSnapshotAffordability,
+  getReviewJobStaySnapshotReadModel,
+  resolveStaySnapshotTtlMs,
+} from './staySnapshots.js';
 
 const EARTH_RADIUS_METERS = 6371000;
+
+function getStayNightCount(
+  checkin: string | null,
+  checkout: string | null,
+): number | null {
+  if (!checkin || !checkout) return null;
+  const start = Date.parse(`${checkin}T00:00:00Z`);
+  const end = Date.parse(`${checkout}T00:00:00Z`);
+  const nights = Math.round((end - start) / 86_400_000);
+  return Number.isFinite(nights) && nights > 0 ? nights : null;
+}
 
 function asNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
@@ -78,6 +94,19 @@ function asJsonObject(value: Prisma.JsonValue | null): Record<string, unknown> |
   }
 
   return value as Record<string, unknown>;
+}
+
+function asPriceRefreshSummary(
+  value: Prisma.JsonValue | null,
+): ReviewJobState['priceRefreshSummary'] {
+  const summary = asJsonObject(value);
+  const requested = asNumber(summary?.requested);
+  const succeeded = asNumber(summary?.succeeded);
+  const failed = asNumber(summary?.failed);
+  if (requested == null || succeeded == null || failed == null) {
+    return null;
+  }
+  return { requested, succeeded, failed };
 }
 
 function getPersistedReviewJobAiBudgetUsd(
@@ -290,8 +319,13 @@ function toReviewJobListingAnalysisState(
 
 export function toWebReviewJobListing(
   row: ReviewJobListingModel & { analysis?: ReviewJobListingAnalysisModel | null },
+  options: {
+    job: ReviewJobModel;
+    ttlMs?: number;
+    now?: Date;
+  },
 ): ReviewJobListing {
-  const pricing =
+  const storedPricing =
     asSearchPricing((row as ReviewJobListingModel & { pricing?: Prisma.JsonValue | null }).pricing)
     ?? (
       row.priceAmount != null || row.totalPrice != null
@@ -316,6 +350,44 @@ export function toWebReviewJobListing(
           }
         : null
     );
+  const staySnapshot = getReviewJobStaySnapshotReadModel({
+    job: options.job,
+    listing: row,
+    analysis: row.analysis,
+    ttlMs: options.ttlMs,
+    now: options.now,
+  });
+  const snapshotPrice = staySnapshot.priceForStay;
+  const nights = getStayNightCount(options.job.checkin, options.job.checkout);
+  const pricing = snapshotPrice
+    ? {
+        nightly:
+          nights
+            ? {
+                amount: snapshotPrice.amount / nights,
+                currency: snapshotPrice.currency,
+                source: 'derived' as const,
+              }
+            : null,
+        total: {
+          amount: snapshotPrice.amount,
+          currency: snapshotPrice.currency,
+          source: 'upstream' as const,
+        },
+        display: {
+          amount: snapshotPrice.amount,
+          currency: snapshotPrice.currency,
+          source: 'upstream' as const,
+          basis: 'stay' as const,
+        },
+      }
+    : storedPricing;
+  const affordability = computeReviewJobSnapshotAffordability({
+    job: options.job,
+    triage: row.analysis?.triage,
+    snapshot: staySnapshot,
+    now: options.now,
+  });
 
   return {
     id: row.listingId,
@@ -344,6 +416,8 @@ export function toWebReviewJobListing(
     liked: row.liked,
     hidden: row.hidden,
     poiDistanceMeters: row.poiDistanceMeters ?? null,
+    staySnapshot,
+    affordability,
     analysis: row.analysis ? toReviewJobListingAnalysisState(row.analysis) : null,
   };
 }
@@ -373,6 +447,8 @@ export function toReviewJobState(
     currentPhase: job.currentPhase,
     analysisStatus: job.analysisStatus,
     analysisCurrentPhase: job.analysisCurrentPhase ?? null,
+    priceRefreshStatus: job.priceRefreshStatus,
+    priceRefreshCurrentPhase: job.priceRefreshCurrentPhase ?? null,
     location: job.location ?? null,
     prompt: job.prompt ?? null,
     boundingBox: parseStoredBoundingBox(job.boundingBox) ?? null,
@@ -398,6 +474,12 @@ export function toReviewJobState(
     analysisDurationMs: job.analysisDurationMs ?? null,
     analysisStartedAt: job.analysisStartedAt?.toISOString() ?? null,
     analysisCompletedAt: job.analysisCompletedAt?.toISOString() ?? null,
+    priceRefreshProgress: job.priceRefreshProgress,
+    priceRefreshErrorMessage: job.priceRefreshErrorMessage ?? null,
+    priceRefreshSummary: asPriceRefreshSummary(job.priceRefreshSummary),
+    priceRefreshDurationMs: job.priceRefreshDurationMs ?? null,
+    priceRefreshStartedAt: job.priceRefreshStartedAt?.toISOString() ?? null,
+    priceRefreshCompletedAt: job.priceRefreshCompletedAt?.toISOString() ?? null,
     costs: buildAiCostBreakdown({
       aiReviewsCostUsd: job.aiReviewsCostUsd,
       aiPhotosCostUsd: job.aiPhotosCostUsd,
@@ -444,6 +526,8 @@ export function toReviewJobResponse(input: {
 }): ReviewJobResponse {
   const resultsReady = hasPersistedReviewJobResults(input.job);
   const persistedAiBudgetUsd = getPersistedReviewJobAiBudgetUsd(input.events);
+  const ttlMs = resolveStaySnapshotTtlMs();
+  const now = new Date();
 
   return {
     job: toReviewJobState(input.job, {
@@ -453,7 +537,12 @@ export function toReviewJobResponse(input: {
       viewerCanEdit: input.viewerCanEdit,
       aiCostBudgetUsd: persistedAiBudgetUsd,
     }),
-    listings: input.listings.map(toWebReviewJobListing),
+    listings: input.listings.map((listing) =>
+      toWebReviewJobListing(listing, {
+        job: input.job,
+        ttlMs,
+        now,
+      })),
     events: input.events.map(toReviewJobEvent),
   };
 }

--- a/web/src/lib/search-worker.ts
+++ b/web/src/lib/search-worker.ts
@@ -34,11 +34,14 @@ import {
   getPoiDistanceMeters,
   getReportPathFromRoot,
   injectPoiContextIntoListingArtifacts,
+  prepareReviewJobPriceRefreshWorkspace,
   prepareReviewJobRunWorkspace,
   readJsonFile,
+  reconcilePriceRefreshManifest,
   summarizeAnalysisStatus,
   summarizeManifestEntryStatus,
   toPhaseStatus,
+  writeJsonFile,
   type AnalysisManifest,
 } from './review-job-analysis.js';
 import {
@@ -61,6 +64,12 @@ import type {
   SearchResult,
 } from '../types.js';
 import { filterResultsForRequest } from './resultFilters.js';
+import { parseStaySnapshot } from '../../../src/stay-snapshot.js';
+import {
+  computeReviewJobSnapshotAffordability,
+  getReviewJobStaySnapshotReadModel,
+  resolveStaySnapshotTtlMs,
+} from './staySnapshots.js';
 
 for (const envPath of [
   path.resolve(process.cwd(), '.env.local'),
@@ -88,6 +97,12 @@ function asStoredMapPoint(value: unknown): { lat: number; lng: number } | null {
   return { lat, lng };
 }
 
+function asStoredRecord(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
 async function appendReviewJobEvent(
   reviewJobId: string,
   input: Parameters<typeof buildReviewJobEventData>[1],
@@ -105,6 +120,8 @@ async function cleanupExpiredReviewJobArtifactRuns(reason: string) {
         OR: [
           { analysisStatus: 'running' },
           { analysisCurrentPhase: 'queued' },
+          { priceRefreshStatus: 'running' },
+          { priceRefreshCurrentPhase: 'queued' },
         ],
       },
       select: { artifactRoot: true },
@@ -966,6 +983,7 @@ async function persistReviewJobManifestEntryToDb(input: {
   const aiReviews = readArtifactJson(input.artifactRoot, input.entry.aiReviews.file);
   const aiPhotos = readArtifactJson(input.artifactRoot, input.entry.aiPhotos.file);
   const triage = readArtifactJson(input.artifactRoot, input.entry.triage.file);
+  const staySnapshot = parseStaySnapshot(details?.staySnapshot);
   const aiCostFields = getManifestEntryAiCostFields(input.entry);
   const terminalStatus = summarizeManifestEntryStatus(input.entry);
   const completedAt =
@@ -982,6 +1000,12 @@ async function persistReviewJobManifestEntryToDb(input: {
       where: { id: input.listing.id },
       data: {
         poiDistanceMeters: poiDistanceMeters ?? null,
+        ...(staySnapshot
+          ? {
+              staySnapshot:
+                staySnapshot as unknown as Prisma.InputJsonValue,
+            }
+          : {}),
       },
     });
 
@@ -1081,6 +1105,446 @@ async function syncReviewJobArtifactsToDb(input: {
   return {
     manifest,
   };
+}
+
+async function runReviewJobPriceRefresh(
+  reviewJobId: string,
+  listingRowIds: string[],
+) {
+  await cleanupExpiredReviewJobArtifactRuns('before-price-refresh');
+  await ensureReviewJobAnalysisRows(reviewJobId);
+
+  const jobRecord = await prisma.reviewJob.findUnique({
+    where: { id: reviewJobId },
+    include: {
+      listings: {
+        where: {
+          hidden: false,
+          id: { in: listingRowIds },
+        },
+        orderBy: { createdAt: 'asc' },
+        include: { analysis: true },
+      },
+    },
+  });
+  if (!jobRecord) {
+    throw new Error(`Review job ${reviewJobId} not found`);
+  }
+  if (!jobRecord.checkin || !jobRecord.checkout) {
+    throw new Error('Exact check-in and check-out dates are required');
+  }
+  if (!jobRecord.artifactRoot) {
+    throw new Error('Saved analysis artifacts are required');
+  }
+  if (jobRecord.listings.length === 0) {
+    throw new Error('No visible listings matched the requested price refresh');
+  }
+
+  const startedAt = new Date();
+  const attemptedAt = startedAt.toISOString();
+  const runId =
+    `price-refresh-${startedAt.toISOString().replace(/[:.]/g, '-')}`;
+  const staged = prepareReviewJobPriceRefreshWorkspace({
+    jobId: reviewJobId,
+    runId,
+    previousArtifactRoot: jobRecord.artifactRoot,
+    dates: {
+      checkIn: jobRecord.checkin,
+      checkOut: jobRecord.checkout,
+      adults: jobRecord.adults,
+    },
+  });
+  fs.writeFileSync(
+    staged.urlsFilePath,
+    `${jobRecord.listings.map((listing) => listing.url).join('\n')}\n`,
+    'utf8',
+  );
+
+  const listingByKey = new Map(
+    jobRecord.listings.map((listing) => [
+      getListingMatchKey(listing.platform, listing.url),
+      listing,
+    ]),
+  );
+  const targetKeys = new Set(listingByKey.keys());
+  const completedKeys = new Set<string>();
+  const requested = jobRecord.listings.length;
+
+  await prisma.reviewJob.update({
+    where: { id: reviewJobId },
+    data: {
+      priceRefreshStatus: 'running',
+      priceRefreshCurrentPhase: 'details',
+      priceRefreshProgress: 0.05,
+      priceRefreshErrorMessage: null,
+      priceRefreshSummary: {
+        requested,
+        succeeded: 0,
+        failed: 0,
+      },
+      priceRefreshStartedAt: startedAt,
+      priceRefreshCompletedAt: null,
+      priceRefreshDurationMs: null,
+    },
+  });
+  await appendReviewJobEvent(reviewJobId, {
+    phase: 'price-refresh',
+    level: 'info',
+    message: `Started exact-stay price refresh for ${requested} listings`,
+    payload: {
+      requested,
+      checkIn: jobRecord.checkin,
+      checkOut: jobRecord.checkout,
+      adults: jobRecord.adults,
+      artifactRoot: staged.rootDir,
+      phases: ['details'],
+    },
+  });
+
+  try {
+    await runBatch([staged.urlsFilePath], {
+      fetchDetails: true,
+      fetchReviews: false,
+      fetchPhotos: false,
+      aiReviews: false,
+      aiPhotos: false,
+      triage: false,
+      aiReviewsExplicit: false,
+      aiPhotosExplicit: false,
+      triageExplicit: false,
+      checkIn: jobRecord.checkin,
+      checkOut: jobRecord.checkout,
+      adults: jobRecord.adults,
+      force: true,
+      retryFailed: false,
+      downloadPhotosAll: false,
+      outputDir: staged.rootDir,
+      scopeManifestToInput: false,
+      print: false,
+      programmatic: true,
+      hooks: {
+        onPhaseUpdate: async (update) => {
+          if (update.phase !== 'details') return;
+          const matchKey = getListingMatchKey(
+            update.entry.platform,
+            update.entry.url,
+          );
+          if (!targetKeys.has(matchKey)) return;
+          completedKeys.add(matchKey);
+          await prisma.reviewJob.update({
+            where: { id: reviewJobId },
+            data: {
+              priceRefreshStatus: 'running',
+              priceRefreshCurrentPhase:
+                `${update.entry.platform}:${update.entry.id}`,
+              priceRefreshProgress:
+                0.05 + (0.75 * completedKeys.size) / requested,
+            },
+          });
+        },
+        onEvent: async (event) => {
+          if (event.level === 'info') return;
+          await appendReviewJobEvent(reviewJobId, {
+            phase: 'price-refresh',
+            level: event.level,
+            message: event.message,
+            listingId: event.listingId ?? null,
+            listingPlatform: event.platform ?? null,
+            payload:
+              (event.payload ?? undefined) as
+                | Prisma.InputJsonValue
+                | undefined,
+          });
+        },
+      },
+    });
+
+    const outcomes = reconcilePriceRefreshManifest({
+      rootDir: staged.rootDir,
+      previousArtifactRoot: jobRecord.artifactRoot,
+      previousManifest: staged.previousManifest,
+      targetKeys,
+    });
+    const reconciledManifest = readJsonFile<AnalysisManifest>(
+      getManifestPathFromRoot(staged.rootDir),
+    );
+    if (!reconciledManifest) {
+      throw new Error('Reconciled price refresh manifest is missing');
+    }
+    const poi = asStoredMapPoint(jobRecord.poi);
+    injectPoiContextIntoListingArtifacts({
+      rootDir: staged.rootDir,
+      manifest: reconciledManifest,
+      poi,
+      fallbackListings: jobRecord.listings.map((listing) => ({
+        platform: listing.platform,
+        url: listing.url,
+        lat: listing.lat,
+        lng: listing.lng,
+        poiDistanceMeters: listing.poiDistanceMeters,
+      })),
+    });
+
+    const ttlMs = resolveStaySnapshotTtlMs();
+    const updates: Array<{
+      listing: typeof jobRecord.listings[number];
+      attempt: {
+        attemptedAt: string;
+        status: 'succeeded' | 'failed';
+        error: string | null;
+      };
+      snapshot: ReturnType<typeof parseStaySnapshot>;
+      details: Record<string, unknown> | null;
+      triage: Record<string, unknown> | null;
+    }> = [];
+
+    for (const outcome of outcomes) {
+      const listing = listingByKey.get(
+        getListingMatchKey(outcome.platform, outcome.url),
+      );
+      if (!listing) continue;
+      const attempt = {
+        attemptedAt,
+        status: outcome.status,
+        error: outcome.error,
+      };
+      if (outcome.status === 'failed' || !outcome.snapshot) {
+        updates.push({
+          listing,
+          attempt,
+          snapshot: null,
+          details: null,
+          triage: null,
+        });
+        continue;
+      }
+
+      const entry = Object.values(reconciledManifest.listings).find(
+        (candidate) =>
+          getListingMatchKey(candidate.platform, candidate.url)
+          === getListingMatchKey(outcome.platform, outcome.url),
+      );
+      const details = entry?.details.file
+        ? readJsonFile<Record<string, unknown>>(
+            path.join(staged.rootDir, entry.details.file),
+          )
+        : outcome.details;
+      const currentTriage = asStoredRecord(listing.analysis?.triage);
+      let triage = currentTriage;
+      if (
+        currentTriage?.scoreSource === 'deterministic_rubric'
+        && details
+      ) {
+        const snapshotReadModel = getReviewJobStaySnapshotReadModel({
+          job: jobRecord,
+          listing: {
+            ...listing,
+            staySnapshot:
+              outcome.snapshot as unknown as Prisma.JsonValue,
+            priceRefreshAttempt:
+              attempt as unknown as Prisma.JsonValue,
+          },
+          analysis: listing.analysis,
+          ttlMs,
+          now: startedAt,
+        });
+        triage = {
+          ...currentTriage,
+          affordability: computeReviewJobSnapshotAffordability({
+            job: jobRecord,
+            triage: currentTriage,
+            snapshot: snapshotReadModel,
+            now: startedAt,
+          }),
+        };
+        if (entry?.triage.file) {
+          writeJsonFile(
+            path.join(staged.rootDir, entry.triage.file),
+            triage,
+          );
+        }
+      }
+      updates.push({
+        listing,
+        attempt,
+        snapshot: outcome.snapshot,
+        details,
+        triage,
+      });
+    }
+
+    const succeeded = updates.filter(
+      (update) => update.attempt.status === 'succeeded',
+    ).length;
+    const failed = requested - succeeded;
+    const status: DbPhaseStatus =
+      failed === 0 ? 'completed' : succeeded === 0 ? 'failed' : 'partial';
+    const completedAt = new Date();
+    let reportPath = jobRecord.reportPath;
+    if (succeeded > 0) {
+      try {
+        const nextReportPath = getReportPathFromRoot(staged.rootDir);
+        await generateReport({
+          outputDir: staged.rootDir,
+          outputFile: nextReportPath,
+        });
+        reportPath = nextReportPath;
+      } catch (error) {
+        reportPath = null;
+        await appendReviewJobEvent(reviewJobId, {
+          phase: 'price-refresh',
+          level: 'warning',
+          message:
+            `Price snapshots were saved, but report regeneration failed: `
+            + `${error instanceof Error ? error.message : String(error)}`,
+        });
+      }
+    }
+
+    await prisma.$transaction(async (tx) => {
+      for (const update of updates) {
+        await tx.reviewJobListing.update({
+          where: { id: update.listing.id },
+          data: {
+            priceRefreshAttempt:
+              update.attempt as unknown as Prisma.InputJsonValue,
+            ...(update.snapshot
+              ? {
+                  staySnapshot:
+                    update.snapshot as unknown as Prisma.InputJsonValue,
+                }
+              : {}),
+          },
+        });
+        if (update.snapshot && update.details) {
+          await tx.reviewJobListingAnalysis.update({
+            where: { jobListingId: update.listing.id },
+            data: {
+              details:
+                update.details as unknown as Prisma.InputJsonValue,
+              detailsStatus: 'completed',
+              ...(update.triage
+                ? {
+                    triage:
+                      update.triage as unknown as Prisma.InputJsonValue,
+                  }
+                : {}),
+            },
+          });
+        }
+        if (update.attempt.status === 'failed') {
+          await tx.reviewJobEvent.create({
+            data: buildReviewJobEventData(reviewJobId, {
+              phase: 'price-refresh',
+              level: 'warning',
+              message:
+                `Price refresh failed; last known snapshot preserved. `
+                + `${update.attempt.error ?? 'Unknown provider failure'}`,
+              listingId: update.listing.listingId,
+              listingPlatform: update.listing.platform,
+            }),
+          });
+        }
+      }
+
+      await tx.reviewJob.update({
+        where: { id: reviewJobId },
+        data: {
+          priceRefreshStatus: status,
+          priceRefreshCurrentPhase: 'completed',
+          priceRefreshProgress: 1,
+          priceRefreshErrorMessage:
+            failed > 0
+              ? `${failed} of ${requested} price refreshes failed; last known snapshots were preserved.`
+              : null,
+          priceRefreshSummary: {
+            requested,
+            succeeded,
+            failed,
+          },
+          priceRefreshCompletedAt: completedAt,
+          priceRefreshDurationMs:
+            completedAt.getTime() - startedAt.getTime(),
+          ...(succeeded > 0
+            ? {
+                artifactRoot: staged.rootDir,
+                reportPath,
+              }
+            : {}),
+        },
+      });
+      await tx.reviewJobEvent.create({
+        data: buildReviewJobEventData(reviewJobId, {
+          phase: 'price-refresh',
+          level: failed === 0 ? 'info' : 'warning',
+          message:
+            failed === 0
+              ? `Refreshed ${succeeded} exact-stay price snapshots`
+              : `Price refresh completed with ${succeeded} succeeded and ${failed} failed`,
+          payload: {
+            requested,
+            succeeded,
+            failed,
+            reviewArtifactsRefreshed: false,
+            photoArtifactsRefreshed: false,
+            aiArtifactsRefreshed: false,
+          },
+        }),
+      });
+    });
+    console.log(
+      `[review-worker] price refresh completed ${reviewJobId}: `
+      + `${succeeded} succeeded, ${failed} failed`,
+    );
+  } catch (error) {
+    const completedAt = new Date();
+    const message =
+      error instanceof Error ? error.message : 'Price refresh failed';
+    const failedAttempt = {
+      attemptedAt,
+      status: 'failed' as const,
+      error: message,
+    };
+    await prisma.$transaction(async (tx) => {
+      await tx.reviewJobListing.updateMany({
+        where: { id: { in: jobRecord.listings.map((listing) => listing.id) } },
+        data: {
+          priceRefreshAttempt:
+            failedAttempt as unknown as Prisma.InputJsonValue,
+        },
+      });
+      await tx.reviewJob.update({
+        where: { id: reviewJobId },
+        data: {
+          priceRefreshStatus: 'failed',
+          priceRefreshCurrentPhase: 'failed',
+          priceRefreshErrorMessage: message,
+          priceRefreshSummary: {
+            requested,
+            succeeded: 0,
+            failed: requested,
+          },
+          priceRefreshCompletedAt: completedAt,
+          priceRefreshDurationMs:
+            completedAt.getTime() - startedAt.getTime(),
+        },
+      });
+      await tx.reviewJobEvent.create({
+        data: buildReviewJobEventData(reviewJobId, {
+          phase: 'price-refresh',
+          level: 'error',
+          message:
+            `Price refresh failed; all last known snapshots were preserved. ${message}`,
+          payload: {
+            requested,
+            succeeded: 0,
+            failed: requested,
+          },
+        }),
+      });
+    });
+    throw error;
+  }
 }
 
 async function runReviewJobAnalysis(
@@ -1617,6 +2081,13 @@ const reviewJobWorker = new Worker<ReviewJobQueueData>(
     await startupArtifactCleanup;
     if (job.data.phase === 'search') {
       await runReviewJobSearch(job.data.reviewJobId);
+      return;
+    }
+    if (job.data.phase === 'refresh-prices') {
+      await runReviewJobPriceRefresh(
+        job.data.reviewJobId,
+        job.data.listingRowIds ?? [],
+      );
       return;
     }
 

--- a/web/src/lib/staySnapshots.ts
+++ b/web/src/lib/staySnapshots.ts
@@ -1,0 +1,179 @@
+import type {
+  Prisma,
+  ReviewJob,
+  ReviewJobListing,
+  ReviewJobListingAnalysis,
+} from '@prisma/client';
+import { resolveArtifactCachePolicy } from '@cli/artifact-cache';
+import {
+  computeAffordability,
+  type AffordabilityBudget,
+  type AffordabilityResult,
+  type ComparableStayAvailability,
+  type ComparableStayPrice,
+} from '@cli/triage-rubric';
+import {
+  getStaySnapshotReadModel,
+  type StayRequestFingerprint,
+  type StaySnapshotReadModel,
+} from '@cli/stay-snapshot';
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function linkedRoomIdFromUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const blockId =
+      parsed.searchParams.get('matching_block_id')
+      ?? parsed.searchParams.get('highlighted_blocks');
+    return blockId?.match(/^(\d+)/)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveStaySnapshotTtlMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  return resolveArtifactCachePolicy(env).ttlMs.details;
+}
+
+export function buildReviewJobStayRequest(input: {
+  job: Pick<ReviewJob, 'checkin' | 'checkout' | 'adults'>;
+  listing: Pick<ReviewJobListing, 'platform' | 'listingId' | 'url'>;
+}): StayRequestFingerprint {
+  return {
+    platform: input.listing.platform,
+    listingId: input.listing.listingId,
+    checkIn: input.job.checkin ?? null,
+    checkOut: input.job.checkout ?? null,
+    adults: input.job.adults ?? null,
+    linkedRoomId:
+      input.listing.platform === 'booking'
+        ? linkedRoomIdFromUrl(input.listing.url)
+        : null,
+  };
+}
+
+export function getStoredBriefBudget(
+  triage: unknown,
+): AffordabilityBudget | null {
+  const triageRecord = asRecord(triage);
+  const requirementSet = asRecord(triageRecord?.requirementSet);
+  const parsedBudget = asRecord(requirementSet?.parsedBudget);
+  const maximumAmount = Number(parsedBudget?.maximumAmount);
+  const currency =
+    typeof parsedBudget?.currency === 'string'
+      ? parsedBudget.currency.trim().toUpperCase()
+      : '';
+  if (
+    parsedBudget?.basis !== 'stay'
+    || parsedBudget?.source !== 'brief'
+    || !Number.isFinite(maximumAmount)
+    || maximumAmount <= 0
+    || !/^[A-Z]{3}$/.test(currency)
+  ) {
+    return null;
+  }
+  return {
+    amount: maximumAmount,
+    currency,
+    basis: 'stay',
+    source: 'brief',
+  };
+}
+
+export function getReviewJobAffordabilityBudget(input: {
+  job: Pick<
+    ReviewJob,
+    'analysisBudgetAmount' | 'analysisBudgetCurrency'
+  >;
+  triage: unknown;
+}): AffordabilityBudget | null {
+  if (
+    input.job.analysisBudgetAmount != null
+    && input.job.analysisBudgetCurrency
+  ) {
+    return {
+      amount: input.job.analysisBudgetAmount,
+      currency: input.job.analysisBudgetCurrency,
+      basis: 'stay',
+      source: 'explicit',
+    };
+  }
+  return getStoredBriefBudget(input.triage);
+}
+
+export function getReviewJobStaySnapshotReadModel(input: {
+  job: Pick<
+    ReviewJob,
+    'checkin' | 'checkout' | 'adults'
+  >;
+  listing: Pick<
+    ReviewJobListing,
+    | 'platform'
+    | 'listingId'
+    | 'url'
+    | 'staySnapshot'
+    | 'priceRefreshAttempt'
+  >;
+  analysis?: Pick<ReviewJobListingAnalysis, 'details'> | null;
+  ttlMs?: number;
+  now?: Date | number;
+}): StaySnapshotReadModel {
+  const details = asRecord(input.analysis?.details);
+  return getStaySnapshotReadModel({
+    snapshot:
+      input.listing.staySnapshot
+      ?? details?.staySnapshot
+      ?? null,
+    fallbackRequest: buildReviewJobStayRequest(input),
+    refreshAttempt: input.listing.priceRefreshAttempt,
+    ttlMs: input.ttlMs ?? resolveStaySnapshotTtlMs(),
+    now: input.now,
+  });
+}
+
+export function getComparableStaySnapshotPrice(
+  snapshot: StaySnapshotReadModel,
+): ComparableStayPrice | null {
+  return snapshot.priceForStay
+    ? {
+        ...snapshot.priceForStay,
+        freshness: snapshot.freshness.price,
+      }
+    : null;
+}
+
+export function getComparableStaySnapshotAvailability(
+  snapshot: StaySnapshotReadModel,
+): ComparableStayAvailability {
+  return {
+    ...snapshot.availability,
+    freshness: snapshot.freshness.availability,
+  };
+}
+
+export function computeReviewJobSnapshotAffordability(input: {
+  job: Pick<
+    ReviewJob,
+    'analysisBudgetAmount' | 'analysisBudgetCurrency'
+  >;
+  triage: Prisma.JsonValue | Record<string, unknown> | null | undefined;
+  snapshot: StaySnapshotReadModel;
+  now?: Date;
+}): AffordabilityResult {
+  return computeAffordability({
+    budget: getReviewJobAffordabilityBudget({
+      job: input.job,
+      triage: input.triage,
+    }),
+    price: getComparableStaySnapshotPrice(input.snapshot),
+    availability: getComparableStaySnapshotAvailability(input.snapshot),
+    now: input.now,
+  });
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,5 +1,7 @@
 // Re-export and adapt types from the CLI for web usage
 // These mirror src/search/types.ts but are self-contained for the web app
+import type { AffordabilityResult } from '@cli/triage-rubric';
+import type { StaySnapshotReadModel } from '@cli/stay-snapshot';
 
 export interface BoundingBox {
   neLat: number;
@@ -215,6 +217,8 @@ export interface ReviewJobListing extends SearchResult {
   liked: boolean;
   hidden: boolean;
   poiDistanceMeters: number | null;
+  staySnapshot: StaySnapshotReadModel;
+  affordability: AffordabilityResult;
   analysis: ReviewJobListingAnalysis | null;
 }
 
@@ -227,6 +231,8 @@ export interface ReviewJobState {
   currentPhase: string;
   analysisStatus: PhaseStatus;
   analysisCurrentPhase: string | null;
+  priceRefreshStatus: PhaseStatus;
+  priceRefreshCurrentPhase: string | null;
   location: string | null;
   prompt: string | null;
   boundingBox: BoundingBox | null;
@@ -252,6 +258,16 @@ export interface ReviewJobState {
   analysisDurationMs: number | null;
   analysisStartedAt: string | null;
   analysisCompletedAt: string | null;
+  priceRefreshProgress: number;
+  priceRefreshErrorMessage: string | null;
+  priceRefreshSummary: {
+    requested: number;
+    succeeded: number;
+    failed: number;
+  } | null;
+  priceRefreshDurationMs: number | null;
+  priceRefreshStartedAt: string | null;
+  priceRefreshCompletedAt: string | null;
   costs: AiCostBreakdown;
   aiCostBudgetUsd: number | null;
   aiCostBudgetExceeded: boolean;


### PR DESCRIPTION
## Summary

- Add a versioned exact-stay snapshot shared by the CLI and StayReviewr: platform/listing identity, check-in/out, adults, Booking linked room ID, public full-stay price, capture time, charge resolution, and `yes`/`no`/`partial`/`unknown` availability.
- Reduce the existing details-cache default TTL from 7 days to 1 day through `REVIEWR_CACHE_DETAILS_TTL_DAYS`, while keeping review/photo TTLs at 30/180 days and deriving staleness at read time.
- Add whole-job and shortlist price refreshes that run only the details phase, bypass details-cache reads, preserve reviews/photos/AI/quality artifacts, and recompute affordability deterministically without another LLM call.
- Persist refresh progress, per-listing attempts, partial success, and exact-stay snapshots; failed extraction preserves the last snapshot and shared-cache entry.
- Surface exact dates, guests, public total, availability, snapshot age/staleness, provider-offered alternate dates, refresh failures, and the logged-out/Genius pricing boundary in both job and results views.
- Group fresh unavailable inventory outside actionable ranking while leaving stale `no` results visible as conditional and legacy snapshots explicitly unknown.

## Evidence boundaries

- Booking parsing is covered with captured fixture shapes for Conrad sold out, Residence Inn refusing the requested window while volunteering an alternate, and Residence Inn available at PLN 18,627 including taxes and charges.
- Airbnb search inclusion is not treated as availability evidence. A PDP public price may be retained while exact-stay inventory remains `unknown`; only an explicit provider refusal or volunteered alternate evidence can produce `no` or `partial`.
- Generic calendar windows are not promoted to provider-offered alternate ranges.
- Prices are public logged-out rates only. Account-specific/Genius pricing remains explicitly out of scope.
- One job remains one date range; multi-leg trips require separate jobs (tracked in #70).

## Failure and cache semantics

- Refresh success replaces the structured snapshot and details artifact.
- A provider/extraction failure records the attempt and error, restores the prior details artifact, and leaves the previous persisted snapshot untouched.
- Exact-date extraction that yields neither price nor explicit availability is not published to the shared details cache, so a failed refresh cannot displace reusable evidence.
- Partial refreshes commit successful listings and preserve failed listings in one database transaction.

## Schema / deploy note

This adds nullable snapshot/attempt fields on `ReviewJobListing` and dedicated price-refresh progress/status fields on `ReviewJob`. Prisma client generation was run locally. No live database or running stack was touched; the production schema push remains for the orchestrator's controlled merge/deploy window.

## Validation

- `pnpm test` — 142 passed
- `pnpm run build`
- `pnpm run lint`
- `npm --prefix web run test:pricing` — 3 passed
- `npm --prefix web run test:ui` — 9 passed
- `npm --prefix web run lint`
- `npm --prefix web run build`
- `git diff --check`

Closes #60
