### PR TITLE
feat: add affordability controls and durable regrade state

### DIFF
--- a/docs/triage-rubric.md
+++ b/docs/triage-rubric.md
@@ -311,15 +311,24 @@ Unknown affordability always carries a machine code and user-facing reason. Requ
 Basis, freshness, invalid-price, and non-public-rate failures have equally specific reasons. The UI
 shows the reason after “Budget unknown”; it does not show a bare unknown state.
 
-The default ranking remains quality-first. A future explicit budget-aware sort may group `within`,
-then `over` by ascending percentage, then `unknown`, with quality score as a tie-breaker. It must not
-create a hidden composite score.
+The default ranking remains quality-first. The native results page also offers an explicit
+budget-fit order: `within`, then `over` by ascending percentage, then `unknown`, with the existing
+quality order as the tie-breaker. Availability eligibility and comparison-status groups remain
+isolated before either ordering is applied. This is not a composite score. Affordability filters
+use the listing's current deterministic `within`, `over`, or `unknown` state and can be combined
+without changing any quality verdict.
 
 Changing only a structured budget or refreshing a price can recompute affordability without an LLM
 call. New rubric results persist the complete comparable-price input used for that calculation.
 Budget edits transactionally replace only the `affordability` object; quality classifications,
 scores, caps, and tiers stay unchanged. Pre-snapshot and legacy JSON are preserved rather than
 reconstructed from guesses. Changing the quality definitions requires a new classification set.
+
+A normalized quality-brief change on a job with completed or partial verdicts durably marks the
+job as requiring a regrade. Leading/trailing whitespace and repeated internal whitespace do not
+invalidate verdicts. The marker survives queued, running, failed, and partial regrade attempts and
+clears only after every listing completes successfully. Structured budget-only edits never set
+the marker and never invoke the LLM.
 
 ## Legacy and mixed verdicts
 
@@ -338,6 +347,10 @@ Stored JSON without `scoreSource`, `rubricVersion`, and `requirementSetId` is
 - The native results page offers an explicit whole-job regrade with an estimated cost. Regrading
   covers every non-hidden listing, reuses saved review and photo analysis, and runs triage only; at
   the measured ~$0.006/listing, a 54-listing job is estimated at ~$0.32.
+- Brief changes, classifier-policy changes, and requirement-set mismatches share one
+  `Regrade needed` presentation with distinct reasons. A brief change preserves the prior verdicts
+  and paid evidence for audit, labels them as reflecting the previous brief, and excludes them from
+  current peer ranks until a fully completed whole-job regrade.
 - Never interleave old model-authored or old-classifier scores with current-policy scores.
 
 CLI/report output follows the same source/version and grouping rules.
@@ -353,6 +366,11 @@ canonical requirement IDs and the current comparability key populate those colum
 stays visibly missing. Insufficient-evidence verdicts keep their auditable cells but remain in a
 separate group outside peer ranking. Older-policy, legacy, mismatched-set, and unscored rows are
 also labeled and never silently label-aligned into current cells.
+
+When the quality brief changes, the matrix remains visible: its priority columns and verdict labels
+say they reflect the previous brief, while evidence snippets, frequencies, years, and sample
+provenance remain available as paid audit data. The matrix header hosts the results page's single
+whole-job regrade banner, action, and cost estimate.
 
 Each classified priority cell carries:
 

--- a/tests/results-rubric.test.ts
+++ b/tests/results-rubric.test.ts
@@ -2,12 +2,15 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  compareAffordability,
   getActiveTriageComparison,
   getActiveRequirementSetId,
   getBookingEligibilityRank,
   getListingResultsSnapshot,
   getTriageComparisonStatus,
+  getTriageRegradeReasons,
   getTriageRegradeListingCount,
+  matchesAffordabilityFilter,
 } from '../web/src/lib/results.js';
 import type { ReviewJobListing } from '../web/src/types.js';
 import {
@@ -341,5 +344,100 @@ test('whole-job regrade scope counts every non-hidden listing', () => {
   assert.equal(
     getTriageRegradeListingCount([stale, current, hidden]),
     2,
+  );
+});
+
+test('brief and comparability staleness share ordered regrade reason codes', () => {
+  const current = listing('current', {
+    scoreSource: 'deterministic_rubric',
+    rubricVersion: '1',
+    requirementSetId: 'reqset_active',
+    classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+    fitScore: 80,
+    tier: 'top_pick',
+    rankingStatus: 'ranked',
+  });
+  const oldPolicy = listing('old-policy', {
+    scoreSource: 'deterministic_rubric',
+    rubricVersion: '1',
+    requirementSetId: 'reqset_active',
+    fitScore: 79,
+    tier: 'shortlist',
+    rankingStatus: 'ranked',
+  });
+  const mismatched = listing('mismatched', {
+    scoreSource: 'deterministic_rubric',
+    rubricVersion: '1',
+    requirementSetId: 'reqset_other',
+    classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+    fitScore: 90,
+    tier: 'top_pick',
+    rankingStatus: 'ranked',
+  });
+  const activeComparison =
+    getCurrentTriageComparability('reqset_active');
+
+  assert.deepEqual(
+    getTriageRegradeReasons(
+      [current, oldPolicy, mismatched],
+      activeComparison,
+      true,
+    ),
+    [
+      'brief_changed',
+      'classifier_policy_changed',
+      'requirement_set_mismatch',
+    ],
+  );
+  assert.equal(
+    getTriageComparisonStatus(
+      getListingResultsSnapshot(current).triage,
+      activeComparison,
+      { regradeRequired: true },
+    ),
+    'regrade_required',
+  );
+});
+
+test('budget-fit ordering is within, least over, then unknown', () => {
+  const affordability = (
+    status: 'within' | 'over' | 'unknown',
+    overByPercent: number | null = null,
+  ) => ({
+    status,
+    overByPercent,
+  }) as ReviewJobListing['affordability'];
+  const values = [
+    affordability('unknown'),
+    affordability('over', 18),
+    affordability('within'),
+    affordability('over', 4),
+    affordability('over', null),
+  ];
+
+  values.sort(compareAffordability);
+  assert.deepEqual(
+    values.map((value) => [value.status, value.overByPercent]),
+    [
+      ['within', null],
+      ['over', 4],
+      ['over', 18],
+      ['over', null],
+      ['unknown', null],
+    ],
+  );
+  assert.equal(
+    matchesAffordabilityFilter(
+      { affordability: affordability('over', 4) },
+      new Set(['within', 'unknown']),
+    ),
+    false,
+  );
+  assert.equal(
+    matchesAffordabilityFilter(
+      { affordability: affordability('unknown') },
+      new Set(['within', 'unknown']),
+    ),
+    true,
   );
 });

--- a/tests/review-job-edits.test.ts
+++ b/tests/review-job-edits.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  getQualityBriefEditEffect,
+  normalizeQualityBriefForComparison,
+  regradeRequiredAfterAnalysis,
+} from '../web/src/lib/reviewJobEdits.js';
+
+test('quality brief normalization ignores whitespace-only edits', () => {
+  assert.equal(
+    normalizeQualityBriefForComparison(
+      '  Quiet sleep\n  and a real desk  ',
+    ),
+    'Quiet sleep and a real desk',
+  );
+  assert.deepEqual(
+    getQualityBriefEditEffect({
+      currentPrompt: 'Quiet sleep and a real desk',
+      nextPrompt: '  Quiet   sleep\nand a real desk ',
+      analysisStatus: 'completed',
+      regradeRequired: false,
+    }),
+    {
+      storedPrompt: 'Quiet   sleep\nand a real desk',
+      qualityBriefChanged: false,
+      regradeRequired: false,
+    },
+  );
+});
+
+test('a real quality brief edit invalidates persisted verdicts only', () => {
+  assert.deepEqual(
+    getQualityBriefEditEffect({
+      currentPrompt: 'Quiet sleep',
+      nextPrompt: 'Quiet sleep and blackout curtains',
+      analysisStatus: 'completed',
+      regradeRequired: false,
+    }),
+    {
+      storedPrompt: 'Quiet sleep and blackout curtains',
+      qualityBriefChanged: true,
+      regradeRequired: true,
+    },
+  );
+  assert.equal(
+    getQualityBriefEditEffect({
+      currentPrompt: 'Quiet sleep',
+      nextPrompt: 'Quiet sleep and blackout curtains',
+      analysisStatus: 'pending',
+      regradeRequired: false,
+    }).regradeRequired,
+    false,
+  );
+  assert.equal(
+    getQualityBriefEditEffect({
+      currentPrompt: 'Quiet sleep',
+      nextPrompt: 'Near the venue',
+      analysisStatus: 'partial',
+      regradeRequired: false,
+    }).regradeRequired,
+    true,
+  );
+  assert.equal(
+    getQualityBriefEditEffect({
+      currentPrompt: 'Quiet sleep',
+      nextPrompt: 'Near the venue',
+      analysisStatus: 'pending',
+      regradeRequired: true,
+    }).regradeRequired,
+    true,
+  );
+});
+
+test('regrade validity clears only after a fully completed run', () => {
+  assert.equal(regradeRequiredAfterAnalysis(true, 'completed'), false);
+  assert.equal(regradeRequiredAfterAnalysis(true, 'partial'), true);
+  assert.equal(regradeRequiredAfterAnalysis(true, 'failed'), true);
+  assert.equal(regradeRequiredAfterAnalysis(false, 'partial'), false);
+});

--- a/tests/review-job-persistence.test.ts
+++ b/tests/review-job-persistence.test.ts
@@ -22,6 +22,7 @@ function makeJob(overrides: Record<string, unknown> = {}) {
     priceRefreshCurrentPhase: null,
     location: 'London',
     prompt: 'quiet and close to POI',
+    regradeRequired: false,
     boundingBox: null,
     circle: null,
     poi: null,
@@ -187,6 +188,7 @@ test('native results readiness is derived from persisted analysis state, not rep
   assert.equal(response.job.reportReady, true);
   assert.equal(response.job.legacyReportAvailable, false);
   assert.equal(response.job.artifactArchiveAvailable, false);
+  assert.equal(response.job.regradeRequired, false);
   assert.deepEqual(response.job.costs, {
     aiReviewsUsd: 0.0142,
     aiPhotosUsd: 0.0061,
@@ -206,6 +208,17 @@ test('native results readiness is derived from persisted analysis state, not rep
     capped: null,
     source: 'unknown',
   });
+});
+
+test('job responses expose the durable quality regrade requirement', () => {
+  const response = toReviewJobResponse({
+    job: makeJob({ regradeRequired: true }),
+    listings: [makeListing()],
+    events: [],
+  });
+
+  assert.equal(response.job.regradeRequired, true);
+  assert.equal(response.job.reportReady, true);
 });
 
 test('job responses preserve exact AI sample provenance from the batch manifest', () => {

--- a/web/README.md
+++ b/web/README.md
@@ -143,6 +143,18 @@ Rows visibly retain their `rankingStatus`. Insufficient-evidence rows are groupe
 comparable ranked results, as are older-policy, legacy, mismatched requirement-set, and unscored
 rows. Sorting a column never mixes those groups.
 
+Result cards are quality-first by default. Users can opt into budget-fit order (`within`, then
+least-over-budget, then `unknown`, with quality as the tie-breaker) and filter by any combination
+of those three current deterministic affordability states. Neither control changes quality scores,
+tiers, booking-eligibility groups, or comparison-status groups.
+
+Editing a saved quality brief after completed or partial analysis durably marks the job as needing
+a regrade; whitespace-only and structured budget-only edits do not. Prior verdicts and paid
+evidence remain visible and are labeled as reflecting the previous brief, but they are removed from
+current peer ranks. The marker clears only after a fully completed whole-job triage regrade and
+survives failed or partial attempts. Brief, classifier-policy, and requirement-set staleness share
+one regrade banner with distinct reasons and the same whole-job action and cost estimate.
+
 Review frequency denominators are the reviews actually sent to AI, not the hotel's public review
 count. When retained `batch_manifest.json` provenance is available, each row separately states the
 AI-analyzed sample, post-filter eligible count, whether the configured sample cap applied, and

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -103,6 +103,7 @@ model ReviewJob {
   priceRefreshCurrentPhase String?
   location       String?
   prompt         String?
+  regradeRequired Boolean         @default(false)
   boundingBox    Json?
   circle         Json?
   poi            Json?

--- a/web/src/app/api/jobs/[jobId]/route.ts
+++ b/web/src/app/api/jobs/[jobId]/route.ts
@@ -13,6 +13,7 @@ import {
   getReviewJobStaySnapshotReadModel,
   resolveStaySnapshotTtlMs,
 } from '@/lib/staySnapshots';
+import { getQualityBriefEditEffect } from '@/lib/reviewJobEdits';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -143,6 +144,8 @@ export async function PATCH(request: Request, { params }: Params) {
       id: true,
       analysisStatus: true,
       analysisCurrentPhase: true,
+      prompt: true,
+      regradeRequired: true,
       currency: true,
       analysisBudgetAmount: true,
       analysisBudgetCurrency: true,
@@ -166,6 +169,28 @@ export async function PATCH(request: Request, { params }: Params) {
       { status: 409 },
     );
   }
+
+  const hasPromptUpdate =
+    Object.prototype.hasOwnProperty.call(body, 'prompt');
+  if (
+    hasPromptUpdate
+    && body.prompt != null
+    && typeof body.prompt !== 'string'
+  ) {
+    return NextResponse.json(
+      { error: 'Analysis brief must be text or null' },
+      { status: 400 },
+    );
+  }
+  const qualityBriefEffect =
+    hasPromptUpdate
+      ? getQualityBriefEditEffect({
+          currentPrompt: existingJob.prompt,
+          nextPrompt: body.prompt,
+          analysisStatus: existingJob.analysisStatus,
+          regradeRequired: existingJob.regradeRequired,
+        })
+      : null;
 
   const hasBudgetUpdate =
     Object.prototype.hasOwnProperty.call(body, 'analysisBudgetAmount')
@@ -206,8 +231,10 @@ export async function PATCH(request: Request, { params }: Params) {
 
   const job = await prisma.$transaction(async (tx) => {
     const updateData: Prisma.ReviewJobUpdateInput = {};
-    if (Object.prototype.hasOwnProperty.call(body, 'prompt')) {
-      updateData.prompt = body.prompt?.trim() || null;
+    if (qualityBriefEffect) {
+      updateData.prompt = qualityBriefEffect.storedPrompt;
+      updateData.regradeRequired =
+        qualityBriefEffect.regradeRequired;
     }
     if (normalizedBudgetAmount !== undefined) {
       updateData.analysisBudgetAmount = normalizedBudgetAmount;
@@ -221,6 +248,24 @@ export async function PATCH(request: Request, { params }: Params) {
       await tx.reviewJob.update({
         where: { id: jobId },
         data: updateData,
+      });
+    }
+
+    if (
+      qualityBriefEffect?.qualityBriefChanged
+      && qualityBriefEffect.regradeRequired
+    ) {
+      await tx.reviewJobEvent.create({
+        data: {
+          jobId,
+          phase: 'triage',
+          level: 'warning',
+          message:
+            'Quality brief changed; saved verdicts require a whole-job regrade.',
+          payload: {
+            reason: 'brief_changed',
+          },
+        },
       });
     }
 

--- a/web/src/components/JobWorkspace.tsx
+++ b/web/src/components/JobWorkspace.tsx
@@ -18,6 +18,9 @@ import {
   getStoredReviewJobPriceDisplay,
 } from '@/lib/reviewJobClient';
 import { useReviewJobPolling } from '@/hooks/useReviewJobPolling';
+import {
+  normalizeQualityBriefForComparison,
+} from '@/lib/reviewJobEdits';
 import AiBudgetNotice from './AiBudgetNotice';
 import EvidenceGapBadge from './EvidenceGapBadge';
 import ResultCard from './ResultCard';
@@ -264,6 +267,18 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
     prompt !== savedPrompt
     || budgetAmount !== savedBudgetAmount
     || budgetCurrency !== savedBudgetCurrency;
+  const qualityBriefDirty =
+    normalizeQualityBriefForComparison(prompt)
+    !== normalizeQualityBriefForComparison(savedPrompt);
+  const qualityRegradeNeeded =
+    data.job.regradeRequired
+    || (
+      qualityBriefDirty
+      && (
+        data.job.analysisStatus === 'completed'
+        || data.job.analysisStatus === 'partial'
+      )
+    );
 
   const persistSelection = useCallback(
     async (
@@ -354,7 +369,11 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
       setBudgetAmount(nextBudgetAmount);
       setSavedBudgetCurrency(nextBudgetCurrency);
       setBudgetCurrency(nextBudgetCurrency);
-      setSaveMessage('Saved');
+      setSaveMessage(
+        nextData.job.regradeRequired
+          ? 'Saved · quality regrade needed'
+          : 'Saved',
+      );
     } catch (error) {
       setSaveMessage(error instanceof Error ? error.message : 'Failed to save prompt');
     } finally {
@@ -392,8 +411,16 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
         throw new Error(payload?.error || 'Failed to save prompt');
       }
 
+      const savedData: ReviewJobResponse = await saveRes.json();
+      const triageOnly =
+        savedData.job.regradeRequired
+        && savedData.job.artifactArchiveAvailable;
       const analyzeRes = await fetch(`/api/jobs/${data.job.id}/analyze`, {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mode: triageOnly ? 'triage' : 'full',
+        }),
       });
 
       if (!analyzeRes.ok) {
@@ -402,7 +429,9 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
       }
 
       await refreshJob();
-      setSaveMessage('Analysis queued');
+      setSaveMessage(
+        triageOnly ? 'Whole-job quality regrade queued' : 'Analysis queued',
+      );
     } catch (error) {
       setSaveMessage(error instanceof Error ? error.message : 'Failed to start analysis');
     } finally {
@@ -518,6 +547,8 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
   const analysisButtonLabel =
     analysisQueued
       ? 'Analysis queued...'
+      : qualityRegradeNeeded && data.job.artifactArchiveAvailable
+        ? `Regrade quality (${sortedResults.length} listings)`
       : data.job.analysisStatus === 'completed' || data.job.analysisStatus === 'partial'
       ? selectedCount > 0
         ? `Re-run analysis (${selectedCount} selected)`
@@ -549,13 +580,21 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
             </div>
 
             <div className="flex flex-col items-start gap-2 lg:items-end">
-              <span className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${statusClassName(data.job.status)}`}>
-                {statusLabel(
-                  data.job.status,
-                  data.job.currentPhase,
-                  data.job.analysisStatus,
-                  data.job.reportReady,
-                )}
+              <span
+                className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${
+                  data.job.regradeRequired
+                    ? 'border-amber-300/20 bg-amber-300/10 text-amber-100'
+                    : statusClassName(data.job.status)
+                }`}
+              >
+                {data.job.regradeRequired
+                  ? 'Regrade needed'
+                  : statusLabel(
+                      data.job.status,
+                      data.job.currentPhase,
+                      data.job.analysisStatus,
+                      data.job.reportReady,
+                    )}
               </span>
               <span className="text-xs text-stone-500">Job ID: {data.job.id}</span>
             </div>
@@ -602,7 +641,10 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
                   {data.job.pagesScanned} pages scanned
                 </span>
                 <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1.5">
-                  Analysis: {phaseStatusLabel(data.job.analysisStatus)}
+                  Analysis:{' '}
+                  {data.job.regradeRequired
+                    ? 'Regrade needed'
+                    : phaseStatusLabel(data.job.analysisStatus)}
                 </span>
                 {hasAiCosts(data.job.costs) && (
                   <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1.5">
@@ -708,6 +750,13 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
                 Price never changes the quality tier. It appears separately as within budget,
                 over by a percentage, or unknown with a reason.
               </p>
+              {qualityRegradeNeeded && (
+                <div className="mt-3 rounded-xl border border-amber-300/20 bg-amber-300/[0.08] px-3 py-2.5 text-xs leading-5 text-amber-100/80">
+                  The saved verdicts reflect the previous quality brief.
+                  Their paid evidence remains available, but a whole-job
+                  triage regrade is required before peer comparison.
+                </div>
+              )}
               <div className="mt-3 flex items-center justify-between gap-3">
                 <span className="text-xs text-stone-500">
                   {saveMessage

--- a/web/src/components/PrioritiesMatrix.test.tsx
+++ b/web/src/components/PrioritiesMatrix.test.tsx
@@ -158,3 +158,32 @@ test('priorities matrix renders evidence frequencies and sample provenance hones
   assert.match(html, /No review data/);
   assert.match(html, /7 analysed · 7 scraped/);
 });
+
+test('priorities matrix preserves paid evidence after a quality brief edit', () => {
+  const html = renderToStaticMarkup(
+    <PrioritiesMatrix
+      listings={[listing('sleep-test')]}
+      regradeReasons={[
+        'brief_changed',
+        'classifier_policy_changed',
+        'requirement_set_mismatch',
+      ]}
+      estimatedRegradeCostUsd={0.012}
+      onRegrade={() => undefined}
+    />,
+  );
+
+  assert.match(html, /Reflects previous quality brief/);
+  assert.match(
+    html,
+    /Evidence snippets, frequencies, and years remain valid audit data/,
+  );
+  assert.match(html, /The priority columns reflect the previous brief/);
+  assert.match(html, /older classifier policy/);
+  assert.match(html, /different canonical priority set/);
+  assert.match(html, /Previous brief · Comparable ranked results/);
+  assert.match(html, /Regrade needed/);
+  assert.match(html, /42 of 250 AI-analyzed reviews/);
+  assert.match(html, /Regrade whole job/);
+  assert.match(html, /Estimated triage cost: \$0\.012/);
+});

--- a/web/src/components/PrioritiesMatrix.tsx
+++ b/web/src/components/PrioritiesMatrix.tsx
@@ -12,6 +12,11 @@ import {
 } from '@cli/priorities-matrix';
 import { buildReviewJobPrioritiesMatrix } from '@/lib/prioritiesMatrix';
 import type { ReviewJobListing } from '@/types';
+import { formatUsdCost } from '@/lib/aiCosts';
+import {
+  TRIAGE_REGRADE_REASON_COPY,
+  type TriageRegradeReason,
+} from '@/lib/results';
 import PlatformBadge from './PlatformBadge';
 
 type SortState = {
@@ -275,10 +280,27 @@ function HeaderButton({
 export default function PrioritiesMatrix({
   listings,
   onSelectListing,
+  regradeReasons = [],
+  regradeLocked = false,
+  regradeListingCount,
+  estimatedRegradeCostUsd,
+  regradeMessage,
+  onRegrade,
 }: {
   listings: ReviewJobListing[];
   onSelectListing?: (listingKey: string) => void;
+  regradeReasons?: TriageRegradeReason[];
+  regradeLocked?: boolean;
+  regradeListingCount?: number;
+  estimatedRegradeCostUsd?: number;
+  regradeMessage?: string | null;
+  onRegrade?: () => void;
 }) {
+  const regradeNeeded = regradeReasons.length > 0;
+  const briefChanged = regradeReasons.includes('brief_changed');
+  const wholeJobListingCount =
+    regradeListingCount
+    ?? listings.filter((listing) => !listing.hidden).length;
   const [sort, setSort] = useState<SortState>({
     key: null,
     direction: 'risk',
@@ -310,9 +332,16 @@ export default function PrioritiesMatrix({
         <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-stone-500">
           Evidence comparison
         </p>
-        <h2 className="mt-2 text-lg font-semibold text-white">
-          Priorities matrix
-        </h2>
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <h2 className="text-lg font-semibold text-white">
+            Priorities matrix
+          </h2>
+          {briefChanged && (
+            <span className="rounded-full border border-amber-300/20 bg-amber-300/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-amber-100">
+              Reflects previous quality brief
+            </span>
+          )}
+        </div>
         <p className="mt-2 max-w-4xl text-xs leading-5 text-stone-500">
           Availability and affordability stay separate from quality. Each
           priority cell shows the strongest status-aligned evidence, its
@@ -320,6 +349,62 @@ export default function PrioritiesMatrix({
           Column sorting never mixes insufficient, legacy, or stale rows into
           the comparable ranked group.
         </p>
+        {regradeNeeded && (
+          <div className="mt-4 flex flex-col gap-3 rounded-2xl border border-amber-300/20 bg-amber-300/[0.08] p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold text-amber-100">
+                Regrade needed before comparing verdicts
+              </p>
+              <ul className="mt-1 max-w-3xl space-y-1 text-[11px] leading-5 text-amber-100/70">
+                {regradeReasons.map((reason) => (
+                  <li key={reason}>
+                    {TRIAGE_REGRADE_REASON_COPY[reason]}
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-1 max-w-3xl text-[11px] leading-5 text-amber-100/70">
+                Evidence snippets, frequencies, and years remain valid audit
+                data.
+                {briefChanged
+                  ? ' The priority columns reflect the previous brief.'
+                  : ' Some verdicts use a different policy or priority set.'}
+                {' '}Peer comparison is not current until the whole job is
+                regraded. Regrading reuses saved review and photo analysis and
+                calls only triage.
+              </p>
+              <p className="mt-1 text-[11px] leading-5 text-amber-100/60">
+                Whole-job scope: {wholeJobListingCount} listing
+                {wholeJobListingCount === 1 ? '' : 's'}.
+                {estimatedRegradeCostUsd != null
+                  ? ` Estimated triage cost: ${
+                      formatUsdCost(estimatedRegradeCostUsd)
+                    } at about $0.006 per listing.`
+                  : ''}
+              </p>
+              {regradeMessage && (
+                <p className="mt-2 text-xs font-semibold text-amber-100">
+                  {regradeMessage}
+                </p>
+              )}
+            </div>
+            {onRegrade ? (
+              <button
+                type="button"
+                onClick={onRegrade}
+                disabled={regradeLocked}
+                className="rounded-xl border border-amber-200/25 bg-amber-100/10 px-3 py-2 text-xs font-semibold text-amber-50 transition hover:bg-amber-100/15 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {regradeLocked
+                  ? 'Regrade queued or running…'
+                  : 'Regrade whole job'}
+              </button>
+            ) : (
+              <span className="text-xs font-semibold text-amber-100/70">
+                Ask the job owner to regrade.
+              </span>
+            )}
+          </div>
+        )}
       </div>
 
       {matrix.columns.length === 0 ? (
@@ -390,7 +475,12 @@ export default function PrioritiesMatrix({
                           colSpan={matrix.columns.length + 3}
                           className="border-b border-white/10 bg-white/[0.035] px-4 py-2 text-[10px] font-bold uppercase tracking-[0.14em] text-stone-500"
                         >
-                          {rankingGroupLabel(row.rankingStatus)}
+                          {briefChanged
+                            && row.rankingStatus !== 'unscored'
+                            ? `Previous brief · ${
+                                rankingGroupLabel(row.rankingStatus)
+                              }`
+                            : rankingGroupLabel(row.rankingStatus)}
                         </td>
                       </tr>
                     )}
@@ -416,14 +506,20 @@ export default function PrioritiesMatrix({
                         <div className="mt-2 flex flex-wrap items-center gap-1.5">
                           <span
                             className={`rounded-full border px-2 py-0.5 text-[9px] font-bold uppercase tracking-[0.1em] ${
-                              row.rankingStatus === 'ranked'
+                              briefChanged
+                                && row.rankingStatus !== 'unscored'
+                                ? statusClassName('partial')
+                                : row.rankingStatus === 'ranked'
                                 ? statusClassName('met')
                                 : row.rankingStatus === 'insufficient_evidence'
                                   ? statusClassName('partial')
                                   : statusClassName('unknown')
                             }`}
                           >
-                            {rankingLabel(row.rankingStatus)}
+                            {briefChanged
+                              && row.rankingStatus !== 'unscored'
+                              ? 'Regrade needed'
+                              : rankingLabel(row.rankingStatus)}
                           </span>
                           {row.coverage != null && (
                             <span className="text-[10px] text-stone-500">

--- a/web/src/components/ResultsWorkspace.tsx
+++ b/web/src/components/ResultsWorkspace.tsx
@@ -16,13 +16,18 @@ import { formatUsdCost, hasAiCosts } from '@/lib/aiCosts';
 import { getPriceDisplayInfo, resolveComparablePrice } from '@/lib/pricing';
 import { buildListingUrl } from '@/lib/listingLinks';
 import {
+  AFFORDABILITY_STATUS_ORDER,
+  compareAffordability,
   formatPoiDistance,
   getActiveTriageComparison,
   getBookingEligibilityRank,
   getListingResultsSnapshot,
   getTriageComparisonStatus,
+  getTriageRegradeReasons,
   getTriageRegradeListingCount,
   getTierRank,
+  matchesAffordabilityFilter,
+  type AffordabilityStatus,
   type ParsedTriage,
   type ParsedTheme,
   type TriageComparisonStatus,
@@ -55,8 +60,14 @@ const SCORE_ORDER = [
   'modernity',
   'valueForMoney',
 ] as const;
-
-type SortKey = 'rank' | 'title' | 'tier' | 'fitScore' | 'price' | 'poiDistance';
+type SortKey =
+  | 'rank'
+  | 'title'
+  | 'tier'
+  | 'fitScore'
+  | 'affordability'
+  | 'price'
+  | 'poiDistance';
 type DetailTab = 'triage' | 'reviews' | 'photos' | 'snapshot';
 
 function listingKey(listing: Pick<ReviewJobListing, 'id' | 'platform'>) {
@@ -95,15 +106,17 @@ function comparisonRank(status: TriageComparisonStatus): number {
   switch (status) {
     case 'ranked':
       return 0;
-    case 'insufficient_evidence':
+    case 'regrade_required':
       return 1;
-    case 'stale_classifier_policy':
+    case 'insufficient_evidence':
       return 2;
+    case 'stale_classifier_policy':
+      return 3;
     case 'legacy':
     case 'stale_requirement_set':
-      return 3;
-    case 'unscored':
       return 4;
+    case 'unscored':
+      return 5;
   }
 }
 
@@ -124,10 +137,15 @@ function displayedTier(
     return { label: 'Insufficient evidence', tier: null };
   }
   if (
+    status === 'regrade_required'
+    ||
     status === 'stale_requirement_set'
     || status === 'stale_classifier_policy'
   ) {
-    return { label: 'Unranked', tier: null };
+    return {
+      label: 'Regrade needed',
+      tier: null,
+    };
   }
   return { label: tierLabel(triage?.tier ?? null), tier: triage?.tier ?? null };
 }
@@ -158,14 +176,21 @@ function VerdictSourceBadge({
   if (status === 'stale_requirement_set') {
     return (
       <span className="rounded-full border border-stone-300/20 bg-stone-300/10 px-2 py-1 text-[10px] font-semibold text-stone-200">
-        Stale requirement set
+        Regrade needed · priority set mismatch
       </span>
     );
   }
   if (status === 'stale_classifier_policy') {
     return (
       <span className="rounded-full border border-stone-300/20 bg-stone-300/10 px-2 py-1 text-[10px] font-semibold text-stone-200">
-        Older classifier policy
+        Regrade needed · policy changed
+      </span>
+    );
+  }
+  if (status === 'regrade_required') {
+    return (
+      <span className="rounded-full border border-amber-300/20 bg-amber-300/10 px-2 py-1 text-[10px] font-semibold text-amber-100">
+        Regrade needed · brief changed
       </span>
     );
   }
@@ -1253,6 +1278,12 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
   const [activeTiers, setActiveTiers] = useState<Set<string>>(
     () => new Set(TIER_ORDER),
   );
+  const [
+    activeAffordabilityStatuses,
+    setActiveAffordabilityStatuses,
+  ] = useState<Set<AffordabilityStatus>>(
+    () => new Set(AFFORDABILITY_STATUS_ORDER),
+  );
   const [maxPriceFilter, setMaxPriceFilter] = useState('');
   const [maxPoiDistanceFilter, setMaxPoiDistanceFilter] = useState('');
   const [sortKey, setSortKey] = useState<SortKey>('fitScore');
@@ -1392,17 +1423,28 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
     () => getActiveTriageComparison(data.listings),
     [data.listings],
   );
-  const olderPolicyCount = useMemo(
-    () =>
-      data.listings.filter(
-        (listing) =>
-          !listing.hidden
-          && getTriageComparisonStatus(
-            getListingResultsSnapshot(listing).triage,
-            activeTriageComparison,
-          ) === 'stale_classifier_policy',
-      ).length,
-    [activeTriageComparison, data.listings],
+  const regradeReasons = useMemo(
+    () => getTriageRegradeReasons(
+      data.listings,
+      activeTriageComparison,
+      data.job.regradeRequired,
+    ),
+    [
+      activeTriageComparison,
+      data.job.regradeRequired,
+      data.listings,
+    ],
+  );
+  const comparisonGateActive =
+    activeTriageComparison != null || data.job.regradeRequired;
+  const resolveComparisonStatus = useCallback(
+    (triage: ParsedTriage | null) =>
+      getTriageComparisonStatus(
+        triage,
+        activeTriageComparison,
+        { regradeRequired: data.job.regradeRequired },
+      ),
+    [activeTriageComparison, data.job.regradeRequired],
   );
   const regradeListingCount = useMemo(
     () => getTriageRegradeListingCount(data.listings),
@@ -1463,12 +1505,12 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       }
       const triageA = getListingResultsSnapshot(a).triage;
       const triageB = getListingResultsSnapshot(b).triage;
-      if (activeTriageComparison) {
+      if (comparisonGateActive) {
         const groupA = comparisonRank(
-          getTriageComparisonStatus(triageA, activeTriageComparison),
+          resolveComparisonStatus(triageA),
         );
         const groupB = comparisonRank(
-          getTriageComparisonStatus(triageB, activeTriageComparison),
+          resolveComparisonStatus(triageB),
         );
         if (groupA !== groupB) return groupA - groupB;
         if (groupA !== 0) {
@@ -1513,11 +1555,12 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
     });
     return next;
   }, [
-    activeTriageComparison,
+    comparisonGateActive,
     data.job.checkin,
     data.job.checkout,
     data.listings,
     priceDisplay,
+    resolveComparisonStatus,
   ]);
 
   const sortableResults = useMemo(() => {
@@ -1528,16 +1571,14 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
 
     if (sortKey === 'rank') {
       if (!sortAsc) return next;
-      if (!activeTriageComparison) return [...next].reverse();
+      if (!comparisonGateActive) return [...next].reverse();
       const ranked = next.filter((listing) =>
-        getTriageComparisonStatus(
+        resolveComparisonStatus(
           getListingResultsSnapshot(listing).triage,
-          activeTriageComparison,
         ) === 'ranked');
       const unranked = next.filter((listing) =>
-        getTriageComparisonStatus(
+        resolveComparisonStatus(
           getListingResultsSnapshot(listing).triage,
-          activeTriageComparison,
         ) !== 'ranked');
       return [...ranked.reverse(), ...unranked];
     }
@@ -1548,26 +1589,40 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       if (eligibilityA !== eligibilityB) {
         return eligibilityA - eligibilityB;
       }
-      if (activeTriageComparison) {
+      if (comparisonGateActive) {
         const groupA = comparisonRank(
-          getTriageComparisonStatus(
+          resolveComparisonStatus(
             getListingResultsSnapshot(a).triage,
-            activeTriageComparison,
           ),
         );
         const groupB = comparisonRank(
-          getTriageComparisonStatus(
+          resolveComparisonStatus(
             getListingResultsSnapshot(b).triage,
-            activeTriageComparison,
           ),
         );
         if (groupA !== groupB) return groupA - groupB;
-        if (groupA !== 0) {
+        if (
+          groupA !== 0
+          && sortKey !== 'affordability'
+        ) {
           return (
             (baseIndex.get(listingKey(a)) ?? 0)
             - (baseIndex.get(listingKey(b)) ?? 0)
           );
         }
+      }
+
+      if (sortKey === 'affordability') {
+        const difference = compareAffordability(
+          a.affordability,
+          b.affordability,
+        );
+        return difference !== 0
+          ? difference
+          : (
+              (baseIndex.get(listingKey(a)) ?? 0)
+              - (baseIndex.get(listingKey(b)) ?? 0)
+            );
       }
 
       if (sortKey === 'title') {
@@ -1610,11 +1665,12 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
 
     return next;
   }, [
-    activeTriageComparison,
     baseRankedResults,
+    comparisonGateActive,
     data.job.checkin,
     data.job.checkout,
     priceDisplay,
+    resolveComparisonStatus,
     sortAsc,
     sortKey,
   ]);
@@ -1631,14 +1687,19 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
     () =>
       displayableResults.filter((listing) => {
         const triage = getListingResultsSnapshot(listing).triage;
-        const comparisonStatus = getTriageComparisonStatus(
-          triage,
-          activeTriageComparison,
-        );
+        const comparisonStatus = resolveComparisonStatus(triage);
         const tier = triage?.tier ?? 'unscored';
         if (
-          (!activeTriageComparison || comparisonStatus === 'ranked')
+          (!comparisonGateActive || comparisonStatus === 'ranked')
           && !activeTiers.has(tier)
+        ) {
+          return false;
+        }
+        if (
+          !matchesAffordabilityFilter(
+            listing,
+            activeAffordabilityStatuses,
+          )
         ) {
           return false;
         }
@@ -1668,14 +1729,16 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
         return true;
       }),
     [
+      activeAffordabilityStatuses,
       activeTiers,
-      activeTriageComparison,
+      comparisonGateActive,
       data.job.checkin,
       data.job.checkout,
       displayableResults,
       maxPoiDistanceFilter,
       maxPriceFilter,
       priceDisplay,
+      resolveComparisonStatus,
     ],
   );
 
@@ -1694,10 +1757,9 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       (listing) =>
         listing.staySnapshot.bookingEligibility.actionable
         && (
-        !activeTriageComparison
-        || getTriageComparisonStatus(
+        !comparisonGateActive
+        || resolveComparisonStatus(
           getListingResultsSnapshot(listing).triage,
-          activeTriageComparison,
         ) === 'ranked'
         ),
     );
@@ -1708,18 +1770,19 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
     return topPicks.length >= 3
       ? topPicks.slice(0, 5)
       : comparable.slice(0, 5);
-  }, [activeTriageComparison, filteredResults]);
+  }, [
+    comparisonGateActive,
+    filteredResults,
+    resolveComparisonStatus,
+  ]);
 
   const tierCounts = useMemo(() => {
     const counts = new Map<string, number>();
     for (const listing of displayableResults) {
       const triage = getListingResultsSnapshot(listing).triage;
       if (
-        activeTriageComparison
-        && getTriageComparisonStatus(
-          triage,
-          activeTriageComparison,
-        ) !== 'ranked'
+        comparisonGateActive
+        && resolveComparisonStatus(triage) !== 'ranked'
       ) {
         continue;
       }
@@ -1727,7 +1790,25 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       counts.set(tier, (counts.get(tier) ?? 0) + 1);
     }
     return counts;
-  }, [activeTriageComparison, displayableResults]);
+  }, [
+    comparisonGateActive,
+    displayableResults,
+    resolveComparisonStatus,
+  ]);
+  const affordabilityCounts = useMemo(() => {
+    const counts = new Map<AffordabilityStatus, number>();
+    for (const status of AFFORDABILITY_STATUS_ORDER) {
+      counts.set(status, 0);
+    }
+    for (const listing of displayableResults) {
+      const status = listing.affordability.status;
+      counts.set(status, (counts.get(status) ?? 0) + 1);
+    }
+    return counts;
+  }, [displayableResults]);
+  const hasAffordabilityFilter =
+    activeAffordabilityStatuses.size
+    !== AFFORDABILITY_STATUS_ORDER.length;
 
   useEffect(() => {
     if (filteredResults.length === 0) {
@@ -1890,10 +1971,8 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       rows.map((listing, index) => {
         const key = listingKey(listing);
         const snapshot = getListingResultsSnapshot(listing);
-        const comparisonStatus = getTriageComparisonStatus(
-          snapshot.triage,
-          activeTriageComparison,
-        );
+        const comparisonStatus =
+          resolveComparisonStatus(snapshot.triage);
         const verdictTier = displayedTier(
           snapshot.triage,
           comparisonStatus,
@@ -1902,26 +1981,29 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
         const previousComparisonGroup =
           index > 0
             ? comparisonRank(
-                getTriageComparisonStatus(
+                resolveComparisonStatus(
                   getListingResultsSnapshot(rows[index - 1]).triage,
-                  activeTriageComparison,
                 ),
               )
             : null;
         const groupHeader =
-          activeTriageComparison
+          comparisonGateActive
           && comparisonGroup !== 0
           && comparisonGroup !== previousComparisonGroup
-            ? comparisonGroup === 1
+            ? comparisonStatus === 'regrade_required'
+              ? 'Regrade needed — these verdicts reflect the previous quality brief'
+              : comparisonStatus === 'insufficient_evidence'
               ? 'Insufficient evidence — shown for audit, not ranked with comparable results'
-              : comparisonGroup === 2
-                ? 'Classified under an older policy — regrade the whole job before comparing'
-                : comparisonGroup === 3
-                  ? 'Legacy or stale requirement-set verdicts — regrade before comparing'
+              : comparisonStatus === 'stale_classifier_policy'
+                ? 'Regrade needed — classifier policy changed'
+                : comparisonStatus === 'stale_requirement_set'
+                  ? 'Regrade needed — canonical priority set mismatch'
+                  : comparisonStatus === 'legacy'
+                    ? 'Legacy verdicts — preserved for audit outside current peer ranking'
                 : 'Unscored listings'
             : null;
         const showPeerRank =
-          !activeTriageComparison || comparisonStatus === 'ranked';
+          !comparisonGateActive || comparisonStatus === 'ranked';
         const priceInfo = getPriceDisplayInfo(listing, priceDisplay, {
           checkin: data.job.checkin,
           checkout: data.job.checkout,
@@ -2149,13 +2231,14 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
         );
       }),
     [
-      activeTriageComparison,
+      comparisonGateActive,
       data.job,
       expandedId,
       handleSelect,
       hiddenIds,
       likedIds,
       priceDisplay,
+      resolveComparisonStatus,
       selectedId,
       showHidden,
       toggleHidden,
@@ -2239,49 +2322,6 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
               onQueued={refreshJob}
             />
           </div>
-
-          {olderPolicyCount > 0 && (
-            <div className="mt-5 rounded-2xl border border-amber-300/20 bg-amber-300/[0.08] p-4">
-              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-                <div>
-                  <p className="text-sm font-semibold text-amber-100">
-                    Classified under an older policy
-                  </p>
-                  <p className="mt-1 max-w-3xl text-xs leading-5 text-amber-100/75">
-                    {olderPolicyCount} verdict{olderPolicyCount === 1 ? ' is' : 's are'} preserved
-                    for audit but excluded from peer ranking until the whole job is regraded.
-                    This reuses saved review and photo analysis and calls only triage.
-                  </p>
-                  <p className="mt-1 text-xs text-amber-100/65">
-                    Whole-job scope: {regradeListingCount} listing
-                    {regradeListingCount === 1 ? '' : 's'}. Estimated AI cost:{' '}
-                    {formatUsdCost(estimatedRegradeCostUsd)} at about $0.006 per listing.
-                  </p>
-                  {regradeMessage && (
-                    <p className="mt-2 text-xs font-semibold text-amber-100">
-                      {regradeMessage}
-                    </p>
-                  )}
-                </div>
-                {viewerCanEdit ? (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      void startTriageRegrade();
-                    }}
-                    disabled={regradeLocked}
-                    className="rounded-2xl border border-amber-200/25 bg-amber-100/10 px-4 py-2 text-sm font-semibold text-amber-50 transition hover:bg-amber-100/15 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {regradeLocked ? 'Regrade queued or running…' : 'Regrade whole job'}
-                  </button>
-                ) : (
-                  <span className="text-xs font-semibold text-amber-100/70">
-                    Ask the job owner to regrade.
-                  </span>
-                )}
-              </div>
-            </div>
-          )}
 
           <div className="mt-5 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -2392,6 +2432,18 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
 
         <PrioritiesMatrix
           listings={displayableResults}
+          regradeReasons={regradeReasons}
+          regradeLocked={regradeLocked}
+          regradeListingCount={regradeListingCount}
+          estimatedRegradeCostUsd={estimatedRegradeCostUsd}
+          regradeMessage={regradeMessage}
+          onRegrade={
+            viewerCanEdit
+              ? () => {
+                  void startTriageRegrade();
+                }
+              : undefined
+          }
           onSelectListing={(key) =>
             handleSelect(key, { scroll: true })}
         />
@@ -2458,6 +2510,82 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
                 );
               })}
             </div>
+            <div className="flex flex-wrap items-end gap-4">
+              <div>
+                <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-stone-500">
+                  Budget status
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {AFFORDABILITY_STATUS_ORDER.map((status) => {
+                    const active =
+                      activeAffordabilityStatuses.has(status);
+                    return (
+                      <button
+                        key={status}
+                        type="button"
+                        onClick={() =>
+                          setActiveAffordabilityStatuses((current) => {
+                            const next = new Set(current);
+                            if (next.has(status)) {
+                              next.delete(status);
+                            } else {
+                              next.add(status);
+                            }
+                            return next;
+                          })
+                        }
+                        className={`rounded-full border px-3 py-1.5 text-xs font-semibold capitalize transition ${
+                          active
+                            ? 'border-white/30 bg-white text-black'
+                            : 'border-white/10 bg-white/[0.04] text-stone-300 hover:bg-white/[0.08] hover:text-white'
+                        }`}
+                      >
+                        {status}
+                        <span className="ml-2 text-[11px] opacity-70">
+                          {affordabilityCounts.get(status) ?? 0}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              <div>
+                <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-stone-500">
+                  Comparison order
+                </p>
+                <div className="flex rounded-xl border border-white/10 bg-black/20 p-1">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSortKey('fitScore');
+                      setSortAsc(false);
+                    }}
+                    className={`rounded-lg px-3 py-1.5 text-xs font-semibold transition ${
+                      sortKey === 'fitScore'
+                        ? 'bg-white text-black'
+                        : 'text-stone-400 hover:text-white'
+                    }`}
+                  >
+                    Quality first
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSortKey('affordability');
+                      setSortAsc(false);
+                    }}
+                    className={`rounded-lg px-3 py-1.5 text-xs font-semibold transition ${
+                      sortKey === 'affordability'
+                        ? 'bg-white text-black'
+                        : 'text-stone-400 hover:text-white'
+                    }`}
+                    title="Within budget, then least over budget, then unknown; quality breaks ties inside comparable ranked groups"
+                  >
+                    Budget fit
+                  </button>
+                </div>
+              </div>
+            </div>
             <div className="flex flex-wrap gap-3">
               <label className="flex min-w-[180px] flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-stone-500">
                 {priceDisplay === 'perNight' ? 'Max Per Night' : 'Max Total'}
@@ -2487,12 +2615,17 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
                   />
                 </label>
               )}
-              {(maxPriceFilter || maxPoiDistanceFilter) && (
+              {(maxPriceFilter
+                || maxPoiDistanceFilter
+                || hasAffordabilityFilter) && (
                 <button
                   type="button"
                   onClick={() => {
                     setMaxPriceFilter('');
                     setMaxPoiDistanceFilter('');
+                    setActiveAffordabilityStatuses(
+                      new Set(AFFORDABILITY_STATUS_ORDER),
+                    );
                   }}
                   className="self-end rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-stone-200 transition hover:bg-white/[0.08]"
                 >

--- a/web/src/lib/results.ts
+++ b/web/src/lib/results.ts
@@ -161,6 +161,7 @@ export interface ParsedTriage {
 
 export type TriageComparisonStatus =
   | 'ranked'
+  | 'regrade_required'
   | 'insufficient_evidence'
   | 'legacy'
   | 'stale_requirement_set'
@@ -168,6 +169,66 @@ export type TriageComparisonStatus =
   | 'unscored';
 
 export type ActiveTriageComparison = TriageComparabilityDescriptor;
+export type TriageRegradeReason =
+  | 'brief_changed'
+  | 'classifier_policy_changed'
+  | 'requirement_set_mismatch';
+export type AffordabilityStatus =
+  ReviewJobListing['affordability']['status'];
+
+export const TRIAGE_REGRADE_REASON_COPY: Record<
+  TriageRegradeReason,
+  string
+> = {
+  brief_changed:
+    'The quality brief changed, so these verdicts reflect the previous brief.',
+  classifier_policy_changed:
+    'Some verdicts use an older classifier policy.',
+  requirement_set_mismatch:
+    'Some verdicts use a different canonical priority set.',
+};
+
+const TRIAGE_REGRADE_REASON_ORDER: TriageRegradeReason[] = [
+  'brief_changed',
+  'classifier_policy_changed',
+  'requirement_set_mismatch',
+];
+
+export const AFFORDABILITY_STATUS_ORDER: AffordabilityStatus[] = [
+  'within',
+  'over',
+  'unknown',
+];
+
+export function compareAffordability(
+  left: ReviewJobListing['affordability'],
+  right: ReviewJobListing['affordability'],
+): number {
+  const leftRank = AFFORDABILITY_STATUS_ORDER.indexOf(left.status);
+  const rightRank = AFFORDABILITY_STATUS_ORDER.indexOf(right.status);
+  if (leftRank !== rightRank) return leftRank - rightRank;
+
+  if (left.status === 'over' && right.status === 'over') {
+    if (
+      left.overByPercent == null
+      && right.overByPercent == null
+    ) {
+      return 0;
+    }
+    if (left.overByPercent == null) return 1;
+    if (right.overByPercent == null) return -1;
+    return left.overByPercent - right.overByPercent;
+  }
+
+  return 0;
+}
+
+export function matchesAffordabilityFilter(
+  listing: Pick<ReviewJobListing, 'affordability'>,
+  activeStatuses: ReadonlySet<AffordabilityStatus>,
+): boolean {
+  return activeStatuses.has(listing.affordability.status);
+}
 
 export function getTriageRegradeListingCount(
   listings: Array<Pick<ReviewJobListing, 'hidden'>>,
@@ -307,11 +368,38 @@ export function getActiveTriageComparison(
     : null;
 }
 
+export function getTriageRegradeReasons(
+  listings: ReviewJobListing[],
+  activeComparison: ActiveTriageComparison | null,
+  briefChanged: boolean,
+): TriageRegradeReason[] {
+  const reasons = new Set<TriageRegradeReason>();
+  if (briefChanged) reasons.add('brief_changed');
+
+  for (const listing of listings) {
+    if (listing.hidden) continue;
+    const status = getTriageComparisonStatus(
+      getListingResultsSnapshot(listing).triage,
+      activeComparison,
+    );
+    if (status === 'stale_classifier_policy') {
+      reasons.add('classifier_policy_changed');
+    } else if (status === 'stale_requirement_set') {
+      reasons.add('requirement_set_mismatch');
+    }
+  }
+
+  return TRIAGE_REGRADE_REASON_ORDER.filter((reason) =>
+    reasons.has(reason));
+}
+
 export function getTriageComparisonStatus(
   triage: ParsedTriage | null,
   activeComparison: ActiveTriageComparison | null,
+  options: { regradeRequired?: boolean } = {},
 ): TriageComparisonStatus {
   if (!triage) return 'unscored';
+  if (options.regradeRequired) return 'regrade_required';
   if (triage.scoreSource === 'model_legacy') return 'legacy';
   if (
     activeComparison

--- a/web/src/lib/reviewJobEdits.ts
+++ b/web/src/lib/reviewJobEdits.ts
@@ -1,0 +1,43 @@
+import type { PhaseStatus } from '../types.js';
+
+export interface QualityBriefEditEffect {
+  storedPrompt: string | null;
+  qualityBriefChanged: boolean;
+  regradeRequired: boolean;
+}
+
+export function normalizeQualityBriefForComparison(
+  value: string | null | undefined,
+): string {
+  return (value ?? '').trim().replace(/\s+/g, ' ');
+}
+
+export function getQualityBriefEditEffect(input: {
+  currentPrompt: string | null | undefined;
+  nextPrompt: string | null | undefined;
+  analysisStatus: PhaseStatus;
+  regradeRequired: boolean;
+}): QualityBriefEditEffect {
+  const storedPrompt = input.nextPrompt?.trim() || null;
+  const qualityBriefChanged =
+    normalizeQualityBriefForComparison(input.currentPrompt)
+    !== normalizeQualityBriefForComparison(storedPrompt);
+  const hasPersistedVerdicts =
+    input.analysisStatus === 'completed'
+    || input.analysisStatus === 'partial';
+
+  return {
+    storedPrompt,
+    qualityBriefChanged,
+    regradeRequired:
+      input.regradeRequired
+      || (qualityBriefChanged && hasPersistedVerdicts),
+  };
+}
+
+export function regradeRequiredAfterAnalysis(
+  current: boolean,
+  status: 'completed' | 'partial' | 'failed',
+): boolean {
+  return status === 'completed' ? false : current;
+}

--- a/web/src/lib/reviewJobs.ts
+++ b/web/src/lib/reviewJobs.ts
@@ -546,6 +546,7 @@ export function toReviewJobState(
     priceRefreshCurrentPhase: job.priceRefreshCurrentPhase ?? null,
     location: job.location ?? null,
     prompt: job.prompt ?? null,
+    regradeRequired: job.regradeRequired,
     boundingBox: parseStoredBoundingBox(job.boundingBox) ?? null,
     circle: asCircleFilter(job.circle),
     poi: asMapPoint(job.poi),

--- a/web/src/lib/search-worker.ts
+++ b/web/src/lib/search-worker.ts
@@ -70,6 +70,7 @@ import {
   getReviewJobStaySnapshotReadModel,
   resolveStaySnapshotTtlMs,
 } from './staySnapshots.js';
+import { regradeRequiredAfterAnalysis } from './reviewJobEdits.js';
 
 for (const envPath of [
   path.resolve(process.cwd(), '.env.local'),
@@ -1907,6 +1908,10 @@ async function runReviewJobAnalysis(
           analysisErrorMessage: null,
           analysisCompletedAt: completedAt,
           analysisDurationMs: completedAt.getTime() - startedAt.getTime(),
+          regradeRequired: regradeRequiredAfterAnalysis(
+            jobRecord.regradeRequired,
+            overallStatus,
+          ),
           artifactRoot,
           reportPath,
           ...aggregatedAiCosts,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -244,6 +244,7 @@ export interface ReviewJobState {
   priceRefreshCurrentPhase: string | null;
   location: string | null;
   prompt: string | null;
+  regradeRequired: boolean;
   boundingBox: BoundingBox | null;
   circle: CircleFilter | null;
   poi: MapPoint | null;


### PR DESCRIPTION
Closes #56

## What changed

- Adds independent `within` / `over` / `unknown` affordability filters driven by each listing's current deterministic affordability read model.
- Adds an opt-in **Budget fit** order: booking eligibility and comparison groups remain isolated, then results order as within budget, over budget by ascending percentage, and unknown. Existing quality order is the tie-break for comparable ranked results; quality-first remains the default and no composite score is introduced.
- Persists `ReviewJob.regradeRequired` after a normalized quality-brief edit when completed or partial verdicts exist. Whitespace-only, sharing, selection, and structured budget-only edits do not invalidate quality.
- Preserves the marker through queued, running, failed, and partial attempts; only a fully completed full or triage-only whole-job run clears it.
- Unifies brief, classifier-policy, and requirement-set staleness under one **Regrade needed** presentation with distinct reason codes and one whole-job action/scope/cost.
- Keeps the priorities matrix and paid evidence visible. Previous-brief columns and rows are explicitly labeled, while hero picks, tiers, and peer ranks remain gated until regrade completion.
- Documents the controls, validity semantics, and deterministic budget-only boundary.

## Validation

- `pnpm test` — 152 passing
- `pnpm run build`
- `pnpm run lint`
- `npm --prefix web run test:pricing` — 3 passing
- `npm --prefix web run test:ui` — 11 passing
- `npm --prefix web run lint`
- Prisma client generation and schema validation
- `npm --prefix web run build`
- `git diff --check`

## Deployment note

This adds one Prisma column, `ReviewJob.regradeRequired Boolean @default(false)`. The live checkout, database, and stack were not touched; schema application remains for the orchestrator's controlled merge window.
