### PR TITLE
feat: add per-priority evidence matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ reviewr batch --retry --triage --priorities "quiet, elevator" -o data/rome
 # Generate interactive HTML report
 reviewr report -o data/rome
 
+# Also write the versioned per-priority evidence matrix as JSON
+reviewr report -o data/rome --priorities-matrix
+
 # Ask follow-up questions about shortlisted properties
 reviewr ask "Is there free parking? ZTL zone?" --picks liked -o data/rome
 reviewr ask "How noisy at night?" --ids 12345,mamomi-house -o data/rome
@@ -139,7 +142,7 @@ npx tsx src/cli.ts <command> [options]
 | `reviewr analyze-photos <dir>` | AI photo analysis using Gemini vision |
 | `reviewr triage <file>` | AI triage -- grade listing against guest priorities |
 | `reviewr ask <question>` | Ask a question about shortlisted properties |
-| `reviewr report` | Generate HTML report from triage results |
+| `reviewr report` | Generate HTML report; add `--priorities-matrix [file]` for the evidence matrix JSON |
 | `reviewr scrape [path]` | Batch scrape reviews from CSV files |
 | `reviewr analytics [path]` | Run analytics on JSON output |
 | `reviewr transform [path]` | JSON to CSV (Booking only) |

--- a/docs/triage-rubric.md
+++ b/docs/triage-rubric.md
@@ -61,10 +61,8 @@ The prose brief and parsed budget are not themselves hashed. Equivalent canonica
 therefore remain comparable, while any material definition or parser-version change creates a new
 set.
 
-These IDs are also the column keys for the priorities matrix planned in #61. Each listing must
-classify the same IDs in the same order. A future matrix cell can display status, confidence,
-evidence, frequency/year metadata, and evidence gaps without attempting to align model-invented
-labels.
+These IDs are also the column keys for the priorities matrix. Each listing must classify the same
+IDs in the same order. Matrix cells are never aligned by model-authored labels.
 
 ### Splitting
 
@@ -343,6 +341,46 @@ Stored JSON without `scoreSource`, `rubricVersion`, and `requirementSetId` is
 - Never interleave old model-authored or old-classifier scores with current-policy scores.
 
 CLI/report output follows the same source/version and grouping rules.
+
+## Priorities matrix
+
+The native results page derives one per-job evidence matrix from persisted deterministic triage;
+it does not make another model call. `Availability` and `Affordability` are fixed leading axes,
+followed by the canonical requirements in their persisted order.
+
+The modal deterministic `requirementSetId` is the active column set. Only verdicts with exact
+canonical requirement IDs and the current comparability key populate those columns. A missing ID
+stays visibly missing. Insufficient-evidence verdicts keep their auditable cells but remain in a
+separate group outside peer ranking. Older-policy, legacy, mismatched-set, and unscored rows are
+also labeled and never silently label-aligned into current cells.
+
+Each classified priority cell carries:
+
+- status, confidence, note, and evidence gaps;
+- all raw matched support and contradiction evidence for drill-down;
+- one strongest status-aligned evidence line, preserving model order within a polarity;
+- the evidence frequency and years when the classifier supplied them.
+
+For `unmet`, contradiction evidence is strongest; for `met`, support evidence is strongest; for
+`partial`, contradiction precedes support. No evidence is synthesized. A missing reviews layer
+must say `No review data`.
+
+A ratio such as `42 of 250` in review evidence means **42 mentions among 250 AI-analyzed
+reviews**. It is not the provider's hotel review total. The row also exposes, separately, the
+number analyzed, the eligible post-filter count, and the total scraped artifact count from
+`batch_manifest.json`. When the analysis cap applies, the UI says so explicitly, for example:
+`250 analysed (capped from 1,924 eligible) · 2,632 scraped`. If manifest provenance has expired,
+these counts remain unknown rather than being guessed from the listing page.
+
+Every evidence axis is sortable. The first click puts risk first, while ranking-status groups stay
+isolated. The CLI emits the same versioned read model:
+
+```bash
+reviewr report -o data/rome --priorities-matrix
+reviewr report -o data/rome --priorities-matrix ./exports/rome-matrix.json
+```
+
+Without an explicit file, `priorities-matrix.json` is written beside the HTML report.
 
 ## Worked examples
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@
 // Usage: reviewr <url> | reviewr <command> [options]
 
 import { Command } from 'commander';
+import * as path from 'node:path';
 import { resolveProxy, applyProxyToEnv, saveProxy, showAuthStatus } from './config.js';
 import { detectPlatform, type Platform } from './utils.js';
 
@@ -623,6 +624,10 @@ program
   .description('Generate HTML report from triage results')
   .option('-o, --output-dir <dir>', 'Data directory with manifest + triage results')
   .option('--output-file <file>', 'Output HTML file path')
+  .option(
+    '--priorities-matrix [file]',
+    'Also write a per-priority evidence matrix as JSON',
+  )
   .action(async (cmdOpts: any, command: Command) => {
     const opts = command.optsWithGlobals();
     const { generateReport } = await import('./report.js');
@@ -632,6 +637,18 @@ program
       outputFile: cmdOpts.outputFile || undefined,
     });
     console.log(`Report: ${result}`);
+    if (cmdOpts.prioritiesMatrix) {
+      const { generatePrioritiesMatrixJson } =
+        await import('./priorities-matrix-report.js');
+      const matrixFile = generatePrioritiesMatrixJson({
+        outputDir,
+        outputFile:
+          typeof cmdOpts.prioritiesMatrix === 'string'
+            ? cmdOpts.prioritiesMatrix
+            : path.join(path.dirname(result), 'priorities-matrix.json'),
+      });
+      console.log(`Priorities matrix: ${matrixFile}`);
+    }
   });
 
 // --- auth command ---

--- a/src/priorities-matrix-report.ts
+++ b/src/priorities-matrix-report.ts
@@ -1,0 +1,201 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { resolveArtifactCachePolicy } from './artifact-cache.js';
+import {
+  buildPrioritiesMatrix,
+  type PrioritiesMatrix,
+  type PrioritiesMatrixAffordability,
+  type PrioritiesMatrixInputRow,
+} from './priorities-matrix.js';
+import {
+  getStaySnapshotReadModel,
+  parseStaySnapshot,
+  type StayRequestFingerprint,
+} from './stay-snapshot.js';
+
+export interface PrioritiesMatrixReportOptions {
+  outputDir: string;
+  outputFile?: string;
+  generatedAt?: string;
+  now?: Date | number;
+}
+
+interface ManifestPhase {
+  status?: string;
+  file?: string;
+  count?: number;
+  expected?: number;
+}
+
+interface ManifestEntry {
+  platform: 'airbnb' | 'booking';
+  id: string;
+  url: string;
+  details?: ManifestPhase;
+  reviews?: ManifestPhase;
+  aiReviews?: ManifestPhase;
+  triage?: ManifestPhase;
+}
+
+interface BatchManifest {
+  dates?: {
+    checkIn?: string;
+    checkOut?: string;
+    adults?: number;
+  };
+  listings?: Record<string, ManifestEntry>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asNonNegativeInteger(value: unknown): number | null {
+  return (
+    typeof value === 'number'
+    && Number.isInteger(value)
+    && value >= 0
+  )
+    ? value
+    : null;
+}
+
+function readJsonFile(filePath: string): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function readArtifact(
+  outputDir: string,
+  phase: ManifestPhase | undefined,
+): unknown {
+  if (!phase?.file) return null;
+  return readJsonFile(path.join(outputDir, phase.file));
+}
+
+function linkedRoomIdFromUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const blockId =
+      parsed.searchParams.get('matching_block_id')
+      ?? parsed.searchParams.get('highlighted_blocks');
+    return blockId?.match(/^(\d+)/)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function fallbackStayRequest(
+  entry: ManifestEntry,
+  dates: BatchManifest['dates'],
+): StayRequestFingerprint {
+  return {
+    platform: entry.platform,
+    listingId: entry.id,
+    checkIn: dates?.checkIn ?? null,
+    checkOut: dates?.checkOut ?? null,
+    adults: dates?.adults ?? null,
+    linkedRoomId:
+      entry.platform === 'booking'
+        ? linkedRoomIdFromUrl(entry.url)
+        : null,
+  };
+}
+
+function getAffordability(
+  triage: unknown,
+): Partial<PrioritiesMatrixAffordability> | null {
+  if (!isRecord(triage) || !isRecord(triage.affordability)) {
+    return null;
+  }
+  return triage.affordability as Partial<PrioritiesMatrixAffordability>;
+}
+
+export function buildPrioritiesMatrixFromArtifacts(
+  options: PrioritiesMatrixReportOptions,
+): PrioritiesMatrix {
+  const outputDir = path.resolve(options.outputDir);
+  const manifestPath = path.join(outputDir, 'batch_manifest.json');
+  const manifest = readJsonFile(manifestPath) as BatchManifest | null;
+  if (!manifest?.listings) {
+    throw new Error(`Manifest not found or invalid: ${manifestPath}`);
+  }
+
+  const detailsTtlMs = resolveArtifactCachePolicy().ttlMs.details;
+  const rows: PrioritiesMatrixInputRow[] = Object.values(
+    manifest.listings,
+  ).map((entry) => {
+    const details = readArtifact(outputDir, entry.details);
+    const detailsRecord = isRecord(details) ? details : null;
+    const triage = readArtifact(outputDir, entry.triage);
+    const parsedSnapshot = parseStaySnapshot(detailsRecord?.staySnapshot);
+    const staySnapshot = getStaySnapshotReadModel({
+      snapshot: detailsRecord?.staySnapshot ?? null,
+      fallbackRequest:
+        parsedSnapshot?.request
+        ?? fallbackStayRequest(entry, manifest.dates),
+      ttlMs: detailsTtlMs,
+      now: options.now,
+    });
+    const analyzedReviewCount = asNonNegativeInteger(
+      entry.aiReviews?.count,
+    );
+    const eligibleReviewCount = asNonNegativeInteger(
+      entry.aiReviews?.expected,
+    );
+
+    return {
+      id: entry.id,
+      platform: entry.platform,
+      name:
+        (typeof detailsRecord?.title === 'string' && detailsRecord.title)
+        || (typeof detailsRecord?.name === 'string' && detailsRecord.name)
+        || entry.id,
+      url: entry.url,
+      triage,
+      availability: {
+        status: staySnapshot.availability.status,
+        freshness: staySnapshot.freshness.availability,
+        eligibility: staySnapshot.bookingEligibility.status,
+        reasonCode: staySnapshot.bookingEligibility.reasonCode,
+        reason: staySnapshot.bookingEligibility.reason,
+        capturedAt: staySnapshot.availability.capturedAt,
+        availableRange: staySnapshot.availability.availableRange ?? null,
+      },
+      affordability: getAffordability(triage),
+      reviewSample: {
+        totalScrapedReviewCount:
+          asNonNegativeInteger(entry.reviews?.count),
+        eligibleReviewCount,
+        analyzedReviewCount,
+        capped:
+          analyzedReviewCount != null && eligibleReviewCount != null
+            ? analyzedReviewCount < eligibleReviewCount
+            : null,
+        source:
+          analyzedReviewCount != null || eligibleReviewCount != null
+            ? 'batch_manifest'
+            : 'unknown',
+      },
+    };
+  });
+
+  return buildPrioritiesMatrix(rows, {
+    generatedAt: options.generatedAt,
+  });
+}
+
+export function generatePrioritiesMatrixJson(
+  options: PrioritiesMatrixReportOptions,
+): string {
+  const matrix = buildPrioritiesMatrixFromArtifacts(options);
+  const outputDir = path.resolve(options.outputDir);
+  const outputFile = options.outputFile
+    ? path.resolve(options.outputFile)
+    : path.join(outputDir, 'priorities-matrix.json');
+  fs.writeFileSync(outputFile, JSON.stringify(matrix, null, 2), 'utf8');
+  return outputFile;
+}

--- a/src/priorities-matrix.ts
+++ b/src/priorities-matrix.ts
@@ -1,0 +1,923 @@
+import {
+  getCurrentTriageComparability,
+  getTriageComparabilityKey,
+} from './triage-comparability.js';
+import type {
+  RequirementConfidence,
+  RequirementStatus,
+  RequirementType,
+} from './triage-rubric.js';
+import type {
+  StayAvailabilityStatus,
+  StaySnapshotFreshness,
+} from './stay-snapshot.js';
+
+export const PRIORITIES_MATRIX_SCHEMA_VERSION = 1;
+
+export type PrioritiesMatrixEvidenceGap =
+  | 'details'
+  | 'reviews'
+  | 'photos';
+
+export type PrioritiesMatrixRankingStatus =
+  | 'ranked'
+  | 'insufficient_evidence'
+  | 'legacy'
+  | 'stale_requirement_set'
+  | 'stale_classifier_policy'
+  | 'unscored';
+
+export interface PrioritiesMatrixFrequency {
+  raw: string | null;
+  mentions: number | null;
+  analyzedReviewCount: number | null;
+  denominatorMeaning: 'ai_analyzed_reviews' | null;
+  display: string | null;
+}
+
+export interface PrioritiesMatrixEvidence {
+  layer: 'details' | 'reviews' | 'photos' | 'unknown';
+  polarity: 'supports' | 'contradicts' | 'unknown';
+  text: string;
+  frequency: PrioritiesMatrixFrequency;
+  years: number[];
+}
+
+export interface PrioritiesMatrixPriorityCell {
+  requirementId: string;
+  state: 'classified' | 'missing' | 'unavailable';
+  unavailableReason: Exclude<
+    PrioritiesMatrixRankingStatus,
+    'ranked' | 'insufficient_evidence'
+  > | 'requirement_missing' | null;
+  status: RequirementStatus;
+  confidence: RequirementConfidence | null;
+  note: string | null;
+  strongestEvidence: PrioritiesMatrixEvidence | null;
+  evidence: PrioritiesMatrixEvidence[];
+  evidenceGaps: PrioritiesMatrixEvidenceGap[];
+}
+
+export interface PrioritiesMatrixPriorityColumn {
+  requirementId: string;
+  label: string;
+  type: RequirementType | null;
+  rank: number | null;
+  weight: number | null;
+  order: number;
+  sourceText: string | null;
+  criteria: string[];
+}
+
+export interface PrioritiesMatrixReviewSample {
+  totalScrapedReviewCount: number | null;
+  eligibleReviewCount: number | null;
+  analyzedReviewCount: number | null;
+  capped: boolean | null;
+  source: 'batch_manifest' | 'unknown';
+}
+
+export interface PrioritiesMatrixAvailability {
+  status: StayAvailabilityStatus;
+  freshness: StaySnapshotFreshness;
+  eligibility: 'eligible' | 'excluded' | 'conditional' | 'unknown';
+  reasonCode: string | null;
+  reason: string | null;
+  capturedAt: string | null;
+  availableRange: {
+    checkIn: string;
+    checkOut: string;
+  } | null;
+}
+
+export interface PrioritiesMatrixAffordability {
+  status: 'within' | 'over' | 'unknown';
+  reasonCode: string | null;
+  reason: string | null;
+  budgetAmount: number | null;
+  priceAmount: number | null;
+  currency: string | null;
+  overByAmount: number | null;
+  overByPercent: number | null;
+}
+
+export interface PrioritiesMatrixInputRow {
+  id: string;
+  platform: string;
+  name: string;
+  url: string;
+  triage: unknown;
+  availability?: Partial<PrioritiesMatrixAvailability> | null;
+  affordability?: Partial<PrioritiesMatrixAffordability> | null;
+  reviewSample?: Partial<PrioritiesMatrixReviewSample> | null;
+}
+
+export interface PrioritiesMatrixRow {
+  id: string;
+  platform: string;
+  name: string;
+  url: string;
+  sourceOrder: number;
+  rankingStatus: PrioritiesMatrixRankingStatus;
+  coverage: number | null;
+  reviewSample: PrioritiesMatrixReviewSample;
+  availability: PrioritiesMatrixAvailability;
+  affordability: PrioritiesMatrixAffordability;
+  priorities: Record<string, PrioritiesMatrixPriorityCell>;
+}
+
+export interface PrioritiesMatrix {
+  schemaVersion: typeof PRIORITIES_MATRIX_SCHEMA_VERSION;
+  generatedAt: string;
+  activeRequirementSetId: string | null;
+  fixedAxes: ['availability', 'affordability'];
+  columns: PrioritiesMatrixPriorityColumn[];
+  rows: PrioritiesMatrixRow[];
+}
+
+export type PrioritiesMatrixSortDirection = 'risk' | 'fit';
+
+interface ParsedTriageRequirement {
+  requirementId: string;
+  label: string;
+  type: RequirementType | null;
+  rank: number | null;
+  weight: number | null;
+  order: number;
+  sourceText: string | null;
+  criteria: string[];
+  status: RequirementStatus;
+  confidence: RequirementConfidence | null;
+  note: string | null;
+  evidence: PrioritiesMatrixEvidence[];
+}
+
+interface ParsedTriage {
+  present: boolean;
+  deterministic: boolean;
+  requirementSetId: string | null;
+  comparabilityKey: string | null;
+  rankingStatus: 'ranked' | 'insufficient_evidence' | null;
+  coverage: number | null;
+  evidenceGaps: PrioritiesMatrixEvidenceGap[];
+  definitions: PrioritiesMatrixPriorityColumn[];
+  requirements: ParsedTriageRequirement[];
+}
+
+const EVIDENCE_GAP_ORDER: PrioritiesMatrixEvidenceGap[] = [
+  'details',
+  'reviews',
+  'photos',
+];
+
+const REQUIREMENT_TYPES = new Set<RequirementType>([
+  'deal_breaker',
+  'must_have',
+  'priority',
+  'nice_to_have',
+]);
+
+const REQUIREMENT_STATUSES = new Set<RequirementStatus>([
+  'met',
+  'partial',
+  'unmet',
+  'unknown',
+]);
+
+const REQUIREMENT_CONFIDENCES = new Set<RequirementConfidence>([
+  'high',
+  'medium',
+  'low',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function asNonNegativeInteger(value: unknown): number | null {
+  return (
+    typeof value === 'number'
+    && Number.isInteger(value)
+    && value >= 0
+  )
+    ? value
+    : null;
+}
+
+function asRequirementType(value: unknown): RequirementType | null {
+  return REQUIREMENT_TYPES.has(value as RequirementType)
+    ? value as RequirementType
+    : null;
+}
+
+function asRequirementStatus(value: unknown): RequirementStatus {
+  return REQUIREMENT_STATUSES.has(value as RequirementStatus)
+    ? value as RequirementStatus
+    : 'unknown';
+}
+
+function asRequirementConfidence(
+  value: unknown,
+): RequirementConfidence | null {
+  return REQUIREMENT_CONFIDENCES.has(value as RequirementConfidence)
+    ? value as RequirementConfidence
+    : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map(asString)
+    .filter((item): item is string => item != null);
+}
+
+function asYearArray(value: unknown): number[] {
+  if (!Array.isArray(value)) return [];
+  return [
+    ...new Set(
+      value.filter(
+        (item): item is number =>
+          typeof item === 'number'
+          && Number.isInteger(item)
+          && item >= 1900
+          && item <= 3000,
+      ),
+    ),
+  ].sort((left, right) => right - left);
+}
+
+export function parsePrioritiesMatrixFrequency(
+  value: unknown,
+): PrioritiesMatrixFrequency {
+  const raw = asString(value);
+  if (!raw) {
+    return {
+      raw: null,
+      mentions: null,
+      analyzedReviewCount: null,
+      denominatorMeaning: null,
+      display: null,
+    };
+  }
+
+  const match = raw.match(
+    /\b([\d,]+)\s*(?:\/|of|out\s+of)\s*([\d,]+)\b/i,
+  );
+  const mentions = match ? Number(match[1].replace(/,/g, '')) : null;
+  const analyzedReviewCount = match
+    ? Number(match[2].replace(/,/g, ''))
+    : null;
+  const hasValidRatio =
+    mentions != null
+    && analyzedReviewCount != null
+    && Number.isInteger(mentions)
+    && Number.isInteger(analyzedReviewCount)
+    && mentions >= 0
+    && analyzedReviewCount > 0
+    && mentions <= analyzedReviewCount;
+
+  if (!hasValidRatio) {
+    return {
+      raw,
+      mentions: null,
+      analyzedReviewCount: null,
+      denominatorMeaning: null,
+      display: raw,
+    };
+  }
+
+  return {
+    raw,
+    mentions,
+    analyzedReviewCount,
+    denominatorMeaning: 'ai_analyzed_reviews',
+    display:
+      `${mentions.toLocaleString('en-US')} of `
+      + `${analyzedReviewCount.toLocaleString('en-US')} AI-analyzed reviews`,
+  };
+}
+
+function parseEvidence(value: unknown): PrioritiesMatrixEvidence | null {
+  if (!isRecord(value)) return null;
+  const text = asString(value.text);
+  if (!text) return null;
+
+  const layer =
+    value.layer === 'details'
+    || value.layer === 'reviews'
+    || value.layer === 'photos'
+      ? value.layer
+      : 'unknown';
+  const polarity =
+    value.polarity === 'supports'
+    || value.polarity === 'contradicts'
+      ? value.polarity
+      : 'unknown';
+
+  return {
+    layer,
+    polarity,
+    text,
+    frequency: parsePrioritiesMatrixFrequency(value.frequency),
+    years: asYearArray(value.years),
+  };
+}
+
+function parseDefinition(
+  value: unknown,
+  fallbackOrder: number,
+): PrioritiesMatrixPriorityColumn | null {
+  if (!isRecord(value)) return null;
+  const requirementId = asString(value.id) ?? asString(value.requirementId);
+  if (!requirementId) return null;
+
+  return {
+    requirementId,
+    label:
+      asString(value.label)
+      ?? asString(value.requirement)
+      ?? requirementId,
+    type: asRequirementType(value.type),
+    rank: asNumber(value.rank),
+    weight: asNumber(value.weight),
+    order: asNumber(value.order) ?? fallbackOrder,
+    sourceText: asString(value.sourceText),
+    criteria: asStringArray(value.criteria),
+  };
+}
+
+function parseRequirement(
+  value: unknown,
+  fallbackOrder: number,
+): ParsedTriageRequirement | null {
+  const definition = parseDefinition(value, fallbackOrder);
+  if (!definition || !isRecord(value)) return null;
+  const requirementId =
+    asString(value.requirementId) ?? definition.requirementId;
+
+  const evidence = Array.isArray(value.evidence)
+    ? value.evidence
+        .map(parseEvidence)
+        .filter((item): item is PrioritiesMatrixEvidence => item != null)
+    : [];
+
+  return {
+    ...definition,
+    requirementId,
+    status: asRequirementStatus(value.status),
+    confidence: asRequirementConfidence(value.confidence),
+    note: asString(value.note),
+    evidence,
+  };
+}
+
+function parseEvidenceGaps(value: unknown): PrioritiesMatrixEvidenceGap[] {
+  if (!Array.isArray(value)) return [];
+  const provided = new Set(value);
+  return EVIDENCE_GAP_ORDER.filter((gap) => provided.has(gap));
+}
+
+function parseTriage(value: unknown): ParsedTriage {
+  if (!isRecord(value)) {
+    return {
+      present: false,
+      deterministic: false,
+      requirementSetId: null,
+      comparabilityKey: null,
+      rankingStatus: null,
+      coverage: null,
+      evidenceGaps: [],
+      definitions: [],
+      requirements: [],
+    };
+  }
+
+  const requirementSetId = asString(value.requirementSetId);
+  const rubricVersion = asString(value.rubricVersion);
+  const classifierVersion = asString(value.classifierVersion);
+  const deterministic =
+    value.scoreSource === 'deterministic_rubric'
+    && requirementSetId != null
+    && rubricVersion != null;
+  const requirementSet = isRecord(value.requirementSet)
+    ? value.requirementSet
+    : null;
+  const definitions = Array.isArray(requirementSet?.definitions)
+    ? requirementSet.definitions
+        .map(parseDefinition)
+        .filter(
+          (item): item is PrioritiesMatrixPriorityColumn => item != null,
+        )
+    : [];
+  const requirements = Array.isArray(value.requirements)
+    ? value.requirements
+        .map(parseRequirement)
+        .filter((item): item is ParsedTriageRequirement => item != null)
+    : [];
+
+  return {
+    present: true,
+    deterministic,
+    requirementSetId: deterministic ? requirementSetId : null,
+    comparabilityKey:
+      deterministic
+        ? getTriageComparabilityKey({
+            rubricVersion,
+            requirementSetId,
+            classifierVersion,
+          })
+        : null,
+    rankingStatus:
+      value.rankingStatus === 'insufficient_evidence'
+        ? 'insufficient_evidence'
+        : value.rankingStatus === 'ranked'
+          ? 'ranked'
+          : null,
+    coverage: asNumber(value.coverage),
+    evidenceGaps: parseEvidenceGaps(value.evidenceGaps),
+    definitions,
+    requirements,
+  };
+}
+
+function getActiveRequirementSetId(
+  triages: ParsedTriage[],
+): string | null {
+  const counts = new Map<string, { count: number; firstIndex: number }>();
+  triages.forEach((triage, index) => {
+    if (!triage.deterministic || !triage.requirementSetId) return;
+    const current = counts.get(triage.requirementSetId);
+    counts.set(triage.requirementSetId, {
+      count: (current?.count ?? 0) + 1,
+      firstIndex: current?.firstIndex ?? index,
+    });
+  });
+
+  return (
+    [...counts.entries()]
+      .sort(
+        (left, right) =>
+          right[1].count - left[1].count
+          || left[1].firstIndex - right[1].firstIndex,
+      )[0]?.[0]
+    ?? null
+  );
+}
+
+function getColumns(
+  triages: ParsedTriage[],
+  activeRequirementSetId: string | null,
+): PrioritiesMatrixPriorityColumn[] {
+  if (!activeRequirementSetId) return [];
+  const activeComparison = getCurrentTriageComparability(
+    activeRequirementSetId,
+  );
+  const candidates = triages
+    .map((triage, index) => ({ triage, index }))
+    .filter(
+      ({ triage }) =>
+        triage.deterministic
+        && triage.requirementSetId === activeRequirementSetId,
+    )
+    .sort(
+      (left, right) =>
+        Number(right.triage.comparabilityKey === activeComparison.key)
+        - Number(left.triage.comparabilityKey === activeComparison.key)
+        || right.triage.definitions.length - left.triage.definitions.length
+        || right.triage.requirements.length - left.triage.requirements.length
+        || left.index - right.index,
+    );
+  const selected = candidates[0]?.triage;
+  if (!selected) return [];
+
+  const source =
+    selected.definitions.length > 0
+      ? selected.definitions
+      : selected.requirements;
+  const seen = new Set<string>();
+  return source
+    .filter((column) => {
+      if (seen.has(column.requirementId)) return false;
+      seen.add(column.requirementId);
+      return true;
+    })
+    .map((column) => ({
+      requirementId: column.requirementId,
+      label: column.label,
+      type: column.type,
+      rank: column.rank,
+      weight: column.weight,
+      order: column.order,
+      sourceText: column.sourceText,
+      criteria: [...column.criteria],
+    }))
+    .sort(
+      (left, right) =>
+        left.order - right.order
+        || left.requirementId.localeCompare(right.requirementId),
+    );
+}
+
+function getRowRankingStatus(
+  triage: ParsedTriage,
+  activeRequirementSetId: string | null,
+): PrioritiesMatrixRankingStatus {
+  if (!triage.deterministic) {
+    return triage.present ? 'legacy' : 'unscored';
+  }
+  if (
+    activeRequirementSetId
+    && triage.requirementSetId !== activeRequirementSetId
+  ) {
+    return 'stale_requirement_set';
+  }
+  if (
+    activeRequirementSetId
+    && triage.comparabilityKey
+      !== getCurrentTriageComparability(activeRequirementSetId).key
+  ) {
+    return 'stale_classifier_policy';
+  }
+  if (
+    triage.rankingStatus === 'insufficient_evidence'
+    || (triage.coverage != null && triage.coverage < 0.5)
+  ) {
+    return 'insufficient_evidence';
+  }
+  return 'ranked';
+}
+
+function selectStrongestEvidence(
+  status: RequirementStatus,
+  evidence: PrioritiesMatrixEvidence[],
+): PrioritiesMatrixEvidence | null {
+  const preferredPolarity =
+    status === 'met'
+      ? 'supports'
+      : status === 'unmet' || status === 'partial'
+        ? 'contradicts'
+        : null;
+  return (
+    (preferredPolarity
+      ? evidence.find((item) => item.polarity === preferredPolarity)
+      : null)
+    ?? evidence[0]
+    ?? null
+  );
+}
+
+function unavailableCell(
+  requirementId: string,
+  reason: PrioritiesMatrixPriorityCell['unavailableReason'],
+  evidenceGaps: PrioritiesMatrixEvidenceGap[],
+): PrioritiesMatrixPriorityCell {
+  return {
+    requirementId,
+    state: reason === 'requirement_missing' ? 'missing' : 'unavailable',
+    unavailableReason: reason,
+    status: 'unknown',
+    confidence: null,
+    note: null,
+    strongestEvidence: null,
+    evidence: [],
+    evidenceGaps,
+  };
+}
+
+function buildPriorityCells(input: {
+  triage: ParsedTriage;
+  columns: PrioritiesMatrixPriorityColumn[];
+  rankingStatus: PrioritiesMatrixRankingStatus;
+}): Record<string, PrioritiesMatrixPriorityCell> {
+  const requirements = new Map(
+    input.triage.requirements.map((requirement) => [
+      requirement.requirementId,
+      requirement,
+    ]),
+  );
+
+  return Object.fromEntries(
+    input.columns.map((column) => {
+      if (
+        input.rankingStatus !== 'ranked'
+        && input.rankingStatus !== 'insufficient_evidence'
+      ) {
+        return [
+          column.requirementId,
+          unavailableCell(
+            column.requirementId,
+            input.rankingStatus,
+            input.triage.evidenceGaps,
+          ),
+        ];
+      }
+
+      const requirement = requirements.get(column.requirementId);
+      if (!requirement) {
+        return [
+          column.requirementId,
+          unavailableCell(
+            column.requirementId,
+            'requirement_missing',
+            input.triage.evidenceGaps,
+          ),
+        ];
+      }
+
+      return [
+        column.requirementId,
+        {
+          requirementId: column.requirementId,
+          state: 'classified',
+          unavailableReason: null,
+          status: requirement.status,
+          confidence: requirement.confidence,
+          note: requirement.note,
+          strongestEvidence: selectStrongestEvidence(
+            requirement.status,
+            requirement.evidence,
+          ),
+          evidence: requirement.evidence,
+          evidenceGaps: input.triage.evidenceGaps,
+        },
+      ];
+    }),
+  );
+}
+
+function normalizeReviewSample(
+  value: PrioritiesMatrixInputRow['reviewSample'],
+): PrioritiesMatrixReviewSample {
+  const totalScrapedReviewCount = asNonNegativeInteger(
+    value?.totalScrapedReviewCount,
+  );
+  const eligibleReviewCount = asNonNegativeInteger(
+    value?.eligibleReviewCount,
+  );
+  const analyzedReviewCount = asNonNegativeInteger(
+    value?.analyzedReviewCount,
+  );
+  const hasManifestSample =
+    value?.source === 'batch_manifest'
+    && (analyzedReviewCount != null || eligibleReviewCount != null);
+
+  return {
+    totalScrapedReviewCount,
+    eligibleReviewCount,
+    analyzedReviewCount,
+    capped:
+      typeof value?.capped === 'boolean'
+        ? value.capped
+        : analyzedReviewCount != null && eligibleReviewCount != null
+          ? analyzedReviewCount < eligibleReviewCount
+          : null,
+    source: hasManifestSample ? 'batch_manifest' : 'unknown',
+  };
+}
+
+function normalizeAvailability(
+  value: PrioritiesMatrixInputRow['availability'],
+): PrioritiesMatrixAvailability {
+  const availableRange =
+    isRecord(value?.availableRange)
+    && asString(value.availableRange.checkIn)
+    && asString(value.availableRange.checkOut)
+      ? {
+          checkIn: asString(value.availableRange.checkIn)!,
+          checkOut: asString(value.availableRange.checkOut)!,
+        }
+      : null;
+
+  return {
+    status:
+      value?.status === 'yes'
+      || value?.status === 'no'
+      || value?.status === 'partial'
+      || value?.status === 'unknown'
+        ? value.status
+        : 'unknown',
+    freshness:
+      value?.freshness === 'fresh'
+      || value?.freshness === 'stale'
+      || value?.freshness === 'unknown'
+        ? value.freshness
+        : 'unknown',
+    eligibility:
+      value?.eligibility === 'eligible'
+      || value?.eligibility === 'excluded'
+      || value?.eligibility === 'conditional'
+      || value?.eligibility === 'unknown'
+        ? value.eligibility
+        : 'unknown',
+    reasonCode: asString(value?.reasonCode),
+    reason: asString(value?.reason),
+    capturedAt: asString(value?.capturedAt),
+    availableRange,
+  };
+}
+
+function normalizeAffordability(
+  value: PrioritiesMatrixInputRow['affordability'],
+): PrioritiesMatrixAffordability {
+  return {
+    status:
+      value?.status === 'within'
+      || value?.status === 'over'
+      || value?.status === 'unknown'
+        ? value.status
+        : 'unknown',
+    reasonCode: asString(value?.reasonCode),
+    reason: asString(value?.reason),
+    budgetAmount: asNumber(value?.budgetAmount),
+    priceAmount: asNumber(value?.priceAmount),
+    currency: asString(value?.currency),
+    overByAmount: asNumber(value?.overByAmount),
+    overByPercent: asNumber(value?.overByPercent),
+  };
+}
+
+export function buildPrioritiesMatrix(
+  rows: PrioritiesMatrixInputRow[],
+  options: { generatedAt?: string } = {},
+): PrioritiesMatrix {
+  const triages = rows.map((row) => parseTriage(row.triage));
+  const activeRequirementSetId = getActiveRequirementSetId(triages);
+  const columns = getColumns(triages, activeRequirementSetId);
+
+  return {
+    schemaVersion: PRIORITIES_MATRIX_SCHEMA_VERSION,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    activeRequirementSetId,
+    fixedAxes: ['availability', 'affordability'],
+    columns,
+    rows: rows.map((row, index) => {
+      const triage = triages[index];
+      const rankingStatus = getRowRankingStatus(
+        triage,
+        activeRequirementSetId,
+      );
+      return {
+        id: row.id,
+        platform: row.platform,
+        name: row.name,
+        url: row.url,
+        sourceOrder: index,
+        rankingStatus,
+        coverage: triage.coverage,
+        reviewSample: normalizeReviewSample(row.reviewSample),
+        availability: normalizeAvailability(row.availability),
+        affordability: normalizeAffordability(row.affordability),
+        priorities: buildPriorityCells({
+          triage,
+          columns,
+          rankingStatus,
+        }),
+      };
+    }),
+  };
+}
+
+export function getPrioritiesMatrixRankingGroup(
+  status: PrioritiesMatrixRankingStatus,
+): number {
+  switch (status) {
+    case 'ranked':
+      return 0;
+    case 'insufficient_evidence':
+      return 1;
+    case 'stale_classifier_policy':
+      return 2;
+    case 'legacy':
+    case 'stale_requirement_set':
+      return 3;
+    case 'unscored':
+      return 4;
+  }
+}
+
+function priorityRiskRank(
+  status: RequirementStatus,
+): number {
+  switch (status) {
+    case 'unmet':
+      return 0;
+    case 'partial':
+      return 1;
+    case 'unknown':
+      return 2;
+    case 'met':
+      return 3;
+  }
+}
+
+function availabilityRiskRank(
+  availability: PrioritiesMatrixAvailability,
+): number {
+  switch (availability.eligibility) {
+    case 'excluded':
+      return 0;
+    case 'conditional':
+      return 1;
+    case 'unknown':
+      return 2;
+    case 'eligible':
+      return 3;
+  }
+}
+
+function affordabilityRiskRank(
+  affordability: PrioritiesMatrixAffordability,
+): number {
+  switch (affordability.status) {
+    case 'over':
+      return 0;
+    case 'unknown':
+      return 1;
+    case 'within':
+      return 2;
+  }
+}
+
+function compareNullableDescending(
+  left: number | null,
+  right: number | null,
+): number {
+  if (left == null && right == null) return 0;
+  if (left == null) return 1;
+  if (right == null) return -1;
+  return right - left;
+}
+
+function frequencyRate(
+  cell: PrioritiesMatrixPriorityCell | undefined,
+): number | null {
+  const frequency = cell?.strongestEvidence?.frequency;
+  if (
+    frequency?.mentions == null
+    || frequency.analyzedReviewCount == null
+    || frequency.analyzedReviewCount <= 0
+  ) {
+    return null;
+  }
+  return frequency.mentions / frequency.analyzedReviewCount;
+}
+
+export function sortPrioritiesMatrixRows(
+  rows: PrioritiesMatrixRow[],
+  sortKey: 'availability' | 'affordability' | string | null,
+  direction: PrioritiesMatrixSortDirection = 'risk',
+): PrioritiesMatrixRow[] {
+  const factor = direction === 'risk' ? 1 : -1;
+  return [...rows].sort((left, right) => {
+    const groupDifference =
+      getPrioritiesMatrixRankingGroup(left.rankingStatus)
+      - getPrioritiesMatrixRankingGroup(right.rankingStatus);
+    if (groupDifference !== 0) return groupDifference;
+    if (!sortKey) return left.sourceOrder - right.sourceOrder;
+
+    if (sortKey === 'availability') {
+      const difference =
+        availabilityRiskRank(left.availability)
+        - availabilityRiskRank(right.availability);
+      if (difference !== 0) return difference * factor;
+    } else if (sortKey === 'affordability') {
+      const difference =
+        affordabilityRiskRank(left.affordability)
+        - affordabilityRiskRank(right.affordability);
+      if (difference !== 0) return difference * factor;
+      if (
+        left.affordability.status === 'over'
+        && right.affordability.status === 'over'
+      ) {
+        const overageDifference = compareNullableDescending(
+          left.affordability.overByPercent,
+          right.affordability.overByPercent,
+        );
+        if (overageDifference !== 0) return overageDifference * factor;
+      }
+    } else {
+      const leftCell = left.priorities[sortKey];
+      const rightCell = right.priorities[sortKey];
+      const difference =
+        priorityRiskRank(leftCell?.status ?? 'unknown')
+        - priorityRiskRank(rightCell?.status ?? 'unknown');
+      if (difference !== 0) return difference * factor;
+
+      const frequencyDifference = compareNullableDescending(
+        frequencyRate(leftCell),
+        frequencyRate(rightCell),
+      );
+      if (frequencyDifference !== 0) return frequencyDifference * factor;
+    }
+
+    return left.sourceOrder - right.sourceOrder;
+  });
+}

--- a/tests/priorities-matrix.test.ts
+++ b/tests/priorities-matrix.test.ts
@@ -1,0 +1,635 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import test from 'node:test';
+import {
+  buildPrioritiesMatrix,
+  parsePrioritiesMatrixFrequency,
+  sortPrioritiesMatrixRows,
+  type PrioritiesMatrixInputRow,
+} from '../src/priorities-matrix.js';
+import {
+  buildPrioritiesMatrixFromArtifacts,
+  generatePrioritiesMatrixJson,
+} from '../src/priorities-matrix-report.js';
+import {
+  TRIAGE_CLASSIFIER_VERSION,
+  TRIAGE_RUBRIC_VERSION,
+} from '../src/triage-comparability.js';
+
+const repositoryRoot = process.cwd();
+const requirementSet = {
+  id: 'reqset_sleep_fixture',
+  schemaVersion: 1,
+  parserVersion: 'fixture-parser-v1',
+  brief: 'Quiet sleep and a usable workspace',
+  definitions: [
+    {
+      id: 'req-01-quiet-sleep',
+      label: 'Quiet sleep',
+      type: 'priority',
+      rank: 1,
+      weight: 3,
+      sourceText: 'Quiet sleep',
+      criteria: ['No persistent HVAC noise'],
+      order: 1,
+    },
+    {
+      id: 'req-02-workspace',
+      label: 'Workspace',
+      type: 'must_have',
+      rank: null,
+      weight: 3,
+      sourceText: 'A usable desk',
+      criteria: ['Desk and chair'],
+      order: 2,
+    },
+  ],
+  parsedBudget: null,
+};
+
+function triage(options: {
+  rankingStatus?: 'ranked' | 'insufficient_evidence';
+  coverage?: number;
+  classifierVersion?: string;
+  set?: typeof requirementSet;
+  requirements?: Array<Record<string, unknown>>;
+  affordability?: Record<string, unknown>;
+} = {}): Record<string, unknown> {
+  const set = options.set ?? requirementSet;
+  return {
+    scoreSource: 'deterministic_rubric',
+    rubricVersion: TRIAGE_RUBRIC_VERSION,
+    classifierVersion:
+      options.classifierVersion ?? TRIAGE_CLASSIFIER_VERSION,
+    requirementSetId: set.id,
+    requirementSet: set,
+    rawFitScore: 70,
+    fitScore: 70,
+    tier: 'consider',
+    capReasons: [],
+    coverage: options.coverage ?? 1,
+    rankingStatus: options.rankingStatus ?? 'ranked',
+    rankingReason: null,
+    affordability: options.affordability ?? {
+      status: 'within',
+      reasonCode: 'within_budget',
+      reason: 'The public stay total is within budget.',
+      budgetAmount: 3000,
+      priceAmount: 2400,
+      currency: 'USD',
+      overByAmount: null,
+      overByPercent: null,
+    },
+    evidenceGaps: [],
+    requirements:
+      options.requirements
+      ?? set.definitions.map((definition) => ({
+        requirementId: definition.id,
+        requirement: definition.label,
+        label: definition.label,
+        type: definition.type,
+        rank: definition.rank,
+        weight: definition.weight,
+        order: definition.order,
+        status: 'met',
+        confidence: 'high',
+        note: 'Fixture verdict.',
+        evidence: [],
+      })),
+  };
+}
+
+function row(
+  id: string,
+  triageValue: unknown,
+  overrides: Partial<PrioritiesMatrixInputRow> = {},
+): PrioritiesMatrixInputRow {
+  return {
+    id,
+    platform: 'booking',
+    name: id,
+    url: `https://www.booking.com/hotel/us/${id}.html`,
+    triage: triageValue,
+    availability: {
+      status: 'yes',
+      freshness: 'fresh',
+      eligibility: 'eligible',
+      reasonCode: 'available',
+      reason: 'Available for the recorded stay.',
+      capturedAt: '2026-07-26T18:00:00.000Z',
+      availableRange: {
+        checkIn: '2026-07-29',
+        checkOut: '2026-08-11',
+      },
+    },
+    affordability: {
+      status: 'within',
+      reasonCode: 'within_budget',
+      reason: 'Within budget.',
+      budgetAmount: 3000,
+      priceAmount: 2400,
+      currency: 'USD',
+      overByAmount: null,
+      overByPercent: null,
+    },
+    ...overrides,
+  };
+}
+
+test('matrix aligns canonical IDs and preserves status-aligned evidence provenance', () => {
+  const riskyTriage = triage({
+    requirements: [
+      {
+        ...requirementSet.definitions[0],
+        requirementId: 'req-01-quiet-sleep',
+        requirement: 'Quiet sleep',
+        status: 'unmet',
+        confidence: 'high',
+        note: 'HVAC noise is a material sleep risk.',
+        evidence: [
+          {
+            layer: 'details',
+            polarity: 'supports',
+            text: 'The listing advertises soundproofing.',
+          },
+          {
+            layer: 'reviews',
+            polarity: 'contradicts',
+            text: 'Guests repeatedly report loud HVAC cycling overnight.',
+            frequency: '42 of 250 reviews',
+            years: [2024, 2026, 2026],
+          },
+        ],
+      },
+      {
+        ...requirementSet.definitions[1],
+        requirementId: 'req-02-workspace',
+        requirement: 'Workspace',
+        status: 'met',
+        confidence: 'medium',
+        note: 'A desk is consistently visible.',
+        evidence: [
+          {
+            layer: 'reviews',
+            polarity: 'contradicts',
+            text: 'One guest found the chair uncomfortable.',
+            frequency: '1/250',
+            years: [2025],
+          },
+          {
+            layer: 'photos',
+            polarity: 'supports',
+            text: 'Current photos show a desk and task chair.',
+            years: [2026],
+          },
+        ],
+      },
+    ],
+  });
+  riskyTriage.evidenceGaps = ['photos'];
+
+  const matchingLabelWrongId = triage({
+    requirements: [
+      {
+        ...requirementSet.definitions[0],
+        requirementId: 'req-not-the-canonical-id',
+        requirement: 'Quiet sleep',
+        label: 'Quiet sleep',
+        status: 'met',
+        confidence: 'high',
+        note: 'Must not be label-aligned.',
+        evidence: [],
+      },
+      {
+        ...requirementSet.definitions[1],
+        requirementId: 'req-02-workspace',
+        requirement: 'Workspace',
+        status: 'met',
+        confidence: 'high',
+        note: 'Workspace present.',
+        evidence: [],
+      },
+    ],
+  });
+
+  const fitTriage = triage({
+    requirements: [
+      {
+        ...requirementSet.definitions[0],
+        requirementId: 'req-01-quiet-sleep',
+        requirement: 'Quiet sleep',
+        status: 'met',
+        confidence: 'high',
+        note: 'Quiet in the analyzed sample.',
+        evidence: [
+          {
+            layer: 'reviews',
+            polarity: 'supports',
+            text: 'Recent guests describe quiet nights.',
+            frequency: '18 out of 250 analyzed reviews',
+            years: [2026],
+          },
+        ],
+      },
+      {
+        ...requirementSet.definitions[1],
+        requirementId: 'req-02-workspace',
+        requirement: 'Workspace',
+        status: 'met',
+        confidence: 'high',
+        note: 'Workspace present.',
+        evidence: [],
+      },
+    ],
+  });
+
+  const insufficientTriage = triage({
+    rankingStatus: 'insufficient_evidence',
+    coverage: 0.25,
+    requirements: requirementSet.definitions.map((definition) => ({
+      ...definition,
+      requirementId: definition.id,
+      requirement: definition.label,
+      status: 'unknown',
+      confidence: 'low',
+      note: 'Not enough review data.',
+      evidence: [],
+    })),
+  });
+  insufficientTriage.evidenceGaps = ['reviews'];
+
+  const oldSet = {
+    ...requirementSet,
+    id: 'reqset_old_fixture',
+    definitions: [
+      {
+        ...requirementSet.definitions[0],
+        id: 'old-quiet-id',
+      },
+    ],
+  };
+  const matrix = buildPrioritiesMatrix(
+    [
+      row('risky', riskyTriage, {
+        reviewSample: {
+          totalScrapedReviewCount: 2632,
+          eligibleReviewCount: 1924,
+          analyzedReviewCount: 250,
+          capped: true,
+          source: 'batch_manifest',
+        },
+      }),
+      row('label-collision', matchingLabelWrongId),
+      row('fit', fitTriage),
+      row('insufficient', insufficientTriage),
+      row('old-policy', triage({
+        classifierVersion: 'triage-classifier-v1',
+      })),
+      row('old-set', triage({ set: oldSet })),
+      row('legacy', {
+        fitScore: 99,
+        requirements: [
+          {
+            requirement: 'Quiet sleep',
+            status: 'met',
+          },
+        ],
+      }),
+      row('unscored', null),
+    ],
+    { generatedAt: '2026-07-26T20:00:00.000Z' },
+  );
+
+  assert.equal(matrix.schemaVersion, 1);
+  assert.equal(matrix.generatedAt, '2026-07-26T20:00:00.000Z');
+  assert.equal(matrix.activeRequirementSetId, requirementSet.id);
+  assert.deepEqual(matrix.fixedAxes, ['availability', 'affordability']);
+  assert.deepEqual(
+    matrix.columns.map((column) => column.requirementId),
+    ['req-01-quiet-sleep', 'req-02-workspace'],
+  );
+
+  const risky = matrix.rows[0];
+  const quiet = risky.priorities['req-01-quiet-sleep'];
+  const workspace = risky.priorities['req-02-workspace'];
+  assert.equal(quiet.status, 'unmet');
+  assert.equal(
+    quiet.strongestEvidence?.text,
+    'Guests repeatedly report loud HVAC cycling overnight.',
+  );
+  assert.deepEqual(quiet.strongestEvidence?.frequency, {
+    raw: '42 of 250 reviews',
+    mentions: 42,
+    analyzedReviewCount: 250,
+    denominatorMeaning: 'ai_analyzed_reviews',
+    display: '42 of 250 AI-analyzed reviews',
+  });
+  assert.deepEqual(quiet.strongestEvidence?.years, [2026, 2024]);
+  assert.equal(quiet.evidence.length, 2);
+  assert.deepEqual(quiet.evidenceGaps, ['photos']);
+  assert.equal(
+    workspace.strongestEvidence?.text,
+    'Current photos show a desk and task chair.',
+  );
+  assert.deepEqual(risky.reviewSample, {
+    totalScrapedReviewCount: 2632,
+    eligibleReviewCount: 1924,
+    analyzedReviewCount: 250,
+    capped: true,
+    source: 'batch_manifest',
+  });
+
+  assert.equal(
+    matrix.rows[1].priorities['req-01-quiet-sleep'].state,
+    'missing',
+  );
+  assert.equal(matrix.rows[3].rankingStatus, 'insufficient_evidence');
+  assert.deepEqual(
+    matrix.rows[3].priorities['req-01-quiet-sleep'].evidenceGaps,
+    ['reviews'],
+  );
+  assert.equal(matrix.rows[4].rankingStatus, 'stale_classifier_policy');
+  assert.equal(
+    matrix.rows[4].priorities['req-01-quiet-sleep'].state,
+    'unavailable',
+  );
+  assert.equal(matrix.rows[5].rankingStatus, 'stale_requirement_set');
+  assert.equal(matrix.rows[6].rankingStatus, 'legacy');
+  assert.equal(matrix.rows[7].rankingStatus, 'unscored');
+
+  assert.deepEqual(
+    sortPrioritiesMatrixRows(
+      matrix.rows,
+      'req-01-quiet-sleep',
+      'risk',
+    ).map((item) => item.id),
+    [
+      'risky',
+      'label-collision',
+      'fit',
+      'insufficient',
+      'old-policy',
+      'old-set',
+      'legacy',
+      'unscored',
+    ],
+  );
+  assert.deepEqual(
+    sortPrioritiesMatrixRows(
+      matrix.rows,
+      'req-01-quiet-sleep',
+      'fit',
+    ).slice(0, 3).map((item) => item.id),
+    ['fit', 'label-collision', 'risky'],
+  );
+});
+
+test('frequency parsing labels only valid ratios as AI-analyzed denominators', () => {
+  assert.deepEqual(parsePrioritiesMatrixFrequency('3/10'), {
+    raw: '3/10',
+    mentions: 3,
+    analyzedReviewCount: 10,
+    denominatorMeaning: 'ai_analyzed_reviews',
+    display: '3 of 10 AI-analyzed reviews',
+  });
+  assert.deepEqual(parsePrioritiesMatrixFrequency('roughly a dozen mentions'), {
+    raw: 'roughly a dozen mentions',
+    mentions: null,
+    analyzedReviewCount: null,
+    denominatorMeaning: null,
+    display: 'roughly a dozen mentions',
+  });
+  assert.equal(
+    parsePrioritiesMatrixFrequency('12 of 10 reviews').denominatorMeaning,
+    null,
+  );
+});
+
+function writeReportFixture(outputDir: string): void {
+  fs.mkdirSync(path.join(outputDir, 'listings'), { recursive: true });
+  fs.mkdirSync(path.join(outputDir, 'triage'), { recursive: true });
+  const capturedAt = '2026-07-26T18:00:00.000Z';
+  fs.writeFileSync(
+    path.join(outputDir, 'listings', 'listing_example.json'),
+    JSON.stringify({
+      title: 'Example Sleep Hotel',
+      rating: 4.6,
+      reviewCount: 2632,
+      staySnapshot: {
+        schemaVersion: 1,
+        request: {
+          platform: 'booking',
+          listingId: 'example',
+          checkIn: '2026-07-29',
+          checkOut: '2026-08-11',
+          adults: 2,
+          linkedRoomId: null,
+        },
+        priceForStay: {
+          amount: 2400,
+          currency: 'USD',
+          basis: 'stay',
+          capturedAt,
+          source: 'booking_property_page',
+          rateType: 'public',
+          mandatoryChargesResolved: true,
+        },
+        availability: {
+          status: 'yes',
+          capturedAt,
+          reasonCode: 'provider_room_inventory',
+        },
+        providerEvidence: {},
+      },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(outputDir, 'triage', 'example.json'),
+    JSON.stringify(triage({
+      requirements: [
+        {
+          ...requirementSet.definitions[0],
+          requirementId: 'req-01-quiet-sleep',
+          requirement: 'Quiet sleep',
+          status: 'unmet',
+          confidence: 'high',
+          note: 'HVAC noise is a sleep risk.',
+          evidence: [
+            {
+              layer: 'reviews',
+              polarity: 'contradicts',
+              text: 'Guests report HVAC noise.',
+              frequency: '42 of 250 reviews',
+              years: [2026],
+            },
+          ],
+        },
+        {
+          ...requirementSet.definitions[1],
+          requirementId: 'req-02-workspace',
+          requirement: 'Workspace',
+          status: 'met',
+          confidence: 'high',
+          note: 'Desk present.',
+          evidence: [],
+        },
+      ],
+    })),
+  );
+  fs.writeFileSync(
+    path.join(outputDir, 'batch_manifest.json'),
+    JSON.stringify({
+      version: 2,
+      createdAt: capturedAt,
+      updatedAt: capturedAt,
+      dates: {
+        checkIn: '2026-07-29',
+        checkOut: '2026-08-11',
+        adults: 2,
+      },
+      listings: {
+        'booking/example': {
+          platform: 'booking',
+          id: 'example',
+          url: 'https://www.booking.com/hotel/us/example.html',
+          details: {
+            status: 'fetched',
+            file: 'listings/listing_example.json',
+          },
+          reviews: {
+            status: 'fetched',
+            file: 'reviews/example_reviews.json',
+            count: 2632,
+          },
+          photos: { status: 'not_requested' },
+          aiReviews: {
+            status: 'fetched',
+            file: 'ai-reviews/example.json',
+            count: 250,
+            expected: 1924,
+          },
+          aiPhotos: { status: 'not_requested' },
+          triage: {
+            status: 'fetched',
+            file: 'triage/example.json',
+          },
+        },
+      },
+    }),
+  );
+}
+
+test('artifact report and CLI expose analyzed, eligible, and scraped counts separately', () => {
+  const outputDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'reviewr-priorities-matrix-'),
+  );
+  const generatedAt = '2026-07-26T20:00:00.000Z';
+  try {
+    writeReportFixture(outputDir);
+    const matrix = buildPrioritiesMatrixFromArtifacts({
+      outputDir,
+      generatedAt,
+      now: Date.parse('2026-07-26T20:00:00.000Z'),
+    });
+    assert.equal(matrix.rows[0].availability.status, 'yes');
+    assert.equal(matrix.rows[0].availability.freshness, 'fresh');
+    assert.equal(matrix.rows[0].affordability.status, 'within');
+    assert.deepEqual(matrix.rows[0].reviewSample, {
+      totalScrapedReviewCount: 2632,
+      eligibleReviewCount: 1924,
+      analyzedReviewCount: 250,
+      capped: true,
+      source: 'batch_manifest',
+    });
+    assert.equal(
+      matrix.rows[0]
+        .priorities['req-01-quiet-sleep']
+        .strongestEvidence?.frequency.display,
+      '42 of 250 AI-analyzed reviews',
+    );
+
+    const customFile = path.join(outputDir, 'matrix-custom.json');
+    assert.equal(
+      generatePrioritiesMatrixJson({
+        outputDir,
+        outputFile: customFile,
+        generatedAt,
+      }),
+      customFile,
+    );
+    const serialized = JSON.parse(fs.readFileSync(customFile, 'utf8'));
+    assert.equal(serialized.schemaVersion, 1);
+    assert.equal(
+      serialized.rows[0].reviewSample.totalScrapedReviewCount,
+      2632,
+    );
+
+    const cliPath = path.join(repositoryRoot, 'src', 'cli.ts');
+    const tsxPath = path.join(
+      repositoryRoot,
+      'node_modules',
+      '.bin',
+      'tsx',
+    );
+    const cliResult = spawnSync(
+      tsxPath,
+      [
+        cliPath,
+        'report',
+        '--output-dir',
+        outputDir,
+        '--priorities-matrix',
+      ],
+      {
+        cwd: repositoryRoot,
+        encoding: 'utf8',
+      },
+    );
+    assert.equal(
+      cliResult.status,
+      0,
+      `${cliResult.stdout}\n${cliResult.stderr}`,
+    );
+    assert.match(cliResult.stdout, /Priorities matrix:/);
+    assert.equal(
+      fs.existsSync(path.join(outputDir, 'priorities-matrix.json')),
+      true,
+    );
+
+    const customReportDir = path.join(outputDir, 'exports');
+    fs.mkdirSync(customReportDir);
+    const customReportFile = path.join(customReportDir, 'report.html');
+    const customCliResult = spawnSync(
+      tsxPath,
+      [
+        cliPath,
+        'report',
+        '--output-dir',
+        outputDir,
+        '--output-file',
+        customReportFile,
+        '--priorities-matrix',
+      ],
+      {
+        cwd: repositoryRoot,
+        encoding: 'utf8',
+      },
+    );
+    assert.equal(
+      customCliResult.status,
+      0,
+      `${customCliResult.stdout}\n${customCliResult.stderr}`,
+    );
+    assert.equal(
+      fs.existsSync(
+        path.join(customReportDir, 'priorities-matrix.json'),
+      ),
+      true,
+    );
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+});

--- a/tests/review-job-persistence.test.ts
+++ b/tests/review-job-persistence.test.ts
@@ -199,6 +199,58 @@ test('native results readiness is derived from persisted analysis state, not rep
     triageUsd: 0.0027,
     totalUsd: 0.023,
   });
+  assert.deepEqual(response.listings[0].analysis?.reviewSample, {
+    totalScrapedReviewCount: 10,
+    eligibleReviewCount: null,
+    analyzedReviewCount: null,
+    capped: null,
+    source: 'unknown',
+  });
+});
+
+test('job responses preserve exact AI sample provenance from the batch manifest', () => {
+  const artifactRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'review-job-review-sample-'),
+  );
+  fs.writeFileSync(
+    path.join(artifactRoot, 'batch_manifest.json'),
+    JSON.stringify({
+      version: 2,
+      listings: {
+        'airbnb/listing_1': {
+          platform: 'airbnb',
+          id: 'listing_1',
+          reviews: {
+            status: 'fetched',
+            count: 2632,
+          },
+          aiReviews: {
+            status: 'fetched',
+            count: 250,
+            expected: 1924,
+          },
+        },
+      },
+    }),
+  );
+
+  try {
+    const response = toReviewJobResponse({
+      job: makeJob({ artifactRoot }),
+      listings: [makeListing()],
+      events: [],
+    });
+
+    assert.deepEqual(response.listings[0].analysis?.reviewSample, {
+      totalScrapedReviewCount: 2632,
+      eligibleReviewCount: 1924,
+      analyzedReviewCount: 250,
+      capped: true,
+      source: 'batch_manifest',
+    });
+  } finally {
+    fs.rmSync(artifactRoot, { recursive: true, force: true });
+  }
 });
 
 test('explicit full-stay analysis budget is exposed independently of search currency', () => {

--- a/web/README.md
+++ b/web/README.md
@@ -131,6 +131,24 @@ therefore exercised by Booking.
 One job represents one date range. Multi-leg trips require a separate job for each leg; issue #70
 tracks first-class multi-leg support.
 
+## Priorities evidence matrix
+
+The native results page includes a horizontally scrollable `Priorities matrix`. Availability and
+affordability stay as separate leading axes; the remaining columns are the job's canonical guest
+priorities. Each cell shows the deterministic status and confidence, strongest status-aligned
+evidence, review frequency and years, and any missing evidence layers. Expanding a cell or the
+listing triage table preserves all raw support and contradiction lines.
+
+Rows visibly retain their `rankingStatus`. Insufficient-evidence rows are grouped outside
+comparable ranked results, as are older-policy, legacy, mismatched requirement-set, and unscored
+rows. Sorting a column never mixes those groups.
+
+Review frequency denominators are the reviews actually sent to AI, not the hotel's public review
+count. When retained `batch_manifest.json` provenance is available, each row separately states the
+AI-analyzed sample, post-filter eligible count, whether the configured sample cap applied, and
+total scraped reviews. If the artifact run has expired, the page reports unknown provenance
+instead of inferring it from Postgres or provider totals.
+
 `web/.env.local` remains supported as a compatibility fallback for direct `web/` commands, but
 the root `.env` takes precedence. Proxy settings also fall back to
 `~/.config/reviewr/.env` created by `reviewr auth`.

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -10,12 +10,13 @@ const nextConfig: NextConfig = {
       ...config.resolve.alias,
       '@cli': path.resolve(__dirname, '../src'),
     };
+    // CLI sources use Node ESM .js specifiers while the shared source is .ts.
+    // Priority-matrix derivation is also bundled client-side.
+    config.resolve.extensionAlias = {
+      ...config.resolve.extensionAlias,
+      '.js': ['.ts', '.js'],
+    };
     if (isServer) {
-      // The CLI code uses .js extensions in imports (Node.js ESM convention)
-      // but sources are .ts files. Tell webpack to also try .ts when resolving .js
-      config.resolve.extensionAlias = {
-        '.js': ['.ts', '.js'],
-      };
       // Externalize Playwright to avoid webpack bundling issues
       config.externals = config.externals || [];
       if (Array.isArray(config.externals)) {

--- a/web/src/components/PlatformBadge.tsx
+++ b/web/src/components/PlatformBadge.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React from 'react';
 import type { Platform } from '@/types';
 
 interface PlatformBadgeProps {

--- a/web/src/components/PrioritiesMatrix.test.tsx
+++ b/web/src/components/PrioritiesMatrix.test.tsx
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  TRIAGE_CLASSIFIER_VERSION,
+  TRIAGE_RUBRIC_VERSION,
+} from '@cli/triage-comparability';
+import type { ReviewJobListing } from '@/types';
+import PrioritiesMatrix from './PrioritiesMatrix.js';
+
+const requirementSet = {
+  id: 'reqset_ui_fixture',
+  schemaVersion: 1,
+  parserVersion: 'fixture-parser-v1',
+  brief: 'Quiet sleep',
+  definitions: [
+    {
+      id: 'req-01-quiet-sleep',
+      label: 'Quiet sleep',
+      type: 'priority',
+      rank: 1,
+      weight: 3,
+      sourceText: 'Quiet sleep',
+      criteria: ['No overnight HVAC noise'],
+      order: 1,
+    },
+  ],
+  parsedBudget: null,
+};
+
+function listing(
+  id: string,
+  options: {
+    insufficient?: boolean;
+    evidenceGaps?: string[];
+  } = {},
+): ReviewJobListing {
+  return {
+    id,
+    platform: 'booking',
+    name:
+      options.insufficient
+        ? 'Sparse Review Hotel'
+        : 'Sleep Test Hotel',
+    url: `https://www.booking.com/hotel/us/${id}.html`,
+    staySnapshot: {
+      availability: {
+        status: 'yes',
+        capturedAt: '2026-07-26T18:00:00.000Z',
+        reasonCode: 'provider_room_inventory',
+      },
+      freshness: {
+        price: 'fresh',
+        availability: 'fresh',
+      },
+      bookingEligibility: {
+        status: 'eligible',
+        actionable: true,
+        reasonCode: 'available',
+        reason: 'Available for the recorded dates and guest count.',
+      },
+    },
+    affordability: {
+      status: 'within',
+      reasonCode: 'within_budget',
+      reason: 'The public stay total is within budget.',
+      budgetAmount: 3000,
+      priceAmount: 2400,
+      currency: 'USD',
+      overByAmount: null,
+      overByPercent: null,
+    },
+    analysis: {
+      triage: {
+        scoreSource: 'deterministic_rubric',
+        rubricVersion: TRIAGE_RUBRIC_VERSION,
+        classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+        requirementSetId: requirementSet.id,
+        requirementSet,
+        rankingStatus:
+          options.insufficient ? 'insufficient_evidence' : 'ranked',
+        coverage: options.insufficient ? 0.25 : 1,
+        evidenceGaps: options.evidenceGaps ?? [],
+        requirements: [
+          {
+            ...requirementSet.definitions[0],
+            requirementId: 'req-01-quiet-sleep',
+            requirement: 'Quiet sleep',
+            status: options.insufficient ? 'unknown' : 'unmet',
+            confidence: options.insufficient ? 'low' : 'high',
+            note:
+              options.insufficient
+                ? 'Not enough review evidence.'
+                : 'HVAC noise is a material sleep risk.',
+            evidence:
+              options.insufficient
+                ? []
+                : [
+                    {
+                      layer: 'reviews',
+                      polarity: 'contradicts',
+                      text: 'Guests repeatedly report loud HVAC cycling.',
+                      frequency: '42 of 250 reviews',
+                      years: [2026],
+                    },
+                  ],
+          },
+        ],
+      },
+      reviewSample:
+        options.insufficient
+          ? {
+              totalScrapedReviewCount: 7,
+              eligibleReviewCount: 7,
+              analyzedReviewCount: 7,
+              capped: false,
+              source: 'batch_manifest',
+            }
+          : {
+              totalScrapedReviewCount: 2632,
+              eligibleReviewCount: 1924,
+              analyzedReviewCount: 250,
+              capped: true,
+              source: 'batch_manifest',
+            },
+    },
+  } as ReviewJobListing;
+}
+
+test('priorities matrix renders evidence frequencies and sample provenance honestly', () => {
+  const html = renderToStaticMarkup(
+    <PrioritiesMatrix
+      listings={[
+        listing('sleep-test'),
+        listing('sparse', {
+          insufficient: true,
+          evidenceGaps: ['reviews'],
+        }),
+      ]}
+    />,
+  );
+
+  assert.match(html, /Priorities matrix/);
+  assert.match(html, /Availability/);
+  assert.match(html, /Affordability/);
+  assert.match(html, /Quiet sleep/);
+  assert.match(html, /42 of 250 AI-analyzed reviews/);
+  assert.match(
+    html,
+    /250 analysed \(capped from 1,924 eligible\) · 2,632 scraped/,
+  );
+  assert.match(html, /Guests repeatedly report loud HVAC cycling/);
+  assert.match(
+    html,
+    /Insufficient evidence — visible for audit, outside peer ranking/,
+  );
+  assert.match(html, /No review data/);
+  assert.match(html, /7 analysed · 7 scraped/);
+});

--- a/web/src/components/PrioritiesMatrix.tsx
+++ b/web/src/components/PrioritiesMatrix.tsx
@@ -1,0 +1,492 @@
+'use client';
+
+import React, { Fragment, useMemo, useState } from 'react';
+import {
+  getPrioritiesMatrixRankingGroup,
+  sortPrioritiesMatrixRows,
+  type PrioritiesMatrixEvidence,
+  type PrioritiesMatrixPriorityCell,
+  type PrioritiesMatrixRankingStatus,
+  type PrioritiesMatrixRow,
+  type PrioritiesMatrixSortDirection,
+} from '@cli/priorities-matrix';
+import { buildReviewJobPrioritiesMatrix } from '@/lib/prioritiesMatrix';
+import type { ReviewJobListing } from '@/types';
+import PlatformBadge from './PlatformBadge';
+
+type SortState = {
+  key: string | null;
+  direction: PrioritiesMatrixSortDirection;
+};
+
+function statusClassName(status: string): string {
+  switch (status) {
+    case 'met':
+    case 'within':
+    case 'yes':
+    case 'eligible':
+      return 'border-emerald-300/20 bg-emerald-300/10 text-emerald-100';
+    case 'partial':
+    case 'conditional':
+      return 'border-amber-300/20 bg-amber-300/10 text-amber-100';
+    case 'unmet':
+    case 'over':
+    case 'no':
+    case 'excluded':
+      return 'border-rose-300/20 bg-rose-300/10 text-rose-100';
+    default:
+      return 'border-white/10 bg-white/[0.05] text-stone-300';
+  }
+}
+
+function rankingLabel(status: PrioritiesMatrixRankingStatus): string {
+  switch (status) {
+    case 'ranked':
+      return 'Ranked';
+    case 'insufficient_evidence':
+      return 'Insufficient evidence';
+    case 'stale_classifier_policy':
+      return 'Older policy';
+    case 'stale_requirement_set':
+      return 'Different priority set';
+    case 'legacy':
+      return 'Legacy';
+    case 'unscored':
+      return 'Unscored';
+  }
+}
+
+function rankingGroupLabel(status: PrioritiesMatrixRankingStatus): string {
+  switch (status) {
+    case 'ranked':
+      return 'Comparable ranked results';
+    case 'insufficient_evidence':
+      return 'Insufficient evidence — visible for audit, outside peer ranking';
+    case 'stale_classifier_policy':
+      return 'Classified under an older policy — regrade before comparing';
+    case 'legacy':
+    case 'stale_requirement_set':
+      return 'Legacy or different priority set — not aligned into current columns';
+    case 'unscored':
+      return 'Unscored candidates';
+  }
+}
+
+function gapLabel(gap: string): string {
+  switch (gap) {
+    case 'reviews':
+      return 'No review data';
+    case 'photos':
+      return 'No photo analysis';
+    case 'details':
+      return 'No listing details';
+    default:
+      return gap;
+  }
+}
+
+function formatEvidenceMeta(evidence: PrioritiesMatrixEvidence): string | null {
+  const parts = [
+    evidence.frequency.display,
+    evidence.years.length > 0
+      ? evidence.years.join(', ')
+      : null,
+  ].filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join(' · ') : null;
+}
+
+function EvidenceLine({
+  evidence,
+  compact = false,
+}: {
+  evidence: PrioritiesMatrixEvidence;
+  compact?: boolean;
+}) {
+  const prefix =
+    evidence.polarity === 'contradicts'
+      ? '[-]'
+      : evidence.polarity === 'supports'
+        ? '[+]'
+        : '[?]';
+  const meta = formatEvidenceMeta(evidence);
+  return (
+    <div className={compact ? 'space-y-1' : 'space-y-1.5'}>
+      <p
+        className={
+          compact
+            ? 'line-clamp-3 text-[11px] leading-4 text-stone-300'
+            : 'text-xs leading-5 text-stone-300'
+        }
+      >
+        <span
+          className={
+            evidence.polarity === 'contradicts'
+              ? 'font-bold text-rose-300'
+              : evidence.polarity === 'supports'
+                ? 'font-bold text-emerald-300'
+                : 'font-bold text-stone-400'
+          }
+        >
+          {prefix}
+        </span>{' '}
+        {evidence.text}
+      </p>
+      {meta && (
+        <p className="text-[10px] font-medium leading-4 text-stone-500">
+          {meta}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function PriorityCell({
+  cell,
+}: {
+  cell: PrioritiesMatrixPriorityCell;
+}) {
+  return (
+    <div className="min-w-[220px] max-w-[280px] space-y-2">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span
+          className={`rounded-full border px-2 py-0.5 text-[9px] font-bold uppercase tracking-[0.12em] ${statusClassName(
+            cell.status,
+          )}`}
+        >
+          {cell.status}
+        </span>
+        {cell.confidence && (
+          <span className="text-[10px] text-stone-500">
+            {cell.confidence} confidence
+          </span>
+        )}
+      </div>
+      {cell.strongestEvidence ? (
+        <EvidenceLine evidence={cell.strongestEvidence} compact />
+      ) : (
+        <p className="text-[11px] leading-4 text-stone-500">
+          {cell.unavailableReason === 'requirement_missing'
+            ? 'Priority cell missing from this verdict.'
+            : cell.state === 'unavailable'
+              ? 'Not aligned with the active priority set.'
+              : cell.note ?? 'No matched evidence.'}
+        </p>
+      )}
+      {cell.note && cell.strongestEvidence && (
+        <p className="line-clamp-2 text-[10px] leading-4 text-stone-500">
+          {cell.note}
+        </p>
+      )}
+      {cell.evidenceGaps.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {cell.evidenceGaps.map((gap) => (
+            <span
+              key={gap}
+              className="rounded-full border border-amber-300/15 bg-amber-300/[0.07] px-1.5 py-0.5 text-[9px] font-semibold text-amber-100/80"
+            >
+              {gapLabel(gap)}
+            </span>
+          ))}
+        </div>
+      )}
+      {cell.evidence.length > 1 && (
+        <details className="text-[10px] text-stone-500">
+          <summary className="cursor-pointer font-semibold hover:text-stone-300">
+            {cell.evidence.length} matched evidence lines
+          </summary>
+          <div className="mt-2 space-y-2 border-l border-white/10 pl-2">
+            {cell.evidence.map((evidence, index) => (
+              <EvidenceLine
+                key={`${evidence.layer}:${evidence.text}:${index}`}
+                evidence={evidence}
+              />
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}
+
+function reviewSampleLabel(row: PrioritiesMatrixRow): string {
+  const sample = row.reviewSample;
+  const total =
+    sample.totalScrapedReviewCount != null
+      ? `${sample.totalScrapedReviewCount.toLocaleString('en-US')} scraped`
+      : 'scraped total unknown';
+  if (sample.analyzedReviewCount == null) {
+    return `Analysed sample unknown · ${total}`;
+  }
+
+  const analyzed =
+    `${sample.analyzedReviewCount.toLocaleString('en-US')} analysed`;
+  if (sample.capped && sample.eligibleReviewCount != null) {
+    return (
+      `${analyzed} (capped from `
+      + `${sample.eligibleReviewCount.toLocaleString('en-US')} eligible) · ${total}`
+    );
+  }
+  if (
+    sample.eligibleReviewCount != null
+    && sample.eligibleReviewCount !== sample.analyzedReviewCount
+  ) {
+    return (
+      `${analyzed} of ${sample.eligibleReviewCount.toLocaleString('en-US')} eligible`
+      + ` · ${total}`
+    );
+  }
+  return `${analyzed} · ${total}`;
+}
+
+function HeaderButton({
+  label,
+  sortKey,
+  sort,
+  onSort,
+  subtitle,
+}: {
+  label: string;
+  sortKey: string;
+  sort: SortState;
+  onSort: (key: string) => void;
+  subtitle?: string;
+}) {
+  const active = sort.key === sortKey;
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(sortKey)}
+      className="min-w-[160px] text-left transition hover:text-white"
+      title="Sort this column; first click puts risks first"
+    >
+      <span className="font-semibold text-stone-300">
+        {label}
+        {active ? (sort.direction === 'risk' ? ' ↓ risk' : ' ↑ fit') : ''}
+      </span>
+      {subtitle && (
+        <span className="mt-1 block text-[9px] normal-case tracking-normal text-stone-600">
+          {subtitle}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export default function PrioritiesMatrix({
+  listings,
+  onSelectListing,
+}: {
+  listings: ReviewJobListing[];
+  onSelectListing?: (listingKey: string) => void;
+}) {
+  const [sort, setSort] = useState<SortState>({
+    key: null,
+    direction: 'risk',
+  });
+  const matrix = useMemo(
+    () => buildReviewJobPrioritiesMatrix(listings),
+    [listings],
+  );
+  const rows = useMemo(
+    () => sortPrioritiesMatrixRows(matrix.rows, sort.key, sort.direction),
+    [matrix.rows, sort],
+  );
+
+  function applySort(key: string) {
+    setSort((current) =>
+      current.key === key
+        ? {
+            key,
+            direction: current.direction === 'risk' ? 'fit' : 'risk',
+          }
+        : { key, direction: 'risk' });
+  }
+
+  if (listings.length === 0) return null;
+
+  return (
+    <section className="rounded-[28px] border border-white/10 bg-black/[0.24] shadow-[0_28px_90px_rgba(0,0,0,0.34)] backdrop-blur-xl">
+      <div className="border-b border-white/10 px-5 py-5">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-stone-500">
+          Evidence comparison
+        </p>
+        <h2 className="mt-2 text-lg font-semibold text-white">
+          Priorities matrix
+        </h2>
+        <p className="mt-2 max-w-4xl text-xs leading-5 text-stone-500">
+          Availability and affordability stay separate from quality. Each
+          priority cell shows the strongest status-aligned evidence, its
+          AI-analyzed frequency and years, plus missing evidence layers.
+          Column sorting never mixes insufficient, legacy, or stale rows into
+          the comparable ranked group.
+        </p>
+      </div>
+
+      {matrix.columns.length === 0 ? (
+        <p className="px-5 py-8 text-sm text-stone-400">
+          No current canonical priority set is available. Regrade the whole
+          job before comparing evidence by priority.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-max border-collapse text-left">
+            <thead>
+              <tr className="border-b border-white/10 bg-black/20 text-[10px] uppercase tracking-[0.12em] text-stone-500">
+                <th className="sticky left-0 z-10 min-w-[260px] bg-[#100d0c] px-4 py-3">
+                  Candidate
+                </th>
+                <th className="min-w-[190px] px-4 py-3 align-top">
+                  <HeaderButton
+                    label="Availability"
+                    sortKey="availability"
+                    sort={sort}
+                    onSort={applySort}
+                    subtitle="Exact stay booking eligibility"
+                  />
+                </th>
+                <th className="min-w-[190px] px-4 py-3 align-top">
+                  <HeaderButton
+                    label="Affordability"
+                    sortKey="affordability"
+                    sort={sort}
+                    onSort={applySort}
+                    subtitle="Deterministic budget axis"
+                  />
+                </th>
+                {matrix.columns.map((column) => (
+                  <th
+                    key={column.requirementId}
+                    className="min-w-[240px] px-4 py-3 align-top"
+                  >
+                    <HeaderButton
+                      label={column.label}
+                      sortKey={column.requirementId}
+                      sort={sort}
+                      onSort={applySort}
+                      subtitle={[
+                        column.type?.replace(/_/g, ' '),
+                        column.weight != null
+                          ? `weight ${column.weight}`
+                          : null,
+                      ].filter(Boolean).join(' · ')}
+                    />
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, index) => {
+                const showGroup =
+                  index === 0
+                  || getPrioritiesMatrixRankingGroup(row.rankingStatus)
+                    !== getPrioritiesMatrixRankingGroup(
+                      rows[index - 1].rankingStatus,
+                    );
+                return (
+                  <Fragment key={`${row.platform}:${row.id}`}>
+                    {showGroup && (
+                      <tr>
+                        <td
+                          colSpan={matrix.columns.length + 3}
+                          className="border-b border-white/10 bg-white/[0.035] px-4 py-2 text-[10px] font-bold uppercase tracking-[0.14em] text-stone-500"
+                        >
+                          {rankingGroupLabel(row.rankingStatus)}
+                        </td>
+                      </tr>
+                    )}
+                    <tr className="border-b border-white/5 align-top hover:bg-white/[0.025]">
+                      <td className="sticky left-0 z-[5] bg-[#0f0c0b] px-4 py-4">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            onSelectListing?.(`${row.platform}:${row.id}`)}
+                          className="max-w-[250px] text-left"
+                        >
+                          <PlatformBadge
+                            platform={
+                              row.platform === 'airbnb'
+                                ? 'airbnb'
+                                : 'booking'
+                            }
+                          />
+                          <span className="mt-2 block text-xs font-semibold leading-5 text-white hover:text-sky-100">
+                            {row.name}
+                          </span>
+                        </button>
+                        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                          <span
+                            className={`rounded-full border px-2 py-0.5 text-[9px] font-bold uppercase tracking-[0.1em] ${
+                              row.rankingStatus === 'ranked'
+                                ? statusClassName('met')
+                                : row.rankingStatus === 'insufficient_evidence'
+                                  ? statusClassName('partial')
+                                  : statusClassName('unknown')
+                            }`}
+                          >
+                            {rankingLabel(row.rankingStatus)}
+                          </span>
+                          {row.coverage != null && (
+                            <span className="text-[10px] text-stone-500">
+                              {Math.round(row.coverage * 100)}% coverage
+                            </span>
+                          )}
+                        </div>
+                        <p className="mt-2 text-[10px] leading-4 text-stone-500">
+                          {reviewSampleLabel(row)}
+                        </p>
+                      </td>
+                      <td className="px-4 py-4">
+                        <div className="min-w-[170px] space-y-2">
+                          <span
+                            className={`inline-flex rounded-full border px-2 py-0.5 text-[9px] font-bold uppercase tracking-[0.12em] ${statusClassName(
+                              row.availability.eligibility,
+                            )}`}
+                          >
+                            {row.availability.status} ·{' '}
+                            {row.availability.freshness}
+                          </span>
+                          <p className="text-[10px] leading-4 text-stone-500">
+                            {row.availability.reason
+                              ?? 'Exact-stay availability is unknown.'}
+                          </p>
+                        </div>
+                      </td>
+                      <td className="px-4 py-4">
+                        <div className="min-w-[170px] space-y-2">
+                          <span
+                            className={`inline-flex rounded-full border px-2 py-0.5 text-[9px] font-bold uppercase tracking-[0.12em] ${statusClassName(
+                              row.affordability.status,
+                            )}`}
+                          >
+                            {row.affordability.status}
+                            {row.affordability.overByPercent != null
+                              ? ` · ${row.affordability.overByPercent}% over`
+                              : ''}
+                          </span>
+                          <p className="text-[10px] leading-4 text-stone-500">
+                            {row.affordability.reason
+                              ?? 'No affordability caveat.'}
+                          </p>
+                        </div>
+                      </td>
+                      {matrix.columns.map((column) => (
+                        <td
+                          key={column.requirementId}
+                          className="px-4 py-4"
+                        >
+                          <PriorityCell
+                            cell={row.priorities[column.requirementId]}
+                          />
+                        </td>
+                      ))}
+                    </tr>
+                  </Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/components/ResultsWorkspace.tsx
+++ b/web/src/components/ResultsWorkspace.tsx
@@ -31,6 +31,7 @@ import {
   estimateTriageRegradeCostUsd,
   getCurrentTriageComparability,
 } from '@cli/triage-comparability';
+import { parsePrioritiesMatrixFrequency } from '@cli/priorities-matrix';
 import {
   fetchReviewJobResponse,
   getStoredReviewJobPriceDisplay,
@@ -42,6 +43,7 @@ import AiBudgetNotice from './AiBudgetNotice';
 import EvidenceGapBadge from './EvidenceGapBadge';
 import StaySnapshotStatus from './StaySnapshotStatus';
 import PriceRefreshControls from './PriceRefreshControls';
+import PrioritiesMatrix from './PrioritiesMatrix';
 
 const MIN_MAP_HEIGHT = 280;
 const TIER_ORDER = ['top_pick', 'shortlist', 'consider', 'unlikely', 'no_go'] as const;
@@ -843,6 +845,9 @@ function ListingDetailPanel({
                           <th className="px-3 py-2 font-semibold">Status</th>
                           <th className="px-3 py-2 font-semibold">Confidence</th>
                           <th className="px-3 py-2 font-semibold">Note</th>
+                          <th className="min-w-[300px] px-3 py-2 font-semibold">
+                            Matched evidence
+                          </th>
                         </tr>
                       </thead>
                       <tbody>
@@ -875,6 +880,54 @@ function ListingDetailPanel({
                             </td>
                             <td className="px-3 py-2 text-stone-400">{requirement.confidence ?? '—'}</td>
                             <td className="px-3 py-2 text-stone-400">{requirement.note ?? '—'}</td>
+                            <td className="px-3 py-2">
+                              {requirement.evidence.length > 0 ? (
+                                <div className="space-y-2">
+                                  {requirement.evidence.map((evidence, index) => {
+                                    const frequency =
+                                      parsePrioritiesMatrixFrequency(
+                                        evidence.frequency,
+                                      );
+                                    const meta = [
+                                      frequency.display,
+                                      evidence.years.length > 0
+                                        ? evidence.years.join(', ')
+                                        : null,
+                                    ].filter(Boolean).join(' · ');
+                                    return (
+                                      <div
+                                        key={`${evidence.layer}:${evidence.text}:${index}`}
+                                        className="border-l border-white/10 pl-2"
+                                      >
+                                        <p className="text-[11px] leading-5 text-stone-300">
+                                          <span
+                                            className={
+                                              evidence.polarity === 'contradicts'
+                                                ? 'font-bold text-rose-300'
+                                                : 'font-bold text-emerald-300'
+                                            }
+                                          >
+                                            {evidence.polarity === 'contradicts'
+                                              ? '[-]'
+                                              : '[+]'}
+                                          </span>{' '}
+                                          {evidence.text}
+                                        </p>
+                                        {meta && (
+                                          <p className="text-[10px] leading-4 text-stone-500">
+                                            {meta}
+                                          </p>
+                                        )}
+                                      </div>
+                                    );
+                                  })}
+                                </div>
+                              ) : (
+                                <span className="text-stone-500">
+                                  No matched evidence
+                                </span>
+                              )}
+                            </td>
                           </tr>
                         ))}
                       </tbody>
@@ -2336,6 +2389,12 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
             </div>
           )}
         </header>
+
+        <PrioritiesMatrix
+          listings={displayableResults}
+          onSelectListing={(key) =>
+            handleSelect(key, { scroll: true })}
+        />
 
         {heroResults.length > 0 && (
           <section className="rounded-[28px] border border-white/10 bg-black/[0.24] px-5 py-5 shadow-[0_28px_90px_rgba(0,0,0,0.38)] backdrop-blur-xl">

--- a/web/src/lib/prioritiesMatrix.ts
+++ b/web/src/lib/prioritiesMatrix.ts
@@ -1,0 +1,42 @@
+import {
+  buildPrioritiesMatrix,
+  type PrioritiesMatrix,
+} from '@cli/priorities-matrix';
+import type { ReviewJobListing } from '../types.js';
+
+export function buildReviewJobPrioritiesMatrix(
+  listings: ReviewJobListing[],
+  options: { generatedAt?: string } = {},
+): PrioritiesMatrix {
+  return buildPrioritiesMatrix(
+    listings.map((listing) => ({
+      id: listing.id,
+      platform: listing.platform,
+      name: listing.name,
+      url: listing.url,
+      triage: listing.analysis?.triage ?? null,
+      availability: {
+        status: listing.staySnapshot.availability.status,
+        freshness: listing.staySnapshot.freshness.availability,
+        eligibility: listing.staySnapshot.bookingEligibility.status,
+        reasonCode: listing.staySnapshot.bookingEligibility.reasonCode,
+        reason: listing.staySnapshot.bookingEligibility.reason,
+        capturedAt: listing.staySnapshot.availability.capturedAt,
+        availableRange:
+          listing.staySnapshot.availability.availableRange ?? null,
+      },
+      affordability: {
+        status: listing.affordability.status,
+        reasonCode: listing.affordability.reasonCode,
+        reason: listing.affordability.reason,
+        budgetAmount: listing.affordability.budgetAmount,
+        priceAmount: listing.affordability.priceAmount,
+        currency: listing.affordability.currency,
+        overByAmount: listing.affordability.overByAmount,
+        overByPercent: listing.affordability.overByPercent,
+      },
+      reviewSample: listing.analysis?.reviewSample ?? null,
+    })),
+    options,
+  );
+}

--- a/web/src/lib/reviewJobs.ts
+++ b/web/src/lib/reviewJobs.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type {
   Prisma,
   ReviewJob as ReviewJobModel,
@@ -15,6 +17,7 @@ import type {
   FullSearchRequest,
   MapPoint,
   ReviewJobEvent,
+  ReviewAnalysisSample,
   ReviewJobListing,
   ReviewJobListingAnalysis,
   ReviewJobResponse,
@@ -107,6 +110,87 @@ function asPriceRefreshSummary(
     return null;
   }
   return { requested, succeeded, failed };
+}
+
+function asNonNegativeInteger(value: unknown): number | null {
+  return (
+    typeof value === 'number'
+    && Number.isInteger(value)
+    && value >= 0
+  )
+    ? value
+    : null;
+}
+
+function unknownReviewSample(
+  totalScrapedReviewCount: number | null = null,
+): ReviewAnalysisSample {
+  return {
+    totalScrapedReviewCount,
+    eligibleReviewCount: null,
+    analyzedReviewCount: null,
+    capped: null,
+    source: 'unknown',
+  };
+}
+
+function getReviewSamplesFromManifest(
+  artifactRoot: string | null | undefined,
+): Map<string, ReviewAnalysisSample> {
+  const samples = new Map<string, ReviewAnalysisSample>();
+  if (!artifactRoot) return samples;
+
+  try {
+    const manifestPath = path.join(artifactRoot, 'batch_manifest.json');
+    const stat = fs.lstatSync(manifestPath);
+    if (!stat.isFile() || stat.isSymbolicLink()) return samples;
+    const manifest = JSON.parse(
+      fs.readFileSync(manifestPath, 'utf8'),
+    ) as unknown;
+    const manifestRecord = asJsonObject(manifest as Prisma.JsonValue);
+    const listings = asJsonObject(
+      (manifestRecord?.listings ?? null) as Prisma.JsonValue | null,
+    );
+    if (!listings) return samples;
+
+    for (const value of Object.values(listings)) {
+      const entry = asJsonObject(value as Prisma.JsonValue);
+      if (!entry) continue;
+      const platform =
+        entry.platform === 'airbnb' || entry.platform === 'booking'
+          ? entry.platform
+          : null;
+      const id = typeof entry.id === 'string' ? entry.id : null;
+      if (!platform || !id) continue;
+
+      const reviews = asJsonObject(
+        (entry.reviews ?? null) as Prisma.JsonValue | null,
+      );
+      const aiReviews = asJsonObject(
+        (entry.aiReviews ?? null) as Prisma.JsonValue | null,
+      );
+      const totalScrapedReviewCount = asNonNegativeInteger(reviews?.count);
+      const analyzedReviewCount = asNonNegativeInteger(aiReviews?.count);
+      const eligibleReviewCount = asNonNegativeInteger(aiReviews?.expected);
+      const hasAiSampleProvenance =
+        analyzedReviewCount != null || eligibleReviewCount != null;
+      samples.set(`${platform}:${id}`, {
+        totalScrapedReviewCount,
+        eligibleReviewCount,
+        analyzedReviewCount,
+        capped:
+          analyzedReviewCount != null && eligibleReviewCount != null
+            ? analyzedReviewCount < eligibleReviewCount
+            : null,
+        source:
+          hasAiSampleProvenance ? 'batch_manifest' : 'unknown',
+      });
+    }
+  } catch {
+    // Artifact retention or a partial legacy workspace leaves provenance unknown.
+  }
+
+  return samples;
 }
 
 function getPersistedReviewJobAiBudgetUsd(
@@ -285,6 +369,7 @@ export function toReviewJobListingRecord(
 
 function toReviewJobListingAnalysisState(
   row: ReviewJobListingAnalysisModel,
+  reviewSample?: ReviewAnalysisSample,
 ): ReviewJobListingAnalysis {
   return {
     id: row.id,
@@ -302,6 +387,9 @@ function toReviewJobListingAnalysisState(
     aiPhotos: asJsonObject(row.aiPhotos),
     triage: asJsonObject(row.triage),
     reviewCount: row.reviewCount ?? null,
+    reviewSample:
+      reviewSample
+      ?? unknownReviewSample(row.reviewCount ?? null),
     photoCount: row.photoCount ?? null,
     costs: buildAiCostBreakdown({
       aiReviewsCostUsd: row.aiReviewsCostUsd,
@@ -323,6 +411,7 @@ export function toWebReviewJobListing(
     job: ReviewJobModel;
     ttlMs?: number;
     now?: Date;
+    reviewSample?: ReviewAnalysisSample;
   },
 ): ReviewJobListing {
   const storedPricing =
@@ -418,7 +507,13 @@ export function toWebReviewJobListing(
     poiDistanceMeters: row.poiDistanceMeters ?? null,
     staySnapshot,
     affordability,
-    analysis: row.analysis ? toReviewJobListingAnalysisState(row.analysis) : null,
+    analysis:
+      row.analysis
+        ? toReviewJobListingAnalysisState(
+            row.analysis,
+            options.reviewSample,
+          )
+        : null,
   };
 }
 
@@ -528,6 +623,7 @@ export function toReviewJobResponse(input: {
   const persistedAiBudgetUsd = getPersistedReviewJobAiBudgetUsd(input.events);
   const ttlMs = resolveStaySnapshotTtlMs();
   const now = new Date();
+  const reviewSamples = getReviewSamplesFromManifest(input.job.artifactRoot);
 
   return {
     job: toReviewJobState(input.job, {
@@ -542,6 +638,15 @@ export function toReviewJobResponse(input: {
         job: input.job,
         ttlMs,
         now,
+        reviewSample:
+          reviewSamples.get(
+            `${listing.platform}:${listing.listingId}`,
+          )
+          ?? (
+            listing.analysis
+              ? unknownReviewSample(listing.analysis.reviewCount ?? null)
+              : undefined
+          ),
       })),
     events: input.events.map(toReviewJobEvent),
   };

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -187,6 +187,14 @@ export interface ReviewJobEvent {
   createdAt: string;
 }
 
+export interface ReviewAnalysisSample {
+  totalScrapedReviewCount: number | null;
+  eligibleReviewCount: number | null;
+  analyzedReviewCount: number | null;
+  capped: boolean | null;
+  source: 'batch_manifest' | 'unknown';
+}
+
 export interface ReviewJobListingAnalysis {
   id: string;
   status: PhaseStatus;
@@ -203,6 +211,7 @@ export interface ReviewJobListingAnalysis {
   aiPhotos: Record<string, unknown> | null;
   triage: Record<string, unknown> | null;
   reviewCount: number | null;
+  reviewSample: ReviewAnalysisSample;
   photoCount: number | null;
   costs: AiCostBreakdown;
   durationMs: number | null;


### PR DESCRIPTION
Closes #61

## Summary

- add one versioned per-priority evidence matrix shared by CLI artifacts and the native results UI
- align columns only by the modal canonical requirement set and exact requirement IDs; keep insufficient, older-policy, legacy, stale-set, and unscored rows visibly isolated
- show status-aligned strongest evidence, all raw support/contradiction lines, frequency, years, and evidence gaps
- preserve review-sample provenance: AI-analyzed count, eligible count, cap status, and total scraped count remain separate
- add `reviewr report --priorities-matrix [file]` and write `priorities-matrix.json` beside the HTML report by default

## Evidence semantics

- `42 of 250` is labeled as 42 mentions among 250 AI-analyzed reviews, never as the provider review total
- row provenance can say `250 analysed (capped from 1,924 eligible) · 2,632 scraped`
- retained batch manifests supply exact counts; missing artifact provenance stays explicitly unknown
- no Prisma schema change and no new LLM call

## Verification

- `pnpm test` — 146 passed
- `pnpm run build`
- `pnpm run lint`
- `npm --prefix web run test:pricing` — 3 passed
- `npm --prefix web run test:ui` — 10 passed
- `npm --prefix web run lint`
- `npm --prefix web run build`
