### PR TITLE
Surface cross-platform listing conflicts

### DIFF
--- a/docs/codex-onramp.md
+++ b/docs/codex-onramp.md
@@ -91,9 +91,10 @@ near-free and fast. Repeat runs on the same destination are the real usage patte
 - `src/booking/` — Playwright-based (hotel pages are AWS-WAF-protected; review list pages work
   with plain HTTP+proxy). `src/airbnb/` — raw HTTP/GraphQL.
 - `web/prisma/schema.prisma` — `ReviewJob`, `ReviewJobListing`, `ReviewJobListingAnalysis`,
-  `ReviewJobEvent` (+ older `SearchJob`/`SearchResult`). Postgres (`dev.db` was a stray, deleted).
+  `ReviewJobDuplicatePair`, `ReviewJobEvent` (+ older `SearchJob`/`SearchResult`). Postgres
+  (`dev.db` was a stray, deleted).
 - `web/src/lib/` — `search-worker.ts` (BullMQ worker, the heart), `reviewJobs.ts`,
-  `review-job-batch-analysis.ts`, `aiCosts.ts`.
+  `review-job-batch-analysis.ts`, `reviewJobDuplicates.ts`, `aiCosts.ts`.
 - `web/src/app/` — `/` landing+map, `/jobs/[jobId]` workspace, `/jobs/[jobId]/results`,
   API under `/api/` (jobs, search, quick-search, geocode, export, SSE stream).
 - Docs worth reading: `web/README.md` (how to run), `docs/review-job-roadmap.md`,

--- a/docs/triage-rubric.md
+++ b/docs/triage-rubric.md
@@ -355,6 +355,21 @@ Stored JSON without `scoreSource`, `rubricVersion`, and `requirementSetId` is
 
 CLI/report output follows the same source/version and grouping rules.
 
+## Cross-platform identity conflicts
+
+Airbnb and Booking offers are never treated as independent peer evidence when an active
+same-property link exposes materially contradictory verdicts. A `likely_same` detector suggestion
+or an owner-confirmed link is active; an unconfirmed `possible_same` suggestion is inert. A pair is
+materially contradictory when both sides have scored tiers at least two levels apart.
+
+The native results page keeps the offers and their evidence separate, shows them together for
+audit, and withholds both from the top-picks hero and comparable peer ranks while the material link
+is active. Their matrix rows remain visible in a labeled conflict group with all paid evidence. It
+does not merge review corpora, recompute either tier, or use the richer platform's
+verdict as a replacement for the thinner one. Dismissing or undoing the link restores the normal
+single-listing comparison rules when no active detector suggestion remains; undoing a confirmation
+otherwise returns the pair to its current detector state.
+
 ## Priorities matrix
 
 The native results page derives one per-job evidence matrix from persisted deterministic triage;

--- a/tests/review-job-duplicate-persistence.test.ts
+++ b/tests/review-job-duplicate-persistence.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  syncReviewJobDuplicatePairs,
+} from '../web/src/lib/reviewJobDuplicatePersistence.js';
+
+test('detector resync updates evidence without overwriting user decisions', async () => {
+  const upserts: Array<Record<string, any>> = [];
+  const deletedIds: string[] = [];
+  const clearedDetectorIds: string[] = [];
+  const client = {
+    reviewJobListing: {
+      findMany: async () => [
+        {
+          listingId: 'nomo-airbnb',
+          platform: 'airbnb',
+          name: 'Hotel in SoHo',
+          lat: 40.72,
+          lng: -74,
+          propertyType: 'Hotel room',
+          analysis: {
+            details: {
+              host: {
+                name: 'NoMo SoHo New York City',
+              },
+            },
+          },
+        },
+        {
+          listingId: 'nomo-booking',
+          platform: 'booking',
+          name: 'NoMo SoHo',
+          lat: 40.72,
+          lng: -73.99903,
+          propertyType: 'Hotel',
+          analysis: {
+            details: {},
+          },
+        },
+      ],
+    },
+    reviewJobDuplicatePair: {
+      findMany: async () => [
+        {
+          id: 'confirmed_pair',
+          airbnbListingId: 'nomo-airbnb',
+          bookingListingId: 'nomo-booking',
+          detectorConfidence: 'likely_same',
+          decisionSource: 'user',
+        },
+        {
+          id: 'stale_user_dismissal',
+          airbnbListingId: 'old-airbnb',
+          bookingListingId: 'old-booking',
+          detectorConfidence: 'possible_same',
+          decisionSource: 'user',
+        },
+        {
+          id: 'stale_detector_suggestion',
+          airbnbListingId: 'gone-airbnb',
+          bookingListingId: 'gone-booking',
+          detectorConfidence: 'possible_same',
+          decisionSource: 'detector',
+        },
+      ],
+      upsert: async (args: Record<string, any>) => {
+        upserts.push(args);
+        return args;
+      },
+      deleteMany: async (args: {
+        where: { id: { in: string[] } };
+      }) => {
+        deletedIds.push(...args.where.id.in);
+        return { count: args.where.id.in.length };
+      },
+      updateMany: async (args: {
+        where: { id: { in: string[] } };
+      }) => {
+        clearedDetectorIds.push(...args.where.id.in);
+        return { count: args.where.id.in.length };
+      },
+    },
+  };
+
+  const detected = await syncReviewJobDuplicatePairs(
+    client as any,
+    'job_1',
+  );
+
+  assert.equal(detected.length, 1);
+  assert.equal(detected[0].confidence, 'likely_same');
+  assert.equal(detected[0].nameSource, 'host');
+  assert.equal(upserts.length, 1);
+  assert.equal(upserts[0].create.decision, 'suggested');
+  assert.equal(upserts[0].create.decisionSource, 'detector');
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(
+      upserts[0].update,
+      'decision',
+    ),
+    false,
+  );
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(
+      upserts[0].update,
+      'decisionSource',
+    ),
+    false,
+  );
+  assert.deepEqual(deletedIds, ['stale_detector_suggestion']);
+  assert.deepEqual(clearedDetectorIds, ['stale_user_dismissal']);
+});

--- a/tests/review-job-duplicates.test.ts
+++ b/tests/review-job-duplicates.test.ts
@@ -1,0 +1,429 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  detectReviewJobDuplicatePairs,
+  normalizeDuplicateName,
+  REVIEW_JOB_DUPLICATE_CANDIDATE_RADIUS_METERS,
+  type DuplicateListingInput,
+} from '../web/src/lib/reviewJobDuplicates.js';
+
+const METERS_PER_LONGITUDE_DEGREE_AT_NYC = 84_000;
+
+function coordinate(
+  lat: number,
+  lng: number,
+  eastMeters = 0,
+) {
+  return {
+    lat,
+    lng: lng + eastMeters / METERS_PER_LONGITUDE_DEGREE_AT_NYC,
+  };
+}
+
+function airbnb(
+  listingId: string,
+  name: string,
+  lat: number,
+  lng: number,
+  options: {
+    eastMeters?: number;
+    hostName?: string;
+    address?: string;
+  } = {},
+): DuplicateListingInput {
+  return {
+    listingId,
+    platform: 'airbnb',
+    name,
+    coordinates: coordinate(
+      lat,
+      lng,
+      options.eastMeters,
+    ),
+    propertyType: 'Hotel room',
+    details: {
+      host: options.hostName
+        ? { name: options.hostName }
+        : null,
+      address: options.address ?? null,
+    },
+  };
+}
+
+function booking(
+  listingId: string,
+  name: string,
+  lat: number,
+  lng: number,
+  options: {
+    eastMeters?: number;
+    address?: string;
+  } = {},
+): DuplicateListingInput {
+  return {
+    listingId,
+    platform: 'booking',
+    name,
+    coordinates: coordinate(
+      lat,
+      lng,
+      options.eastMeters,
+    ),
+    propertyType: 'Hotel',
+    details: {
+      address: options.address ?? null,
+    },
+  };
+}
+
+test('duplicate name normalization keeps brands and drops lodging boilerplate', () => {
+  assert.equal(
+    normalizeDuplicateName('  Merchant LES Hotel  '),
+    'merchant les',
+  );
+  assert.equal(
+    normalizeDuplicateName('Hôtel Room at NoMo SoHo'),
+    'nomo soho',
+  );
+});
+
+test('real NYC pairs use card or host names despite offset Airbnb coordinates', () => {
+  const listings = [
+    airbnb('merchant-airbnb', 'Merchant LES', 40.71, -74),
+    booking(
+      'merchant-booking',
+      'Merchant LES Hotel',
+      40.71,
+      -74,
+      { eastMeters: 2.4 },
+    ),
+    airbnb(
+      'nomo-airbnb',
+      'Hotel in SoHo',
+      40.72,
+      -74,
+      { hostName: 'NoMo SoHo New York City' },
+    ),
+    booking(
+      'nomo-booking',
+      'NoMo SoHo',
+      40.72,
+      -74,
+      { eastMeters: 81.4 },
+    ),
+    airbnb(
+      'untitled-airbnb',
+      'Room in Downtown Manhattan',
+      40.73,
+      -74,
+      { hostName: 'Untitled' },
+    ),
+    booking(
+      'untitled-booking',
+      'UNTITLED at 3 Freeman Alley',
+      40.73,
+      -74,
+      { eastMeters: 151.1 },
+    ),
+    airbnb('17john-airbnb', '17John Hotel', 40.74, -74),
+    booking(
+      'amtd-booking',
+      'AMTD Idea Tribeca Hotel',
+      40.74,
+      -74,
+      { eastMeters: 36.8 },
+    ),
+    airbnb(
+      'walker-airbnb',
+      'Walker Hotel Tribeca',
+      40.75,
+      -74,
+    ),
+    booking(
+      'walker-booking',
+      'Walker Hotel Tribeca',
+      40.75,
+      -74,
+      { eastMeters: 2 },
+    ),
+  ];
+
+  const pairs = detectReviewJobDuplicatePairs(listings);
+  const byAirbnb = new Map(
+    pairs.map((pair) => [pair.airbnbListingId, pair]),
+  );
+
+  assert.equal(
+    byAirbnb.get('merchant-airbnb')?.confidence,
+    'likely_same',
+  );
+  assert.equal(
+    byAirbnb.get('merchant-airbnb')?.nameSource,
+    'card',
+  );
+  assert.ok(
+    Math.abs(
+      (byAirbnb.get('merchant-airbnb')?.distanceMeters ?? 0)
+      - 2.4,
+    ) < 1,
+  );
+  assert.equal(
+    byAirbnb.get('nomo-airbnb')?.confidence,
+    'likely_same',
+  );
+  assert.equal(
+    byAirbnb.get('nomo-airbnb')?.nameSource,
+    'host',
+  );
+  assert.ok(
+    Math.abs(
+      (byAirbnb.get('nomo-airbnb')?.distanceMeters ?? 0)
+      - 81.4,
+    ) < 1,
+  );
+  assert.equal(
+    byAirbnb.get('untitled-airbnb')?.confidence,
+    'likely_same',
+  );
+  assert.equal(
+    byAirbnb.get('untitled-airbnb')?.nameSource,
+    'host',
+  );
+  assert.ok(
+    Math.abs(
+      (byAirbnb.get('untitled-airbnb')?.distanceMeters ?? 0)
+      - 151.1,
+    ) < 1,
+  );
+  assert.equal(
+    byAirbnb.get('17john-airbnb')?.confidence,
+    'possible_same',
+  );
+  assert.ok(
+    Math.abs(
+      (byAirbnb.get('17john-airbnb')?.distanceMeters ?? 0)
+      - 36.8,
+    ) < 1,
+  );
+  assert.equal(
+    byAirbnb.get('walker-airbnb')?.confidence,
+    'likely_same',
+  );
+});
+
+test('strong names outside the 250 meter envelope are not candidates', () => {
+  const pairs = detectReviewJobDuplicatePairs([
+    airbnb('far-airbnb', 'NoMo SoHo', 40.71, -74),
+    booking(
+      'far-booking',
+      'NoMo SoHo Hotel',
+      40.71,
+      -74,
+      {
+        eastMeters:
+          REVIEW_JOB_DUPLICATE_CANDIDATE_RADIUS_METERS + 2,
+      },
+    ),
+  ]);
+
+  assert.deepEqual(pairs, []);
+});
+
+test('generic locality overlap and private or reseller host names never become likely matches', () => {
+  const pairs = detectReviewJobDuplicatePairs([
+    airbnb(
+      'jeniffer-airbnb',
+      'Private room in SoHo',
+      40.71,
+      -74,
+      { hostName: 'Jeniffer' },
+    ),
+    booking(
+      'soho-booking',
+      'Jeniffer Hotel',
+      40.71,
+      -74,
+      { eastMeters: 5 },
+    ),
+    airbnb(
+      'roompicks-airbnb',
+      'Hotel room in Midtown',
+      40.72,
+      -74,
+      { hostName: 'RoomPicks' },
+    ),
+    booking(
+      'midtown-booking',
+      'RoomPicks Renwick Hotel',
+      40.72,
+      -74,
+      { eastMeters: 6 },
+    ),
+  ]);
+
+  assert.equal(
+    pairs.some((pair) => pair.confidence === 'likely_same'),
+    false,
+  );
+  assert.equal(
+    pairs.some((pair) =>
+      pair.evidence.sharedDistinctiveTokens.includes('jeniffer')),
+    false,
+  );
+  assert.equal(
+    pairs.some((pair) =>
+      pair.evidence.sharedDistinctiveTokens.includes('roompicks')),
+    false,
+  );
+});
+
+test('one-to-many strong-name ambiguity stays possible until a user confirms', () => {
+  const pairs = detectReviewJobDuplicatePairs([
+    airbnb(
+      'brand-airbnb',
+      'Hotel room in Manhattan',
+      40.71,
+      -74,
+      { hostName: 'Example House' },
+    ),
+    booking(
+      'brand-booking-a',
+      'Example House',
+      40.71,
+      -74,
+      { eastMeters: 20 },
+    ),
+    booking(
+      'brand-booking-b',
+      'Example House Annex',
+      40.71,
+      -74,
+      { eastMeters: 30 },
+    ),
+  ]);
+
+  assert.equal(pairs.length, 2);
+  assert.deepEqual(
+    pairs.map((pair) => pair.confidence),
+    ['possible_same', 'possible_same'],
+  );
+  assert.ok(
+    pairs.every((pair) =>
+      pair.evidence.ambiguousStrongName),
+  );
+});
+
+test('generic nearby Chinatown candidates stay possible for user review', () => {
+  const pairs = detectReviewJobDuplicatePairs([
+    airbnb(
+      'chinatown-airbnb',
+      'Hotel room in Chinatown',
+      40.71,
+      -74,
+    ),
+    booking(
+      'pacific-booking',
+      'U.S. Pacific Hotel',
+      40.71,
+      -74,
+      { eastMeters: 26 },
+    ),
+    booking(
+      'citynest-booking',
+      'CityNest New York',
+      40.71,
+      -74,
+      { eastMeters: 51 },
+    ),
+  ]);
+
+  assert.deepEqual(
+    pairs.map((pair) => [
+      pair.bookingListingId,
+      pair.confidence,
+    ]).sort((left, right) =>
+      left[0].localeCompare(right[0])),
+    [
+      ['citynest-booking', 'possible_same'],
+      ['pacific-booking', 'possible_same'],
+    ],
+  );
+});
+
+test('an exact captured street address can promote otherwise unrelated names', () => {
+  const pairs = detectReviewJobDuplicatePairs([
+    airbnb(
+      'address-airbnb',
+      'Room in Lower Manhattan',
+      40.71,
+      -74,
+      { address: '17 John Street, New York, NY 10038' },
+    ),
+    booking(
+      'address-booking',
+      'AMTD Idea Tribeca Hotel',
+      40.71,
+      -74,
+      {
+        eastMeters: 36.8,
+        address: '17 John Street, New York, NY 10038',
+      },
+    ),
+  ]);
+
+  assert.equal(pairs[0]?.confidence, 'likely_same');
+  assert.equal(pairs[0]?.nameSource, 'address');
+  assert.equal(pairs[0]?.evidence.exactAddressMatch, true);
+});
+
+test('detection is stable regardless of listing input order', () => {
+  const listings = [
+    airbnb(
+      'nomo-airbnb',
+      'Hotel in SoHo',
+      40.71,
+      -74,
+      { hostName: 'NoMo SoHo New York City' },
+    ),
+    booking(
+      'nomo-booking',
+      'NoMo SoHo',
+      40.71,
+      -74,
+      { eastMeters: 81.4 },
+    ),
+  ];
+
+  assert.deepEqual(
+    detectReviewJobDuplicatePairs(listings),
+    detectReviewJobDuplicatePairs([...listings].reverse()),
+  );
+});
+
+test('equidistant geo-only ties use listing IDs instead of input order', () => {
+  const listings = [
+    airbnb('airbnb-b', 'Room in Manhattan', 40.71, -74),
+    airbnb('airbnb-a', 'Room in Manhattan', 40.71, -74),
+    booking('booking-b', 'Hotel in Manhattan', 40.71, -74),
+    booking('booking-a', 'Hotel in Manhattan', 40.71, -74),
+  ];
+  const forward = detectReviewJobDuplicatePairs(listings);
+  const reversed = detectReviewJobDuplicatePairs(
+    [...listings].reverse(),
+  );
+
+  assert.deepEqual(forward, reversed);
+  assert.deepEqual(
+    forward.map((pair) => [
+      pair.airbnbListingId,
+      pair.bookingListingId,
+      pair.confidence,
+    ]),
+    [
+      ['airbnb-a', 'booking-a', 'possible_same'],
+      ['airbnb-a', 'booking-b', 'possible_same'],
+      ['airbnb-b', 'booking-a', 'possible_same'],
+      ['airbnb-b', 'booking-b', 'possible_same'],
+    ],
+  );
+});

--- a/tests/review-job-persistence.test.ts
+++ b/tests/review-job-persistence.test.ts
@@ -221,6 +221,85 @@ test('job responses expose the durable quality regrade requirement', () => {
   assert.equal(response.job.reportReady, true);
 });
 
+test('job responses expose duplicate decisions only while both offers are present', () => {
+  const duplicatePair = {
+    id: 'pair_1',
+    jobId: 'job_1',
+    airbnbListingId: 'listing_1',
+    bookingListingId: 'listing_2',
+    detectorVersion: 'cross-platform-property-v1',
+    detectorConfidence: 'likely_same',
+    decision: 'confirmed',
+    decisionSource: 'user',
+    distanceMeters: 81.4,
+    nameScore: 1,
+    nameSource: 'host',
+    evidence: {
+      airbnbHostName: 'NoMo SoHo New York City',
+    },
+    createdAt: new Date('2026-07-26T20:00:00.000Z'),
+    updatedAt: new Date('2026-07-26T20:01:00.000Z'),
+  } as any;
+  const response = toReviewJobResponse({
+    job: makeJob(),
+    listings: [
+      makeListing(),
+      makeListing({
+        id: 'row_2',
+        listingId: 'listing_2',
+        platform: 'booking',
+      }),
+    ],
+    duplicatePairs: [
+      duplicatePair,
+      {
+        ...duplicatePair,
+        id: 'pair_missing',
+        bookingListingId: 'not-in-results',
+      },
+    ],
+    events: [],
+  });
+
+  assert.equal(response.duplicatePairs.length, 1);
+  assert.deepEqual(response.duplicatePairs[0], {
+    id: 'pair_1',
+    airbnbListingId: 'listing_1',
+    bookingListingId: 'listing_2',
+    detectorVersion: 'cross-platform-property-v1',
+    detectorConfidence: 'likely_same',
+    decision: 'confirmed',
+    decisionSource: 'user',
+    distanceMeters: 81.4,
+    nameScore: 1,
+    nameSource: 'host',
+    evidence: {
+      airbnbHostName: 'NoMo SoHo New York City',
+    },
+    createdAt: '2026-07-26T20:00:00.000Z',
+    updatedAt: '2026-07-26T20:01:00.000Z',
+  });
+
+  const publicResponse = toReviewJobResponse({
+    job: makeJob(),
+    listings: [
+      makeListing(),
+      makeListing({
+        id: 'row_2',
+        listingId: 'listing_2',
+        platform: 'booking',
+      }),
+    ],
+    duplicatePairs: [{
+      ...duplicatePair,
+      decision: 'dismissed',
+    }],
+    events: [],
+    viewerCanEdit: false,
+  });
+  assert.deepEqual(publicResponse.duplicatePairs, []);
+});
+
 test('job responses preserve exact AI sample provenance from the batch manifest', () => {
   const artifactRoot = fs.mkdtempSync(
     path.join(os.tmpdir(), 'review-job-review-sample-'),

--- a/web/README.md
+++ b/web/README.md
@@ -161,6 +161,27 @@ AI-analyzed sample, post-filter eligible count, whether the configured sample ca
 total scraped reviews. If the artifact run has expired, the page reports unknown provenance
 instead of inferring it from Postgres or provider totals.
 
+## Cross-platform same-property checks
+
+Review jobs run a deterministic, versioned Airbnb-to-Booking candidate detector. It considers
+cross-platform pairs within 250 meters, but coordinates are only a weak prior because Airbnb hotel
+coordinates are intentionally offset. A `likely same` suggestion requires strong distinctive name
+evidence from either the Airbnb card name or its captured host name, or an exact captured address.
+Generous `possible same` suggestions may use weaker evidence, but they have no ranking effect until
+the owner confirms them.
+
+The pair record and its detector evidence persist independently from either listing. Owners can
+confirm, dismiss, undo, or manually link a missed pair; rerunning search or enriching listing
+details updates detector evidence without overwriting user decisions. Public results expose active
+links read-only and omit dismissed suggestions.
+
+The two offers, prices, availability states, public review totals, analyzed samples, and underlying
+analysis remain separate. StayReviewr does not merge reviews or copy one platform's verdict to the
+other. When a likely or confirmed pair has a tier gap of at least two levels, both offers leave the
+top-picks hero and comparable peer ranks. Possible suggestions never trigger that gate. The
+priorities-matrix rows remain visible with all paid evidence, but move into a labeled
+`Cross-platform conflict` audit group outside comparable peers.
+
 `web/.env.local` remains supported as a compatibility fallback for direct `web/` commands, but
 the root `.env` takes precedence. Proxy settings also fall back to
 `~/.config/reviewr/.env` created by `reviewr auth`.

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -29,6 +29,22 @@ enum PhaseStatus {
   partial
 }
 
+enum DuplicatePairConfidence {
+  likely_same
+  possible_same
+}
+
+enum DuplicatePairDecision {
+  suggested
+  confirmed
+  dismissed
+}
+
+enum DuplicatePairDecisionSource {
+  detector
+  user
+}
+
 enum SearchAreaMode {
   window
   rectangle
@@ -148,6 +164,7 @@ model ReviewJob {
   totalAiCostUsd   Float         @default(0)
   listings       ReviewJobListing[]
   events         ReviewJobEvent[]
+  duplicatePairs ReviewJobDuplicatePair[]
 
   @@index([ownerKey, createdAt])
 }
@@ -222,6 +239,27 @@ model ReviewJobListingAnalysis {
   durationMs      Int?
 
   @@index([status, updatedAt])
+}
+
+model ReviewJobDuplicatePair {
+  id                 String                      @id @default(cuid())
+  jobId              String
+  job                ReviewJob                   @relation(fields: [jobId], references: [id], onDelete: Cascade)
+  airbnbListingId    String
+  bookingListingId   String
+  detectorVersion    String
+  detectorConfidence DuplicatePairConfidence?
+  decision           DuplicatePairDecision       @default(suggested)
+  decisionSource     DuplicatePairDecisionSource @default(detector)
+  distanceMeters     Float?
+  nameScore          Float?
+  nameSource         String?
+  evidence           Json?
+  createdAt          DateTime                    @default(now())
+  updatedAt          DateTime                    @updatedAt
+
+  @@unique([jobId, airbnbListingId, bookingListingId])
+  @@index([jobId, decision])
 }
 
 model ReviewJobEvent {

--- a/web/src/app/api/jobs/[jobId]/duplicates/route.ts
+++ b/web/src/app/api/jobs/[jobId]/duplicates/route.ts
@@ -1,0 +1,232 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getReviewJobOwnerKey } from '@/lib/reviewJobOwner';
+import {
+  buildOwnedReviewJobQuery,
+  toReviewJobResponseRecordForViewer,
+} from '@/lib/reviewJobs';
+import {
+  duplicateDistanceMeters,
+  REVIEW_JOB_DUPLICATE_DETECTOR_VERSION,
+} from '@/lib/reviewJobDuplicates';
+import type { ReviewJobResponse } from '@/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface Params {
+  params: Promise<{ jobId: string }>;
+}
+
+type DuplicateDecision = 'suggested' | 'confirmed' | 'dismissed';
+
+function isDecision(value: unknown): value is DuplicateDecision {
+  return (
+    value === 'suggested'
+    || value === 'confirmed'
+    || value === 'dismissed'
+  );
+}
+
+export async function PATCH(request: Request, { params }: Params) {
+  const { jobId } = await params;
+  const ownerKey = await getReviewJobOwnerKey();
+  if (!ownerKey) {
+    return NextResponse.json(
+      { error: 'Review job not found' },
+      { status: 404 },
+    );
+  }
+
+  let body: {
+    airbnbListingId?: unknown;
+    bookingListingId?: unknown;
+    decision?: unknown;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: 'Invalid JSON body' },
+      { status: 400 },
+    );
+  }
+
+  if (
+    typeof body.airbnbListingId !== 'string'
+    || !body.airbnbListingId.trim()
+    || typeof body.bookingListingId !== 'string'
+    || !body.bookingListingId.trim()
+    || !isDecision(body.decision)
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          'airbnbListingId, bookingListingId, and a valid decision are required',
+      },
+      { status: 400 },
+    );
+  }
+
+  const airbnbListingId = body.airbnbListingId.trim();
+  const bookingListingId = body.bookingListingId.trim();
+  const decision = body.decision;
+  const ownedJob = await prisma.reviewJob.findFirst({
+    where: { id: jobId, ownerKey },
+    select: { id: true },
+  });
+  if (!ownedJob) {
+    return NextResponse.json(
+      { error: 'Review job not found' },
+      { status: 404 },
+    );
+  }
+
+  const listings = await prisma.reviewJobListing.findMany({
+    where: {
+      jobId,
+      OR: [
+        {
+          platform: 'airbnb',
+          listingId: airbnbListingId,
+        },
+        {
+          platform: 'booking',
+          listingId: bookingListingId,
+        },
+      ],
+    },
+    select: {
+      platform: true,
+      listingId: true,
+      lat: true,
+      lng: true,
+    },
+  });
+  const airbnb = listings.find(
+    (listing) =>
+      listing.platform === 'airbnb'
+      && listing.listingId === airbnbListingId,
+  );
+  const booking = listings.find(
+    (listing) =>
+      listing.platform === 'booking'
+      && listing.listingId === bookingListingId,
+  );
+  if (!airbnb || !booking) {
+    return NextResponse.json(
+      { error: 'Both listings must belong to this review job' },
+      { status: 400 },
+    );
+  }
+
+  const job = await prisma.$transaction(async (tx) => {
+    const pairWhere = {
+      jobId_airbnbListingId_bookingListingId: {
+        jobId,
+        airbnbListingId,
+        bookingListingId,
+      },
+    };
+    const existing = await tx.reviewJobDuplicatePair.findUnique({
+      where: pairWhere,
+    });
+
+    if (decision === 'suggested') {
+      if (!existing) {
+        throw new Error('DUPLICATE_PAIR_NOT_FOUND');
+      }
+      if (existing.detectorConfidence == null) {
+        await tx.reviewJobDuplicatePair.delete({
+          where: pairWhere,
+        });
+      } else {
+        await tx.reviewJobDuplicatePair.update({
+          where: pairWhere,
+          data: {
+            decision: 'suggested',
+            decisionSource: 'detector',
+          },
+        });
+      }
+    } else if (existing) {
+      await tx.reviewJobDuplicatePair.update({
+        where: pairWhere,
+        data: {
+          decision,
+          decisionSource: 'user',
+        },
+      });
+    } else if (decision === 'confirmed') {
+      const distanceMeters =
+        airbnb.lat != null
+        && airbnb.lng != null
+        && booking.lat != null
+        && booking.lng != null
+          ? duplicateDistanceMeters(
+              { lat: airbnb.lat, lng: airbnb.lng },
+              { lat: booking.lat, lng: booking.lng },
+            )
+          : null;
+      await tx.reviewJobDuplicatePair.create({
+        data: {
+          jobId,
+          airbnbListingId,
+          bookingListingId,
+          detectorVersion: REVIEW_JOB_DUPLICATE_DETECTOR_VERSION,
+          detectorConfidence: null,
+          decision: 'confirmed',
+          decisionSource: 'user',
+          distanceMeters,
+          evidence: {
+            manual: true,
+          },
+        },
+      });
+    } else {
+      throw new Error('DUPLICATE_PAIR_NOT_FOUND');
+    }
+
+    await tx.reviewJobEvent.create({
+      data: {
+        jobId,
+        phase: 'duplicates',
+        level: 'info',
+        message:
+          decision === 'confirmed'
+            ? 'Cross-platform listing link confirmed'
+            : decision === 'dismissed'
+              ? 'Cross-platform listing suggestion dismissed'
+              : 'Cross-platform listing decision undone',
+        payload: {
+          airbnbListingId,
+          bookingListingId,
+          decision,
+        },
+      },
+    });
+
+    return tx.reviewJob.findFirstOrThrow(
+      buildOwnedReviewJobQuery(jobId, ownerKey),
+    );
+  }).catch((error: unknown) => {
+    if (
+      error instanceof Error
+      && error.message === 'DUPLICATE_PAIR_NOT_FOUND'
+    ) {
+      return null;
+    }
+    throw error;
+  });
+
+  if (!job) {
+    return NextResponse.json(
+      { error: 'Duplicate pair not found' },
+      { status: 404 },
+    );
+  }
+
+  const response: ReviewJobResponse =
+    toReviewJobResponseRecordForViewer(job, ownerKey);
+  return NextResponse.json(response);
+}

--- a/web/src/components/DuplicatePairsPanel.test.tsx
+++ b/web/src/components/DuplicatePairsPanel.test.tsx
@@ -1,0 +1,269 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type {
+  ReviewJobDuplicatePair,
+  ReviewJobListing,
+} from '@/types';
+import {
+  getMaterialDuplicateConflictKeys,
+} from '@/lib/reviewJobDuplicatePresentation';
+import DuplicatePairsPanel from './DuplicatePairsPanel.js';
+
+function listing(
+  id: string,
+  platform: 'airbnb' | 'booking',
+  name: string,
+  tier: string,
+  reviewCount: number,
+  analyzedCount: number,
+  scrapedCount: number,
+): ReviewJobListing {
+  return {
+    id,
+    platform,
+    name,
+    url: `https://example.com/${id}`,
+    rating: platform === 'airbnb' ? 4.8 : 8.9,
+    reviewCount,
+    pricing: {
+      nightly: {
+        amount: platform === 'airbnb' ? 210 : 235,
+        currency: 'USD',
+        source: 'upstream',
+      },
+      total: {
+        amount: platform === 'airbnb' ? 1470 : 1645,
+        currency: 'USD',
+        source: 'upstream',
+      },
+      display: null,
+    },
+    coordinates: { lat: 40.72, lng: -74 },
+    propertyType: 'Hotel room',
+    photoUrl: null,
+    selected: true,
+    liked: false,
+    hidden: false,
+    poiDistanceMeters: 500,
+    staySnapshot: {
+      availability: {
+        status: 'yes',
+        capturedAt: '2026-07-26T20:00:00.000Z',
+        reasonCode: 'provider_room_inventory',
+      },
+      freshness: {
+        price: 'fresh',
+        availability: 'fresh',
+      },
+      bookingEligibility: {
+        status: 'eligible',
+        actionable: true,
+        reasonCode: 'available',
+        reason: 'Available for the recorded dates and guest count.',
+      },
+    },
+    affordability: {
+      status: 'within',
+      reasonCode: 'within_budget',
+      reason: 'Within budget.',
+      budgetAmount: 2000,
+      priceAmount: 1470,
+      currency: 'USD',
+      overByAmount: null,
+      overByPercent: null,
+    },
+    analysis: {
+      id: `${id}-analysis`,
+      status: 'completed',
+      currentPhase: 'completed',
+      errorMessage: null,
+      detailsStatus: 'completed',
+      reviewsStatus: 'completed',
+      photosStatus: 'completed',
+      aiReviewsStatus: 'completed',
+      aiPhotosStatus: 'completed',
+      triageStatus: 'completed',
+      details: null,
+      aiReviews: null,
+      aiPhotos: null,
+      triage: {
+        tier,
+        fitScore: tier === 'top_pick' ? 91 : 42,
+      },
+      reviewCount: scrapedCount,
+      reviewSample: {
+        totalScrapedReviewCount: scrapedCount,
+        eligibleReviewCount: scrapedCount,
+        analyzedReviewCount: analyzedCount,
+        capped: analyzedCount < scrapedCount,
+        source: 'batch_manifest',
+      },
+      photoCount: 0,
+      costs: {
+        aiReviewsUsd: 0,
+        aiPhotosUsd: 0,
+        triageUsd: 0,
+        totalUsd: 0,
+      },
+      durationMs: 100,
+      startedAt: '2026-07-26T20:00:00.000Z',
+      completedAt: '2026-07-26T20:00:01.000Z',
+      createdAt: '2026-07-26T20:00:00.000Z',
+      updatedAt: '2026-07-26T20:00:01.000Z',
+    },
+  } as unknown as ReviewJobListing;
+}
+
+function pair(
+  confidence: 'likely_same' | 'possible_same',
+): ReviewJobDuplicatePair {
+  return {
+    id: `pair-${confidence}`,
+    airbnbListingId: 'nomo-airbnb',
+    bookingListingId: 'nomo-booking',
+    detectorVersion: 'cross-platform-property-v1',
+    detectorConfidence: confidence,
+    decision: 'suggested',
+    decisionSource: 'detector',
+    distanceMeters: 81.4,
+    nameScore: 1,
+    nameSource: 'host',
+    evidence: {
+      airbnbHostName: 'NoMo SoHo New York City',
+    },
+    createdAt: '2026-07-26T20:00:00.000Z',
+    updatedAt: '2026-07-26T20:00:00.000Z',
+  };
+}
+
+const listings = [
+  listing(
+    'nomo-airbnb',
+    'airbnb',
+    'Hotel in SoHo',
+    'top_pick',
+    24,
+    20,
+    24,
+  ),
+  listing(
+    'nomo-booking',
+    'booking',
+    'NoMo SoHo',
+    'no_go',
+    2110,
+    250,
+    1924,
+  ),
+];
+
+test('duplicate panel surfaces separate evidence and gates a likely material conflict', () => {
+  const html = renderToStaticMarkup(
+    <DuplicatePairsPanel
+      pairs={[pair('likely_same')]}
+      listings={listings}
+      job={{ checkin: '2026-09-01', checkout: '2026-09-08' }}
+      priceDisplay="total"
+      viewerCanEdit
+      onDecision={async () => undefined}
+    />,
+  );
+
+  assert.match(html, /Likely same property/);
+  assert.match(html, /Airbnb host name matched · 81\.4 m apart/);
+  assert.match(html, /Captured Airbnb host: NoMo SoHo New York City/);
+  assert.match(html, /Material verdict conflict/);
+  assert.match(html, /Verdict: top pick/);
+  assert.match(html, /Verdict: no go/);
+  assert.match(html, /24 public reviews/);
+  assert.match(html, /20 analysed · 24 scraped/);
+  assert.match(html, /2,110 public reviews/);
+  assert.match(html, /250 analysed · 1,924 scraped/);
+  assert.match(html, /Confirm same property/);
+  assert.match(html, /Not the same/);
+  assert.match(html, /Link a missed pair/);
+});
+
+test('possible suggestions are explicitly inert and public views are read-only', () => {
+  assert.deepEqual(
+    [...getMaterialDuplicateConflictKeys(
+      [pair('possible_same')],
+      listings,
+    )],
+    [],
+  );
+  const html = renderToStaticMarkup(
+    <DuplicatePairsPanel
+      pairs={[pair('possible_same')]}
+      listings={listings}
+      job={{ checkin: null, checkout: null }}
+      priceDisplay="perNight"
+      viewerCanEdit={false}
+    />,
+  );
+
+  assert.match(html, /Possible same property/);
+  assert.match(html, /Suggestion only — no ranking impact unless confirmed/);
+  assert.doesNotMatch(html, /Material verdict conflict/);
+  assert.match(html, /Read-only/);
+  assert.doesNotMatch(html, /Confirm same property/);
+  assert.doesNotMatch(html, /Link a missed pair/);
+});
+
+test('likely pairs with a two-tier verdict gap leave peer ranking', () => {
+  assert.deepEqual(
+    [...getMaterialDuplicateConflictKeys(
+      [pair('likely_same')],
+      listings,
+    )].sort(),
+    ['airbnb:nomo-airbnb', 'booking:nomo-booking'],
+  );
+});
+
+test('confirming a possible pair activates the conflict gate', () => {
+  const confirmed = {
+    ...pair('possible_same'),
+    decision: 'confirmed' as const,
+    decisionSource: 'user' as const,
+  };
+  assert.deepEqual(
+    [...getMaterialDuplicateConflictKeys(
+      [confirmed],
+      listings,
+    )].sort(),
+    ['airbnb:nomo-airbnb', 'booking:nomo-booking'],
+  );
+});
+
+test('owners can undo a dismissed suggestion while public viewers cannot see it', () => {
+  const dismissed = {
+    ...pair('possible_same'),
+    decision: 'dismissed' as const,
+    decisionSource: 'user' as const,
+  };
+  const ownerHtml = renderToStaticMarkup(
+    <DuplicatePairsPanel
+      pairs={[dismissed]}
+      listings={listings}
+      job={{ checkin: null, checkout: null }}
+      priceDisplay="total"
+      viewerCanEdit
+      onDecision={async () => undefined}
+    />,
+  );
+  const publicHtml = renderToStaticMarkup(
+    <DuplicatePairsPanel
+      pairs={[dismissed]}
+      listings={listings}
+      job={{ checkin: null, checkout: null }}
+      priceDisplay="total"
+      viewerCanEdit={false}
+    />,
+  );
+
+  assert.match(ownerHtml, /Dismissed suggestion/);
+  assert.match(ownerHtml, /Undo dismissal/);
+  assert.doesNotMatch(publicHtml, /Dismissed suggestion/);
+});

--- a/web/src/components/DuplicatePairsPanel.tsx
+++ b/web/src/components/DuplicatePairsPanel.tsx
@@ -1,0 +1,433 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import type {
+  PriceDisplayMode,
+  ReviewJobDuplicatePair,
+  ReviewJobListing,
+  ReviewJobResponse,
+} from '@/types';
+import { getPriceDisplayInfo } from '@/lib/pricing';
+import { getListingResultsSnapshot } from '@/lib/results';
+import {
+  isActiveDuplicatePair,
+  isMaterialDuplicateConflict,
+} from '@/lib/reviewJobDuplicatePresentation';
+import PlatformBadge from './PlatformBadge';
+
+type PairDecision = 'suggested' | 'confirmed' | 'dismissed';
+
+function listingKey(listing: ReviewJobListing): string {
+  return `${listing.platform}:${listing.id}`;
+}
+
+function tierLabel(listing: ReviewJobListing): string {
+  const tier = getListingResultsSnapshot(listing).triage?.tier;
+  return tier?.replace(/_/g, ' ') ?? 'unscored';
+}
+
+function reviewSampleLabel(listing: ReviewJobListing): string {
+  const sample = listing.analysis?.reviewSample;
+  const analyzed =
+    sample?.analyzedReviewCount == null
+      ? 'analysed sample unknown'
+      : `${sample.analyzedReviewCount.toLocaleString('en-US')} analysed`;
+  const scraped =
+    sample?.totalScrapedReviewCount == null
+      ? 'scraped total unknown'
+      : `${sample.totalScrapedReviewCount.toLocaleString('en-US')} scraped`;
+  return `${analyzed} · ${scraped}`;
+}
+
+function confidenceLabel(pair: ReviewJobDuplicatePair): string {
+  if (pair.decision === 'confirmed') return 'Confirmed same property';
+  if (pair.decision === 'dismissed') return 'Dismissed suggestion';
+  if (pair.detectorConfidence === 'likely_same') {
+    return 'Likely same property';
+  }
+  return 'Possible same property';
+}
+
+function evidenceLabel(pair: ReviewJobDuplicatePair): string {
+  const distance =
+    pair.distanceMeters == null
+      ? 'distance unknown'
+      : `${pair.distanceMeters.toFixed(1)} m apart`;
+  if (pair.nameSource === 'host') {
+    return `Airbnb host name matched · ${distance}`;
+  }
+  if (pair.nameSource === 'address') {
+    return `Exact captured address matched · ${distance}`;
+  }
+  if (pair.nameSource === 'card') {
+    return `Listing names matched · ${distance}`;
+  }
+  return `Nearby cross-platform candidate · ${distance}`;
+}
+
+function ListingEvidenceCard({
+  listing,
+  job,
+  priceDisplay,
+  onSelect,
+}: {
+  listing: ReviewJobListing;
+  job: Pick<ReviewJobResponse['job'], 'checkin' | 'checkout'>;
+  priceDisplay: PriceDisplayMode;
+  onSelect?: (key: string) => void;
+}) {
+  const price = getPriceDisplayInfo(listing, priceDisplay, {
+    checkin: job.checkin,
+    checkout: job.checkout,
+  });
+  const triage = getListingResultsSnapshot(listing).triage;
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect?.(listingKey(listing))}
+      className="min-w-0 rounded-2xl border border-white/10 bg-black/20 p-4 text-left transition hover:border-white/20 hover:bg-white/[0.04]"
+    >
+      <PlatformBadge platform={listing.platform} />
+      <span className="mt-2 block text-sm font-semibold text-white">
+        {listing.name}
+      </span>
+      <span className="mt-2 block text-xs capitalize text-stone-300">
+        Verdict: {tierLabel(listing)} ·{' '}
+        {(triage?.rankingStatus ?? 'unscored').replace(/_/g, ' ')}
+      </span>
+      <span className="mt-1 block text-xs text-stone-400">
+        {price.primary}
+        {price.secondary ? ` · ${price.secondary}` : ''}
+      </span>
+      <span className="mt-1 block text-xs text-stone-400">
+        {listing.staySnapshot.bookingEligibility.reason
+          ?? 'Exact-stay availability unknown'}
+      </span>
+      <span className="mt-1 block text-xs capitalize text-stone-400">
+        Affordability: {listing.affordability.status}
+      </span>
+      <span className="mt-2 block text-[11px] text-stone-500">
+        {listing.reviewCount.toLocaleString('en-US')} public reviews
+      </span>
+      <span className="mt-1 block text-[11px] text-stone-500">
+        {reviewSampleLabel(listing)}
+      </span>
+    </button>
+  );
+}
+
+export default function DuplicatePairsPanel({
+  pairs,
+  listings,
+  job,
+  priceDisplay,
+  viewerCanEdit,
+  onDecision,
+  onSelectListing,
+}: {
+  pairs: ReviewJobDuplicatePair[];
+  listings: ReviewJobListing[];
+  job: Pick<ReviewJobResponse['job'], 'checkin' | 'checkout'>;
+  priceDisplay: PriceDisplayMode;
+  viewerCanEdit: boolean;
+  onDecision?: (
+    pair: Pick<
+      ReviewJobDuplicatePair,
+      'airbnbListingId' | 'bookingListingId'
+    >,
+    decision: PairDecision,
+  ) => Promise<void>;
+  onSelectListing?: (key: string) => void;
+}) {
+  const [manualAirbnbId, setManualAirbnbId] = useState('');
+  const [manualBookingId, setManualBookingId] = useState('');
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const listingsByKey = useMemo(
+    () => new Map(
+      listings.map((listing) => [listingKey(listing), listing]),
+    ),
+    [listings],
+  );
+  const visiblePairs = useMemo(
+    () => pairs
+      .filter((pair) =>
+        viewerCanEdit || pair.decision !== 'dismissed')
+      .sort((left, right) =>
+        Number(isActiveDuplicatePair(right))
+        - Number(isActiveDuplicatePair(left))
+        || left.createdAt.localeCompare(right.createdAt)),
+    [pairs, viewerCanEdit],
+  );
+  const airbnbListings = listings.filter(
+    (listing) => listing.platform === 'airbnb',
+  );
+  const bookingListings = listings.filter(
+    (listing) => listing.platform === 'booking',
+  );
+
+  async function decide(
+    pair: Pick<
+      ReviewJobDuplicatePair,
+      'airbnbListingId' | 'bookingListingId'
+    >,
+    decision: PairDecision,
+  ) {
+    if (!onDecision) return;
+    const key =
+      `${pair.airbnbListingId}:${pair.bookingListingId}:${decision}`;
+    setPendingKey(key);
+    setMessage(null);
+    try {
+      await onDecision(pair, decision);
+      setMessage(
+        decision === 'confirmed'
+          ? 'Cross-platform link confirmed.'
+          : decision === 'dismissed'
+            ? 'Suggestion dismissed.'
+            : 'Decision undone.',
+      );
+      if (decision === 'confirmed') {
+        setManualAirbnbId('');
+        setManualBookingId('');
+      }
+    } catch (error) {
+      setMessage(
+        error instanceof Error
+          ? error.message
+          : 'Failed to update cross-platform link.',
+      );
+    } finally {
+      setPendingKey(null);
+    }
+  }
+
+  if (
+    visiblePairs.length === 0
+    && (!viewerCanEdit || airbnbListings.length === 0 || bookingListings.length === 0)
+  ) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-[28px] border border-sky-300/15 bg-sky-300/[0.045] p-5 shadow-[0_24px_70px_rgba(0,0,0,0.28)]">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sky-200/70">
+            Cross-platform identity
+          </p>
+          <h2 className="mt-2 text-lg font-semibold text-white">
+            Same-property checks
+          </h2>
+          <p className="mt-2 max-w-4xl text-xs leading-5 text-stone-400">
+            Each offer and its evidence stay separate. Confirmed or likely
+            pairs with materially different verdicts are withheld from peer
+            ranking until you review both; possible suggestions never affect
+            ranking.
+          </p>
+        </div>
+        {!viewerCanEdit && (
+          <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-xs text-stone-400">
+            Read-only
+          </span>
+        )}
+      </div>
+
+      {visiblePairs.length > 0 && (
+        <div className="mt-5 space-y-4">
+          {visiblePairs.map((pair) => {
+            const airbnb = listingsByKey.get(
+              `airbnb:${pair.airbnbListingId}`,
+            );
+            const booking = listingsByKey.get(
+              `booking:${pair.bookingListingId}`,
+            );
+            if (!airbnb || !booking) return null;
+            const materialConflict = isMaterialDuplicateConflict(
+              pair,
+              listingsByKey,
+            );
+            const hostName =
+              typeof pair.evidence?.airbnbHostName === 'string'
+                ? pair.evidence.airbnbHostName
+                : null;
+            return (
+              <article
+                key={pair.id}
+                className="rounded-2xl border border-white/10 bg-black/20 p-4"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className={`rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.12em] ${
+                    pair.decision === 'confirmed'
+                      ? 'border-emerald-300/20 bg-emerald-300/10 text-emerald-100'
+                      : pair.decision === 'dismissed'
+                        ? 'border-white/10 bg-white/[0.04] text-stone-400'
+                      : pair.detectorConfidence === 'likely_same'
+                        ? 'border-sky-300/20 bg-sky-300/10 text-sky-100'
+                        : 'border-amber-300/20 bg-amber-300/10 text-amber-100'
+                  }`}>
+                    {confidenceLabel(pair)}
+                  </span>
+                  <span className="text-[11px] text-stone-500">
+                    {evidenceLabel(pair)}
+                  </span>
+                </div>
+                {hostName && pair.nameSource === 'host' && (
+                  <p className="mt-2 text-[11px] text-stone-400">
+                    Captured Airbnb host: {hostName}
+                  </p>
+                )}
+                {materialConflict && (
+                  <p className="mt-3 rounded-xl border border-rose-300/20 bg-rose-300/[0.08] px-3 py-2 text-xs font-semibold text-rose-100">
+                    Material verdict conflict — inspect both evidence sets.
+                    Neither offer is included in peer ranks or the top-picks
+                    hero while this link is active.
+                  </p>
+                )}
+                {pair.decision === 'dismissed' ? (
+                  <p className="mt-3 rounded-xl border border-white/10 bg-white/[0.035] px-3 py-2 text-xs text-stone-400">
+                    Dismissed — no ranking impact.
+                  </p>
+                ) : !isActiveDuplicatePair(pair) && (
+                  <p className="mt-3 rounded-xl border border-amber-300/15 bg-amber-300/[0.06] px-3 py-2 text-xs text-amber-100/80">
+                    Suggestion only — no ranking impact unless confirmed.
+                  </p>
+                )}
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <ListingEvidenceCard
+                    listing={airbnb}
+                    job={job}
+                    priceDisplay={priceDisplay}
+                    onSelect={onSelectListing}
+                  />
+                  <ListingEvidenceCard
+                    listing={booking}
+                    job={job}
+                    priceDisplay={priceDisplay}
+                    onSelect={onSelectListing}
+                  />
+                </div>
+                {viewerCanEdit && onDecision && (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {pair.decision === 'dismissed' ? (
+                      <button
+                        type="button"
+                        disabled={pendingKey != null}
+                        onClick={() => void decide(pair, 'suggested')}
+                        className="rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-stone-300 disabled:opacity-50"
+                      >
+                        Undo dismissal
+                      </button>
+                    ) : pair.decision === 'confirmed' ? (
+                      <>
+                        <button
+                          type="button"
+                          disabled={pendingKey != null}
+                          onClick={() => void decide(pair, 'suggested')}
+                          className="rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-stone-300 disabled:opacity-50"
+                        >
+                          Undo confirmation
+                        </button>
+                        <button
+                          type="button"
+                          disabled={pendingKey != null}
+                          onClick={() => void decide(pair, 'dismissed')}
+                          className="rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-stone-300 disabled:opacity-50"
+                        >
+                          Not the same
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          type="button"
+                          disabled={pendingKey != null}
+                          onClick={() => void decide(pair, 'confirmed')}
+                          className="rounded-xl border border-emerald-300/20 bg-emerald-300/10 px-3 py-2 text-xs font-semibold text-emerald-100 disabled:opacity-50"
+                        >
+                          Confirm same property
+                        </button>
+                        <button
+                          type="button"
+                          disabled={pendingKey != null}
+                          onClick={() => void decide(pair, 'dismissed')}
+                          className="rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-stone-300 disabled:opacity-50"
+                        >
+                          Not the same
+                        </button>
+                      </>
+                    )}
+                  </div>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      )}
+
+      {viewerCanEdit
+        && onDecision
+        && airbnbListings.length > 0
+        && bookingListings.length > 0 && (
+          <div className="mt-5 rounded-2xl border border-white/10 bg-black/15 p-4">
+            <p className="text-xs font-semibold text-white">
+              Link a missed pair
+            </p>
+            <div className="mt-3 grid gap-2 md:grid-cols-[1fr_1fr_auto]">
+              <select
+                aria-label="Airbnb listing"
+                value={manualAirbnbId}
+                onChange={(event) =>
+                  setManualAirbnbId(event.target.value)}
+                className="rounded-xl border border-white/10 bg-[#171311] px-3 py-2 text-xs text-stone-200"
+              >
+                <option value="">Choose Airbnb listing</option>
+                {airbnbListings.map((listing) => (
+                  <option key={listing.id} value={listing.id}>
+                    {listing.name}
+                  </option>
+                ))}
+              </select>
+              <select
+                aria-label="Booking listing"
+                value={manualBookingId}
+                onChange={(event) =>
+                  setManualBookingId(event.target.value)}
+                className="rounded-xl border border-white/10 bg-[#171311] px-3 py-2 text-xs text-stone-200"
+              >
+                <option value="">Choose Booking listing</option>
+                {bookingListings.map((listing) => (
+                  <option key={listing.id} value={listing.id}>
+                    {listing.name}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                disabled={
+                  !manualAirbnbId
+                  || !manualBookingId
+                  || pendingKey != null
+                }
+                onClick={() => void decide(
+                  {
+                    airbnbListingId: manualAirbnbId,
+                    bookingListingId: manualBookingId,
+                  },
+                  'confirmed',
+                )}
+                className="rounded-xl border border-sky-300/20 bg-sky-300/10 px-4 py-2 text-xs font-semibold text-sky-100 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Link listings
+              </button>
+            </div>
+          </div>
+        )}
+      {message && (
+        <p className="mt-3 text-xs font-semibold text-stone-300">
+          {message}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/web/src/components/PrioritiesMatrix.test.tsx
+++ b/web/src/components/PrioritiesMatrix.test.tsx
@@ -187,3 +187,25 @@ test('priorities matrix preserves paid evidence after a quality brief edit', () 
   assert.match(html, /Regrade whole job/);
   assert.match(html, /Estimated triage cost: \$0\.012/);
 });
+
+test('duplicate conflicts keep their evidence in a separate unranked group', () => {
+  const html = renderToStaticMarkup(
+    <PrioritiesMatrix
+      listings={[listing('sleep-test')]}
+      duplicateConflictKeys={
+        new Set(['booking:sleep-test'])
+      }
+    />,
+  );
+
+  assert.match(
+    html,
+    /Cross-platform conflict — linked offers visible for audit, outside peer ranking/,
+  );
+  assert.match(html, /Cross-platform conflict/);
+  assert.match(
+    html,
+    /Guests repeatedly report loud HVAC cycling/,
+  );
+  assert.match(html, /42 of 250 AI-analyzed reviews/);
+});

--- a/web/src/components/PrioritiesMatrix.tsx
+++ b/web/src/components/PrioritiesMatrix.tsx
@@ -23,6 +23,8 @@ type SortState = {
   key: string | null;
   direction: PrioritiesMatrixSortDirection;
 };
+const EMPTY_DUPLICATE_CONFLICT_KEYS: ReadonlySet<string> =
+  new Set();
 
 function statusClassName(status: string): string {
   switch (status) {
@@ -279,6 +281,7 @@ function HeaderButton({
 
 export default function PrioritiesMatrix({
   listings,
+  duplicateConflictKeys = EMPTY_DUPLICATE_CONFLICT_KEYS,
   onSelectListing,
   regradeReasons = [],
   regradeLocked = false,
@@ -288,6 +291,7 @@ export default function PrioritiesMatrix({
   onRegrade,
 }: {
   listings: ReviewJobListing[];
+  duplicateConflictKeys?: ReadonlySet<string>;
   onSelectListing?: (listingKey: string) => void;
   regradeReasons?: TriageRegradeReason[];
   regradeLocked?: boolean;
@@ -309,10 +313,34 @@ export default function PrioritiesMatrix({
     () => buildReviewJobPrioritiesMatrix(listings),
     [listings],
   );
-  const rows = useMemo(
+  const sortedRows = useMemo(
     () => sortPrioritiesMatrixRows(matrix.rows, sort.key, sort.direction),
     [matrix.rows, sort],
   );
+  const rows = useMemo(() => {
+    const comparable: PrioritiesMatrixRow[] = [];
+    const conflicts: PrioritiesMatrixRow[] = [];
+    const other: PrioritiesMatrixRow[] = [];
+    for (const row of sortedRows) {
+      const key = `${row.platform}:${row.id}`;
+      if (duplicateConflictKeys.has(key)) {
+        conflicts.push(row);
+      } else if (
+        getPrioritiesMatrixRankingGroup(row.rankingStatus) === 0
+      ) {
+        comparable.push(row);
+      } else {
+        other.push(row);
+      }
+    }
+    return [...comparable, ...conflicts, ...other];
+  }, [duplicateConflictKeys, sortedRows]);
+
+  function rowGroupKey(row: PrioritiesMatrixRow): string {
+    return duplicateConflictKeys.has(`${row.platform}:${row.id}`)
+      ? 'duplicate_conflict'
+      : `ranking:${getPrioritiesMatrixRankingGroup(row.rankingStatus)}`;
+  }
 
   function applySort(key: string) {
     setSort((current) =>
@@ -346,8 +374,8 @@ export default function PrioritiesMatrix({
           Availability and affordability stay separate from quality. Each
           priority cell shows the strongest status-aligned evidence, its
           AI-analyzed frequency and years, plus missing evidence layers.
-          Column sorting never mixes insufficient, legacy, or stale rows into
-          the comparable ranked group.
+          Column sorting never mixes cross-platform conflicts, insufficient,
+          legacy, or stale rows into the comparable ranked group.
         </p>
         {regradeNeeded && (
           <div className="mt-4 flex flex-col gap-3 rounded-2xl border border-amber-300/20 bg-amber-300/[0.08] p-3 sm:flex-row sm:items-center sm:justify-between">
@@ -461,12 +489,12 @@ export default function PrioritiesMatrix({
             </thead>
             <tbody>
               {rows.map((row, index) => {
+                const duplicateConflict = duplicateConflictKeys.has(
+                  `${row.platform}:${row.id}`,
+                );
                 const showGroup =
                   index === 0
-                  || getPrioritiesMatrixRankingGroup(row.rankingStatus)
-                    !== getPrioritiesMatrixRankingGroup(
-                      rows[index - 1].rankingStatus,
-                    );
+                  || rowGroupKey(row) !== rowGroupKey(rows[index - 1]);
                 return (
                   <Fragment key={`${row.platform}:${row.id}`}>
                     {showGroup && (
@@ -475,12 +503,14 @@ export default function PrioritiesMatrix({
                           colSpan={matrix.columns.length + 3}
                           className="border-b border-white/10 bg-white/[0.035] px-4 py-2 text-[10px] font-bold uppercase tracking-[0.14em] text-stone-500"
                         >
-                          {briefChanged
-                            && row.rankingStatus !== 'unscored'
-                            ? `Previous brief · ${
-                                rankingGroupLabel(row.rankingStatus)
-                              }`
-                            : rankingGroupLabel(row.rankingStatus)}
+                          {duplicateConflict
+                            ? 'Cross-platform conflict — linked offers visible for audit, outside peer ranking'
+                            : briefChanged
+                              && row.rankingStatus !== 'unscored'
+                              ? `Previous brief · ${
+                                  rankingGroupLabel(row.rankingStatus)
+                                }`
+                              : rankingGroupLabel(row.rankingStatus)}
                         </td>
                       </tr>
                     )}
@@ -506,7 +536,9 @@ export default function PrioritiesMatrix({
                         <div className="mt-2 flex flex-wrap items-center gap-1.5">
                           <span
                             className={`rounded-full border px-2 py-0.5 text-[9px] font-bold uppercase tracking-[0.1em] ${
-                              briefChanged
+                              duplicateConflict
+                                ? statusClassName('unmet')
+                                : briefChanged
                                 && row.rankingStatus !== 'unscored'
                                 ? statusClassName('partial')
                                 : row.rankingStatus === 'ranked'
@@ -516,7 +548,9 @@ export default function PrioritiesMatrix({
                                   : statusClassName('unknown')
                             }`}
                           >
-                            {briefChanged
+                            {duplicateConflict
+                              ? 'Cross-platform conflict'
+                              : briefChanged
                               && row.rankingStatus !== 'unscored'
                               ? 'Regrade needed'
                               : rankingLabel(row.rankingStatus)}

--- a/web/src/components/ResultsWorkspace.tsx
+++ b/web/src/components/ResultsWorkspace.tsx
@@ -11,7 +11,12 @@ import {
   type MouseEvent,
   type ReactNode,
 } from 'react';
-import type { PriceDisplayMode, ReviewJobListing, ReviewJobResponse } from '@/types';
+import type {
+  PriceDisplayMode,
+  ReviewJobDuplicatePair,
+  ReviewJobListing,
+  ReviewJobResponse,
+} from '@/types';
 import { formatUsdCost, hasAiCosts } from '@/lib/aiCosts';
 import { getPriceDisplayInfo, resolveComparablePrice } from '@/lib/pricing';
 import { buildListingUrl } from '@/lib/listingLinks';
@@ -49,6 +54,12 @@ import EvidenceGapBadge from './EvidenceGapBadge';
 import StaySnapshotStatus from './StaySnapshotStatus';
 import PriceRefreshControls from './PriceRefreshControls';
 import PrioritiesMatrix from './PrioritiesMatrix';
+import DuplicatePairsPanel from './DuplicatePairsPanel';
+import {
+  duplicateListingKeys,
+  getMaterialDuplicateConflictKeys,
+  isMaterialDuplicateConflict,
+} from '@/lib/reviewJobDuplicatePresentation';
 
 const MIN_MAP_HEIGHT = 280;
 const TIER_ORDER = ['top_pick', 'shortlist', 'consider', 'unlikely', 'no_go'] as const;
@@ -69,6 +80,9 @@ type SortKey =
   | 'price'
   | 'poiDistance';
 type DetailTab = 'triage' | 'reviews' | 'photos' | 'snapshot';
+type ResultsComparisonStatus =
+  | TriageComparisonStatus
+  | 'duplicate_conflict';
 
 function listingKey(listing: Pick<ReviewJobListing, 'id' | 'platform'>) {
   return `${listing.platform}:${listing.id}`;
@@ -102,27 +116,29 @@ function formatPercent(value: number | null): string {
   }).format(value);
 }
 
-function comparisonRank(status: TriageComparisonStatus): number {
+function comparisonRank(status: ResultsComparisonStatus): number {
   switch (status) {
     case 'ranked':
       return 0;
-    case 'regrade_required':
+    case 'duplicate_conflict':
       return 1;
-    case 'insufficient_evidence':
+    case 'regrade_required':
       return 2;
-    case 'stale_classifier_policy':
+    case 'insufficient_evidence':
       return 3;
+    case 'stale_classifier_policy':
+      return 4;
     case 'legacy':
     case 'stale_requirement_set':
-      return 4;
-    case 'unscored':
       return 5;
+    case 'unscored':
+      return 6;
   }
 }
 
 function displayedTier(
   triage: ParsedTriage | null,
-  comparisonStatus?: TriageComparisonStatus,
+  comparisonStatus?: ResultsComparisonStatus,
 ): { label: string; tier: string | null } {
   const status =
     comparisonStatus
@@ -135,6 +151,9 @@ function displayedTier(
           : 'unscored');
   if (status === 'insufficient_evidence') {
     return { label: 'Insufficient evidence', tier: null };
+  }
+  if (status === 'duplicate_conflict') {
+    return { label: 'Cross-platform conflict', tier: null };
   }
   if (
     status === 'regrade_required'
@@ -155,8 +174,15 @@ function VerdictSourceBadge({
   comparisonStatus,
 }: {
   triage: ParsedTriage | null;
-  comparisonStatus?: TriageComparisonStatus;
+  comparisonStatus?: ResultsComparisonStatus;
 }) {
+  if (comparisonStatus === 'duplicate_conflict') {
+    return (
+      <span className="rounded-full border border-rose-300/20 bg-rose-300/10 px-2 py-1 text-[10px] font-semibold text-rose-100">
+        Linked property · verdict conflict
+      </span>
+    );
+  }
   if (!triage) return null;
   const status =
     comparisonStatus
@@ -663,7 +689,7 @@ function ListingDetailPanel({
   listing: ReviewJobListing;
   job: ReviewJobResponse['job'];
   priceDisplay: PriceDisplayMode;
-  comparisonStatus: TriageComparisonStatus;
+  comparisonStatus: ResultsComparisonStatus;
   onLocate: () => void;
 }) {
   const snapshot = useMemo(() => getListingResultsSnapshot(listing), [listing]);
@@ -1310,6 +1336,34 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
 
   const viewerCanEdit = data.job.viewerCanEdit;
 
+  const updateDuplicatePair = useCallback(async (
+    pair: Pick<
+      ReviewJobDuplicatePair,
+      'airbnbListingId' | 'bookingListingId'
+    >,
+    decision: 'suggested' | 'confirmed' | 'dismissed',
+  ) => {
+    if (!viewerCanEdit) {
+      throw new Error('This results view is read-only.');
+    }
+    const response = await fetch(
+      `/api/jobs/${data.job.id}/duplicates`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...pair, decision }),
+      },
+    );
+    if (!response.ok) {
+      const payload = await response.json().catch(() => null);
+      throw new Error(
+        payload?.error ?? 'Failed to update cross-platform link',
+      );
+    }
+    const nextData: ReviewJobResponse = await response.json();
+    applyJobUpdate(nextData);
+  }, [applyJobUpdate, data.job.id, viewerCanEdit]);
+
   const setPublicSharing = useCallback(async (nextValue: boolean) => {
     if (!viewerCanEdit) {
       return;
@@ -1435,8 +1489,38 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       data.listings,
     ],
   );
+  const materialDuplicateConflictKeys = useMemo(
+    () => getMaterialDuplicateConflictKeys(
+      data.duplicatePairs,
+      data.listings,
+    ),
+    [data.duplicatePairs, data.listings],
+  );
+  const materialDuplicateSortKeys = useMemo(() => {
+    const listingsByKey = new Map(
+      data.listings.map((listing) => [
+        listingKey(listing),
+        listing,
+      ]),
+    );
+    const sortKeys = new Map<string, string>();
+    for (const pair of data.duplicatePairs) {
+      if (!isMaterialDuplicateConflict(pair, listingsByKey)) continue;
+      const [airbnbKey, bookingKey] = duplicateListingKeys(pair);
+      const pairKey = `${pair.createdAt}:${pair.id}`;
+      if (!sortKeys.has(airbnbKey)) {
+        sortKeys.set(airbnbKey, `${pairKey}:0`);
+      }
+      if (!sortKeys.has(bookingKey)) {
+        sortKeys.set(bookingKey, `${pairKey}:1`);
+      }
+    }
+    return sortKeys;
+  }, [data.duplicatePairs, data.listings]);
   const comparisonGateActive =
-    activeTriageComparison != null || data.job.regradeRequired;
+    activeTriageComparison != null
+    || data.job.regradeRequired
+    || materialDuplicateConflictKeys.size > 0;
   const resolveComparisonStatus = useCallback(
     (triage: ParsedTriage | null) =>
       getTriageComparisonStatus(
@@ -1445,6 +1529,15 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
         { regradeRequired: data.job.regradeRequired },
       ),
     [activeTriageComparison, data.job.regradeRequired],
+  );
+  const resolveListingComparisonStatus = useCallback(
+    (listing: ReviewJobListing): ResultsComparisonStatus =>
+      materialDuplicateConflictKeys.has(listingKey(listing))
+        ? 'duplicate_conflict'
+        : resolveComparisonStatus(
+            getListingResultsSnapshot(listing).triage,
+          ),
+    [materialDuplicateConflictKeys, resolveComparisonStatus],
   );
   const regradeListingCount = useMemo(
     () => getTriageRegradeListingCount(data.listings),
@@ -1507,13 +1600,20 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       const triageB = getListingResultsSnapshot(b).triage;
       if (comparisonGateActive) {
         const groupA = comparisonRank(
-          resolveComparisonStatus(triageA),
+          resolveListingComparisonStatus(a),
         );
         const groupB = comparisonRank(
-          resolveComparisonStatus(triageB),
+          resolveListingComparisonStatus(b),
         );
         if (groupA !== groupB) return groupA - groupB;
         if (groupA !== 0) {
+          if (groupA === comparisonRank('duplicate_conflict')) {
+            return (
+              materialDuplicateSortKeys.get(listingKey(a)) ?? ''
+            ).localeCompare(
+              materialDuplicateSortKeys.get(listingKey(b)) ?? '',
+            );
+          }
           return (
             (originalIndex.get(listingKey(a)) ?? 0)
             - (originalIndex.get(listingKey(b)) ?? 0)
@@ -1559,8 +1659,9 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
     data.job.checkin,
     data.job.checkout,
     data.listings,
+    materialDuplicateSortKeys,
     priceDisplay,
-    resolveComparisonStatus,
+    resolveListingComparisonStatus,
   ]);
 
   const sortableResults = useMemo(() => {
@@ -1573,13 +1674,9 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       if (!sortAsc) return next;
       if (!comparisonGateActive) return [...next].reverse();
       const ranked = next.filter((listing) =>
-        resolveComparisonStatus(
-          getListingResultsSnapshot(listing).triage,
-        ) === 'ranked');
+        resolveListingComparisonStatus(listing) === 'ranked');
       const unranked = next.filter((listing) =>
-        resolveComparisonStatus(
-          getListingResultsSnapshot(listing).triage,
-        ) !== 'ranked');
+        resolveListingComparisonStatus(listing) !== 'ranked');
       return [...ranked.reverse(), ...unranked];
     }
 
@@ -1591,16 +1688,18 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       }
       if (comparisonGateActive) {
         const groupA = comparisonRank(
-          resolveComparisonStatus(
-            getListingResultsSnapshot(a).triage,
-          ),
+          resolveListingComparisonStatus(a),
         );
         const groupB = comparisonRank(
-          resolveComparisonStatus(
-            getListingResultsSnapshot(b).triage,
-          ),
+          resolveListingComparisonStatus(b),
         );
         if (groupA !== groupB) return groupA - groupB;
+        if (groupA === comparisonRank('duplicate_conflict')) {
+          return (
+            (baseIndex.get(listingKey(a)) ?? 0)
+            - (baseIndex.get(listingKey(b)) ?? 0)
+          );
+        }
         if (
           groupA !== 0
           && sortKey !== 'affordability'
@@ -1670,7 +1769,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
     data.job.checkin,
     data.job.checkout,
     priceDisplay,
-    resolveComparisonStatus,
+    resolveListingComparisonStatus,
     sortAsc,
     sortKey,
   ]);
@@ -1687,7 +1786,8 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
     () =>
       displayableResults.filter((listing) => {
         const triage = getListingResultsSnapshot(listing).triage;
-        const comparisonStatus = resolveComparisonStatus(triage);
+        const comparisonStatus =
+          resolveListingComparisonStatus(listing);
         const tier = triage?.tier ?? 'unscored';
         if (
           (!comparisonGateActive || comparisonStatus === 'ranked')
@@ -1738,7 +1838,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       maxPoiDistanceFilter,
       maxPriceFilter,
       priceDisplay,
-      resolveComparisonStatus,
+      resolveListingComparisonStatus,
     ],
   );
 
@@ -1758,9 +1858,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
         listing.staySnapshot.bookingEligibility.actionable
         && (
         !comparisonGateActive
-        || resolveComparisonStatus(
-          getListingResultsSnapshot(listing).triage,
-        ) === 'ranked'
+        || resolveListingComparisonStatus(listing) === 'ranked'
         ),
     );
     const topPicks = comparable.filter(
@@ -1773,7 +1871,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
   }, [
     comparisonGateActive,
     filteredResults,
-    resolveComparisonStatus,
+    resolveListingComparisonStatus,
   ]);
 
   const tierCounts = useMemo(() => {
@@ -1782,7 +1880,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       const triage = getListingResultsSnapshot(listing).triage;
       if (
         comparisonGateActive
-        && resolveComparisonStatus(triage) !== 'ranked'
+        && resolveListingComparisonStatus(listing) !== 'ranked'
       ) {
         continue;
       }
@@ -1793,7 +1891,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
   }, [
     comparisonGateActive,
     displayableResults,
-    resolveComparisonStatus,
+    resolveListingComparisonStatus,
   ]);
   const affordabilityCounts = useMemo(() => {
     const counts = new Map<AffordabilityStatus, number>();
@@ -1972,7 +2070,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
         const key = listingKey(listing);
         const snapshot = getListingResultsSnapshot(listing);
         const comparisonStatus =
-          resolveComparisonStatus(snapshot.triage);
+          resolveListingComparisonStatus(listing);
         const verdictTier = displayedTier(
           snapshot.triage,
           comparisonStatus,
@@ -1981,16 +2079,16 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
         const previousComparisonGroup =
           index > 0
             ? comparisonRank(
-                resolveComparisonStatus(
-                  getListingResultsSnapshot(rows[index - 1]).triage,
-                ),
+                resolveListingComparisonStatus(rows[index - 1]),
               )
             : null;
         const groupHeader =
           comparisonGateActive
           && comparisonGroup !== 0
           && comparisonGroup !== previousComparisonGroup
-            ? comparisonStatus === 'regrade_required'
+            ? comparisonStatus === 'duplicate_conflict'
+              ? 'Cross-platform conflict — review both offers and evidence sets'
+              : comparisonStatus === 'regrade_required'
               ? 'Regrade needed — these verdicts reflect the previous quality brief'
               : comparisonStatus === 'insufficient_evidence'
               ? 'Insufficient evidence — shown for audit, not ranked with comparable results'
@@ -2238,7 +2336,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       hiddenIds,
       likedIds,
       priceDisplay,
-      resolveComparisonStatus,
+      resolveListingComparisonStatus,
       selectedId,
       showHidden,
       toggleHidden,
@@ -2430,8 +2528,22 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
           )}
         </header>
 
+        <DuplicatePairsPanel
+          pairs={data.duplicatePairs}
+          listings={data.listings}
+          job={data.job}
+          priceDisplay={priceDisplay}
+          viewerCanEdit={viewerCanEdit}
+          onDecision={
+            viewerCanEdit ? updateDuplicatePair : undefined
+          }
+          onSelectListing={(key) =>
+            handleSelect(key, { scroll: true })}
+        />
+
         <PrioritiesMatrix
           listings={displayableResults}
+          duplicateConflictKeys={materialDuplicateConflictKeys}
           regradeReasons={regradeReasons}
           regradeLocked={regradeLocked}
           regradeListingCount={regradeListingCount}

--- a/web/src/lib/reviewJobDuplicatePersistence.ts
+++ b/web/src/lib/reviewJobDuplicatePersistence.ts
@@ -1,0 +1,151 @@
+import { Prisma } from '@prisma/client';
+import {
+  detectReviewJobDuplicatePairs,
+  REVIEW_JOB_DUPLICATE_DETECTOR_VERSION,
+  type DuplicateListingInput,
+} from './reviewJobDuplicates.js';
+
+type DuplicateSyncClient = Pick<
+  Prisma.TransactionClient,
+  'reviewJobListing' | 'reviewJobDuplicatePair'
+>;
+
+function pairKey(
+  airbnbListingId: string,
+  bookingListingId: string,
+): string {
+  return `${airbnbListingId}\u0000${bookingListingId}`;
+}
+
+export async function syncReviewJobDuplicatePairs(
+  client: DuplicateSyncClient,
+  jobId: string,
+) {
+  const rows = await client.reviewJobListing.findMany({
+    where: { jobId },
+    select: {
+      listingId: true,
+      platform: true,
+      name: true,
+      lat: true,
+      lng: true,
+      propertyType: true,
+      analysis: {
+        select: {
+          details: true,
+        },
+      },
+    },
+  });
+  const listings: DuplicateListingInput[] = rows.map((row) => ({
+    listingId: row.listingId,
+    platform: row.platform,
+    name: row.name,
+    coordinates:
+      row.lat != null && row.lng != null
+        ? { lat: row.lat, lng: row.lng }
+        : null,
+    propertyType: row.propertyType,
+    details: row.analysis?.details,
+  }));
+  const detected = detectReviewJobDuplicatePairs(listings);
+  const detectedKeys = new Set(
+    detected.map((pair) =>
+      pairKey(
+        pair.airbnbListingId,
+        pair.bookingListingId,
+      )),
+  );
+  const existing = await client.reviewJobDuplicatePair.findMany({
+    where: { jobId },
+    select: {
+      id: true,
+      airbnbListingId: true,
+      bookingListingId: true,
+      detectorConfidence: true,
+      decisionSource: true,
+    },
+  });
+
+  for (const pair of detected) {
+    await client.reviewJobDuplicatePair.upsert({
+      where: {
+        jobId_airbnbListingId_bookingListingId: {
+          jobId,
+          airbnbListingId: pair.airbnbListingId,
+          bookingListingId: pair.bookingListingId,
+        },
+      },
+      create: {
+        jobId,
+        airbnbListingId: pair.airbnbListingId,
+        bookingListingId: pair.bookingListingId,
+        detectorVersion: pair.detectorVersion,
+        detectorConfidence: pair.confidence,
+        decision: 'suggested',
+        decisionSource: 'detector',
+        distanceMeters: pair.distanceMeters,
+        nameScore: pair.nameScore,
+        nameSource: pair.nameSource,
+        evidence:
+          pair.evidence as unknown as Prisma.InputJsonValue,
+      },
+      update: {
+        detectorVersion: pair.detectorVersion,
+        detectorConfidence: pair.confidence,
+        distanceMeters: pair.distanceMeters,
+        nameScore: pair.nameScore,
+        nameSource: pair.nameSource,
+        evidence:
+          pair.evidence as unknown as Prisma.InputJsonValue,
+      },
+    });
+  }
+
+  const staleDetectorPairIds = existing
+    .filter(
+      (pair) =>
+        pair.decisionSource === 'detector'
+        && !detectedKeys.has(pairKey(
+          pair.airbnbListingId,
+          pair.bookingListingId,
+        )),
+    )
+    .map((pair) => pair.id);
+  if (staleDetectorPairIds.length > 0) {
+    await client.reviewJobDuplicatePair.deleteMany({
+      where: {
+        id: { in: staleDetectorPairIds },
+      },
+    });
+  }
+  const staleUserDetectorPairIds = existing
+    .filter(
+      (pair) =>
+        pair.decisionSource === 'user'
+        && pair.detectorConfidence != null
+        && !detectedKeys.has(pairKey(
+          pair.airbnbListingId,
+          pair.bookingListingId,
+        )),
+    )
+    .map((pair) => pair.id);
+  if (staleUserDetectorPairIds.length > 0) {
+    await client.reviewJobDuplicatePair.updateMany({
+      where: {
+        id: { in: staleUserDetectorPairIds },
+      },
+      data: {
+        detectorVersion: REVIEW_JOB_DUPLICATE_DETECTOR_VERSION,
+        detectorConfidence: null,
+        nameScore: null,
+        nameSource: null,
+        evidence: {
+          detectorInactive: true,
+        },
+      },
+    });
+  }
+
+  return detected;
+}

--- a/web/src/lib/reviewJobDuplicatePresentation.ts
+++ b/web/src/lib/reviewJobDuplicatePresentation.ts
@@ -1,0 +1,79 @@
+import type {
+  ReviewJobDuplicatePair,
+  ReviewJobListing,
+} from '../types.js';
+import { getListingResultsSnapshot } from './results.js';
+
+const TIER_RANK = new Map([
+  ['top_pick', 0],
+  ['shortlist', 1],
+  ['consider', 2],
+  ['unlikely', 3],
+  ['no_go', 4],
+]);
+
+export function duplicateListingKeys(
+  pair: Pick<
+    ReviewJobDuplicatePair,
+    'airbnbListingId' | 'bookingListingId'
+  >,
+): [string, string] {
+  return [
+    `airbnb:${pair.airbnbListingId}`,
+    `booking:${pair.bookingListingId}`,
+  ];
+}
+
+export function isActiveDuplicatePair(
+  pair: Pick<
+    ReviewJobDuplicatePair,
+    'decision' | 'detectorConfidence'
+  >,
+): boolean {
+  return (
+    pair.decision === 'confirmed'
+    || (
+      pair.decision === 'suggested'
+      && pair.detectorConfidence === 'likely_same'
+    )
+  );
+}
+
+export function isMaterialDuplicateConflict(
+  pair: ReviewJobDuplicatePair,
+  listingsByKey: ReadonlyMap<string, ReviewJobListing>,
+): boolean {
+  if (!isActiveDuplicatePair(pair)) return false;
+  const [airbnbKey, bookingKey] = duplicateListingKeys(pair);
+  const airbnb = listingsByKey.get(airbnbKey);
+  const booking = listingsByKey.get(bookingKey);
+  if (!airbnb || !booking) return false;
+
+  const airbnbTier = getListingResultsSnapshot(airbnb).triage?.tier;
+  const bookingTier = getListingResultsSnapshot(booking).triage?.tier;
+  const airbnbRank = airbnbTier ? TIER_RANK.get(airbnbTier) : null;
+  const bookingRank = bookingTier ? TIER_RANK.get(bookingTier) : null;
+  return (
+    airbnbRank != null
+    && bookingRank != null
+    && Math.abs(airbnbRank - bookingRank) >= 2
+  );
+}
+
+export function getMaterialDuplicateConflictKeys(
+  pairs: ReviewJobDuplicatePair[],
+  listings: ReviewJobListing[],
+): Set<string> {
+  const listingsByKey = new Map(
+    listings.map((listing) => [
+      `${listing.platform}:${listing.id}`,
+      listing,
+    ]),
+  );
+  const keys = new Set<string>();
+  for (const pair of pairs) {
+    if (!isMaterialDuplicateConflict(pair, listingsByKey)) continue;
+    for (const key of duplicateListingKeys(pair)) keys.add(key);
+  }
+  return keys;
+}

--- a/web/src/lib/reviewJobDuplicates.ts
+++ b/web/src/lib/reviewJobDuplicates.ts
@@ -1,0 +1,531 @@
+import type { Platform } from '../types.js';
+
+export const REVIEW_JOB_DUPLICATE_DETECTOR_VERSION =
+  'cross-platform-property-v1';
+export const REVIEW_JOB_DUPLICATE_CANDIDATE_RADIUS_METERS = 250;
+
+export type DuplicatePairConfidence =
+  | 'likely_same'
+  | 'possible_same';
+export type DuplicatePairDecision =
+  | 'suggested'
+  | 'confirmed'
+  | 'dismissed';
+export type DuplicatePairDecisionSource = 'detector' | 'user';
+export type DuplicateNameSource = 'card' | 'host' | 'address' | 'none';
+
+export interface DuplicateListingInput {
+  listingId: string;
+  platform: Platform;
+  name: string;
+  coordinates: { lat: number; lng: number } | null;
+  propertyType?: string | null;
+  details?: unknown;
+}
+
+export interface DuplicateNameEvidence {
+  score: number;
+  source: DuplicateNameSource;
+  airbnbName: string | null;
+  bookingName: string;
+  sharedDistinctiveTokens: string[];
+  exactAddressMatch: boolean;
+}
+
+export interface DetectedReviewJobDuplicatePair {
+  airbnbListingId: string;
+  bookingListingId: string;
+  detectorVersion: string;
+  confidence: DuplicatePairConfidence;
+  distanceMeters: number;
+  nameScore: number;
+  nameSource: DuplicateNameSource;
+  evidence: {
+    airbnbCardName: string;
+    airbnbHostName: string | null;
+    bookingName: string;
+    sharedDistinctiveTokens: string[];
+    exactAddressMatch: boolean;
+    mutualNearest: boolean;
+    ambiguousStrongName: boolean;
+  };
+}
+
+const EARTH_RADIUS_METERS = 6_371_000;
+const NAME_STOP_WORDS = new Set([
+  'a',
+  'accommodation',
+  'accommodations',
+  'an',
+  'and',
+  'apartment',
+  'apartments',
+  'apt',
+  'at',
+  'boutique',
+  'by',
+  'hotel',
+  'hotels',
+  'hostel',
+  'hostels',
+  'in',
+  'inn',
+  'lodging',
+  'private',
+  'property',
+  'resort',
+  'room',
+  'rooms',
+  'stay',
+  'stays',
+  'suite',
+  'suites',
+  'the',
+]);
+const NON_DISTINCTIVE_LOCATION_TOKENS = new Set([
+  'brooklyn',
+  'chinatown',
+  'city',
+  'downtown',
+  'east',
+  'les',
+  'lower',
+  'manhattan',
+  'midtown',
+  'new',
+  'nyc',
+  'queens',
+  'side',
+  'soho',
+  'tribeca',
+  'upper',
+  'west',
+  'york',
+]);
+// Real-job negative controls: a private profile and an inventory reseller,
+// neither of which is evidence of the property's identity.
+const UNTRUSTED_AIRBNB_HOST_NAMES = new Set([
+  'jeniffer',
+  'roompicks',
+]);
+
+function isTrustedAirbnbHostName(value: string): boolean {
+  const normalized = normalizeDuplicateName(value);
+  const tokens = normalized.split(' ').filter(Boolean);
+  const compact = tokens.join('');
+  return (
+    !UNTRUSTED_AIRBNB_HOST_NAMES.has(compact)
+    && !tokens.some((token) =>
+      UNTRUSTED_AIRBNB_HOST_NAMES.has(token))
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return (
+    value != null
+    && typeof value === 'object'
+    && !Array.isArray(value)
+  )
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim()
+    ? value.trim()
+    : null;
+}
+
+function getNestedString(
+  value: unknown,
+  keys: string[],
+): string | null {
+  let current: unknown = value;
+  for (const key of keys) {
+    current = asRecord(current)?.[key];
+  }
+  return asNonEmptyString(current);
+}
+
+export function getDuplicateHostName(details: unknown): string | null {
+  return getNestedString(details, ['host', 'name']);
+}
+
+export function getDuplicateAddress(details: unknown): string | null {
+  const record = asRecord(details);
+  if (!record) return null;
+  const address = record.address;
+  return (
+    asNonEmptyString(address)
+    ?? getNestedString(address, ['full'])
+    ?? getNestedString(address, ['address'])
+  );
+}
+
+function normalizeUnicode(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLocaleLowerCase('en-US')
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+export function normalizeDuplicateName(value: string): string {
+  return normalizeUnicode(value)
+    .split(' ')
+    .filter((token) => token && !NAME_STOP_WORDS.has(token))
+    .join(' ');
+}
+
+function nameTokens(value: string): string[] {
+  return normalizeDuplicateName(value).split(' ').filter(Boolean);
+}
+
+function isDistinctiveToken(token: string): boolean {
+  return (
+    token.length >= 3
+    && !/^\d+$/.test(token)
+    && !NAME_STOP_WORDS.has(token)
+    && !NON_DISTINCTIVE_LOCATION_TOKENS.has(token)
+  );
+}
+
+function levenshteinDistance(left: string, right: string): number {
+  if (left === right) return 0;
+  if (!left) return right.length;
+  if (!right) return left.length;
+
+  let previous = Array.from(
+    { length: right.length + 1 },
+    (_, index) => index,
+  );
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    const current = [leftIndex];
+    for (
+      let rightIndex = 1;
+      rightIndex <= right.length;
+      rightIndex += 1
+    ) {
+      const substitutionCost =
+        left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1;
+      current[rightIndex] = Math.min(
+        current[rightIndex - 1] + 1,
+        previous[rightIndex] + 1,
+        previous[rightIndex - 1] + substitutionCost,
+      );
+    }
+    previous = current;
+  }
+  return previous[right.length];
+}
+
+function scoreNames(
+  leftName: string,
+  rightName: string,
+): {
+  score: number;
+  sharedDistinctiveTokens: string[];
+} {
+  const left = normalizeDuplicateName(leftName);
+  const right = normalizeDuplicateName(rightName);
+  if (!left || !right) {
+    return { score: 0, sharedDistinctiveTokens: [] };
+  }
+
+  const leftTokens = new Set(nameTokens(left));
+  const rightTokens = new Set(nameTokens(right));
+  const sharedTokens = [...leftTokens].filter((token) =>
+    rightTokens.has(token));
+  const sharedDistinctiveTokens = sharedTokens.filter(isDistinctiveToken);
+  const unionSize =
+    new Set([...leftTokens, ...rightTokens]).size;
+  const jaccard =
+    unionSize > 0 ? sharedTokens.length / unionSize : 0;
+  const containment =
+    sharedTokens.length
+    / Math.max(1, Math.min(leftTokens.size, rightTokens.size));
+  const edit =
+    1
+    - (
+      levenshteinDistance(left, right)
+      / Math.max(left.length, right.length)
+    );
+  const distinctiveContainment =
+    sharedDistinctiveTokens.length > 0
+      ? containment * 0.92
+      : 0;
+
+  return {
+    score: Math.max(
+      left === right ? 1 : 0,
+      edit,
+      jaccard,
+      distinctiveContainment,
+    ),
+    sharedDistinctiveTokens,
+  };
+}
+
+function normalizeAddress(value: string | null): string | null {
+  if (!value) return null;
+  const normalized = normalizeUnicode(value)
+    .replace(/\b(?:apt|apartment|room|suite|unit)\s*[a-z0-9-]+\b/g, '')
+    .trim()
+    .replace(/\s+/g, ' ');
+  return normalized && /\d/.test(normalized) ? normalized : null;
+}
+
+function getNameEvidence(
+  airbnb: DuplicateListingInput,
+  booking: DuplicateListingInput,
+): DuplicateNameEvidence {
+  const capturedHostName = getDuplicateHostName(airbnb.details);
+  const hostName =
+    capturedHostName
+    && isTrustedAirbnbHostName(capturedHostName)
+      ? capturedHostName
+      : null;
+  const signals = [
+    {
+      source: 'card' as const,
+      name: airbnb.name,
+      ...scoreNames(airbnb.name, booking.name),
+    },
+    ...(hostName
+      ? [{
+          source: 'host' as const,
+          name: hostName,
+          ...scoreNames(hostName, booking.name),
+        }]
+      : []),
+  ].sort((left, right) =>
+    right.score - left.score
+    || (
+      left.source === 'host' ? -1 : 1
+    ));
+
+  const airbnbAddress = normalizeAddress(
+    getDuplicateAddress(airbnb.details),
+  );
+  const bookingAddress = normalizeAddress(
+    getDuplicateAddress(booking.details),
+  );
+  const exactAddressMatch =
+    airbnbAddress != null
+    && bookingAddress != null
+    && airbnbAddress === bookingAddress;
+  const strongest = signals[0];
+
+  return {
+    score: exactAddressMatch ? 1 : strongest?.score ?? 0,
+    source: exactAddressMatch
+      ? 'address'
+      : strongest?.source ?? 'none',
+    airbnbName: exactAddressMatch
+      ? getDuplicateAddress(airbnb.details)
+      : strongest?.name ?? null,
+    bookingName: booking.name,
+    sharedDistinctiveTokens:
+      strongest?.sharedDistinctiveTokens ?? [],
+    exactAddressMatch,
+  };
+}
+
+function toRadians(value: number): number {
+  return (value * Math.PI) / 180;
+}
+
+export function duplicateDistanceMeters(
+  left: { lat: number; lng: number },
+  right: { lat: number; lng: number },
+): number {
+  const leftLat = toRadians(left.lat);
+  const rightLat = toRadians(right.lat);
+  const deltaLat = rightLat - leftLat;
+  const deltaLng = toRadians(right.lng - left.lng);
+  const haversine =
+    Math.sin(deltaLat / 2) ** 2
+    + (
+      Math.cos(leftLat)
+      * Math.cos(rightLat)
+      * Math.sin(deltaLng / 2) ** 2
+    );
+  return (
+    2
+    * EARTH_RADIUS_METERS
+    * Math.atan2(
+      Math.sqrt(haversine),
+      Math.sqrt(1 - haversine),
+    )
+  );
+}
+
+interface PairCandidate {
+  airbnb: DuplicateListingInput;
+  booking: DuplicateListingInput;
+  distanceMeters: number;
+  name: DuplicateNameEvidence;
+}
+
+function candidateKey(
+  airbnbListingId: string,
+  bookingListingId: string,
+): string {
+  return `${airbnbListingId}\u0000${bookingListingId}`;
+}
+
+function isStrongName(candidate: PairCandidate): boolean {
+  return (
+    candidate.name.exactAddressMatch
+    || (
+      candidate.name.score >= 0.82
+      && candidate.name.sharedDistinctiveTokens.length > 0
+    )
+  );
+}
+
+export function detectReviewJobDuplicatePairs(
+  listings: DuplicateListingInput[],
+): DetectedReviewJobDuplicatePair[] {
+  const airbnbListings = listings.filter(
+    (listing) =>
+      listing.platform === 'airbnb'
+      && listing.coordinates != null,
+  );
+  const bookingListings = listings.filter(
+    (listing) =>
+      listing.platform === 'booking'
+      && listing.coordinates != null,
+  );
+  const candidates: PairCandidate[] = [];
+
+  for (const airbnb of airbnbListings) {
+    for (const booking of bookingListings) {
+      const distanceMeters = duplicateDistanceMeters(
+        airbnb.coordinates!,
+        booking.coordinates!,
+      );
+      if (
+        distanceMeters
+        > REVIEW_JOB_DUPLICATE_CANDIDATE_RADIUS_METERS
+      ) {
+        continue;
+      }
+      candidates.push({
+        airbnb,
+        booking,
+        distanceMeters,
+        name: getNameEvidence(airbnb, booking),
+      });
+    }
+  }
+
+  const nearestBookingByAirbnb = new Map<string, string>();
+  for (const airbnb of airbnbListings) {
+    const nearest = candidates
+      .filter((candidate) =>
+        candidate.airbnb.listingId === airbnb.listingId)
+      .sort((left, right) =>
+        left.distanceMeters - right.distanceMeters
+        || left.booking.listingId.localeCompare(
+          right.booking.listingId,
+        ))[0];
+    if (nearest) {
+      nearestBookingByAirbnb.set(
+        airbnb.listingId,
+        nearest.booking.listingId,
+      );
+    }
+  }
+  const nearestAirbnbByBooking = new Map<string, string>();
+  for (const booking of bookingListings) {
+    const nearest = candidates
+      .filter((candidate) =>
+        candidate.booking.listingId === booking.listingId)
+      .sort((left, right) =>
+        left.distanceMeters - right.distanceMeters
+        || left.airbnb.listingId.localeCompare(
+          right.airbnb.listingId,
+        ))[0];
+    if (nearest) {
+      nearestAirbnbByBooking.set(
+        booking.listingId,
+        nearest.airbnb.listingId,
+      );
+    }
+  }
+
+  const strongByAirbnb = new Map<string, number>();
+  const strongByBooking = new Map<string, number>();
+  for (const candidate of candidates.filter(isStrongName)) {
+    strongByAirbnb.set(
+      candidate.airbnb.listingId,
+      (strongByAirbnb.get(candidate.airbnb.listingId) ?? 0) + 1,
+    );
+    strongByBooking.set(
+      candidate.booking.listingId,
+      (strongByBooking.get(candidate.booking.listingId) ?? 0) + 1,
+    );
+  }
+
+  return candidates
+    .map((candidate) => {
+      const mutualNearest =
+        nearestBookingByAirbnb.get(candidate.airbnb.listingId)
+          === candidate.booking.listingId
+        && nearestAirbnbByBooking.get(candidate.booking.listingId)
+          === candidate.airbnb.listingId;
+      const strong = isStrongName(candidate);
+      const ambiguousStrongName =
+        strong
+        && (
+          (strongByAirbnb.get(candidate.airbnb.listingId) ?? 0) > 1
+          || (strongByBooking.get(candidate.booking.listingId) ?? 0) > 1
+        );
+      return {
+        airbnbListingId: candidate.airbnb.listingId,
+        bookingListingId: candidate.booking.listingId,
+        detectorVersion:
+          REVIEW_JOB_DUPLICATE_DETECTOR_VERSION,
+        confidence:
+          strong && !ambiguousStrongName
+            ? 'likely_same' as const
+            : 'possible_same' as const,
+        distanceMeters: candidate.distanceMeters,
+        nameScore: candidate.name.score,
+        nameSource: candidate.name.source,
+        evidence: {
+          airbnbCardName: candidate.airbnb.name,
+          airbnbHostName: getDuplicateHostName(
+            candidate.airbnb.details,
+          ),
+          bookingName: candidate.booking.name,
+          sharedDistinctiveTokens:
+            candidate.name.sharedDistinctiveTokens,
+          exactAddressMatch: candidate.name.exactAddressMatch,
+          mutualNearest,
+          ambiguousStrongName,
+        },
+      };
+    })
+    .sort((left, right) =>
+      (
+        left.confidence === right.confidence
+          ? 0
+          : left.confidence === 'likely_same'
+            ? -1
+            : 1
+      )
+      || right.nameScore - left.nameScore
+      || left.distanceMeters - right.distanceMeters
+      || candidateKey(
+        left.airbnbListingId,
+        left.bookingListingId,
+      ).localeCompare(candidateKey(
+        right.airbnbListingId,
+        right.bookingListingId,
+      )));
+}

--- a/web/src/lib/reviewJobs.ts
+++ b/web/src/lib/reviewJobs.ts
@@ -4,6 +4,7 @@ import type {
   Prisma,
   ReviewJob as ReviewJobModel,
   ReviewJobEvent as ReviewJobEventModel,
+  ReviewJobDuplicatePair as ReviewJobDuplicatePairModel,
   ReviewJobListing as ReviewJobListingModel,
   ReviewJobListingAnalysis as ReviewJobListingAnalysisModel,
 } from '@prisma/client';
@@ -17,6 +18,7 @@ import type {
   FullSearchRequest,
   MapPoint,
   ReviewJobEvent,
+  ReviewJobDuplicatePair,
   ReviewAnalysisSample,
   ReviewJobListing,
   ReviewJobListingAnalysis,
@@ -273,6 +275,9 @@ export const reviewJobResponseInclude = {
     },
   },
   events: {
+    orderBy: { createdAt: 'asc' as const },
+  },
+  duplicatePairs: {
     orderBy: { createdAt: 'asc' as const },
   },
 } satisfies Prisma.ReviewJobInclude;
@@ -614,9 +619,36 @@ export function toReviewJobEvent(row: ReviewJobEventModel): ReviewJobEvent {
   };
 }
 
+export function toReviewJobDuplicatePair(
+  row: ReviewJobDuplicatePairModel,
+): ReviewJobDuplicatePair {
+  return {
+    id: row.id,
+    airbnbListingId: row.airbnbListingId,
+    bookingListingId: row.bookingListingId,
+    detectorVersion: row.detectorVersion,
+    detectorConfidence: row.detectorConfidence,
+    decision: row.decision,
+    decisionSource: row.decisionSource,
+    distanceMeters: row.distanceMeters,
+    nameScore: row.nameScore,
+    nameSource:
+      row.nameSource === 'card'
+      || row.nameSource === 'host'
+      || row.nameSource === 'address'
+      || row.nameSource === 'none'
+        ? row.nameSource
+        : null,
+    evidence: asJsonObject(row.evidence),
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
 export function toReviewJobResponse(input: {
   job: ReviewJobModel;
   listings: Array<ReviewJobListingModel & { analysis?: ReviewJobListingAnalysisModel | null }>;
+  duplicatePairs?: ReviewJobDuplicatePairModel[];
   events: ReviewJobEventModel[];
   viewerCanEdit?: boolean;
 }): ReviewJobResponse {
@@ -625,6 +657,10 @@ export function toReviewJobResponse(input: {
   const ttlMs = resolveStaySnapshotTtlMs();
   const now = new Date();
   const reviewSamples = getReviewSamplesFromManifest(input.job.artifactRoot);
+  const visibleListingKeys = new Set(
+    input.listings.map((listing) =>
+      `${listing.platform}:${listing.listingId}`),
+  );
 
   return {
     job: toReviewJobState(input.job, {
@@ -649,6 +685,15 @@ export function toReviewJobResponse(input: {
               : undefined
           ),
       })),
+    duplicatePairs: (input.duplicatePairs ?? [])
+      .filter((pair) =>
+        visibleListingKeys.has(`airbnb:${pair.airbnbListingId}`)
+        && visibleListingKeys.has(`booking:${pair.bookingListingId}`)
+        && (
+          input.viewerCanEdit !== false
+          || pair.decision !== 'dismissed'
+        ))
+      .map(toReviewJobDuplicatePair),
     events: input.events.map(toReviewJobEvent),
   };
 }
@@ -657,6 +702,7 @@ export function toReviewJobResponseRecord(job: ReviewJobResponseRecord): ReviewJ
   return toReviewJobResponse({
     job,
     listings: job.listings,
+    duplicatePairs: job.duplicatePairs,
     events: job.events,
   });
 }
@@ -668,6 +714,7 @@ export function toReviewJobResponseRecordForViewer(
   return toReviewJobResponse({
     job,
     listings: job.listings,
+    duplicatePairs: job.duplicatePairs,
     events: job.events,
     viewerCanEdit: canEditReviewJob(job, ownerKey),
   });

--- a/web/src/lib/search-worker.ts
+++ b/web/src/lib/search-worker.ts
@@ -71,6 +71,9 @@ import {
   resolveStaySnapshotTtlMs,
 } from './staySnapshots.js';
 import { regradeRequiredAfterAnalysis } from './reviewJobEdits.js';
+import {
+  syncReviewJobDuplicatePairs,
+} from './reviewJobDuplicatePersistence.js';
 
 for (const envPath of [
   path.resolve(process.cwd(), '.env.local'),
@@ -486,6 +489,7 @@ async function runReviewJobSearch(reviewJobId: string) {
           skipDuplicates: true,
         });
       }
+      await syncReviewJobDuplicatePairs(tx, reviewJobId);
       await tx.reviewJob.update({
         where: { id: reviewJobId },
         data: {
@@ -1877,6 +1881,7 @@ async function runReviewJobAnalysis(
       artifactRoot,
       poi,
     });
+    await syncReviewJobDuplicatePairs(prisma, reviewJobId);
 
     const completedAt = new Date();
     let overallStatus: 'completed' | 'partial' | 'failed' = 'completed';
@@ -1950,6 +1955,7 @@ async function runReviewJobAnalysis(
         artifactRoot,
         poi,
       });
+      await syncReviewJobDuplicatePairs(prisma, reviewJobId);
 
       await prisma.$transaction(async (tx) => {
         await resetReviewJobListingAnalyses(tx, inactiveListingIds);

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -231,6 +231,22 @@ export interface ReviewJobListing extends SearchResult {
   analysis: ReviewJobListingAnalysis | null;
 }
 
+export interface ReviewJobDuplicatePair {
+  id: string;
+  airbnbListingId: string;
+  bookingListingId: string;
+  detectorVersion: string;
+  detectorConfidence: 'likely_same' | 'possible_same' | null;
+  decision: 'suggested' | 'confirmed' | 'dismissed';
+  decisionSource: 'detector' | 'user';
+  distanceMeters: number | null;
+  nameScore: number | null;
+  nameSource: 'card' | 'host' | 'address' | 'none' | null;
+  evidence: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface ReviewJobState {
   id: string;
   ownerKey: string | null;
@@ -293,6 +309,7 @@ export interface ReviewJobState {
 export interface ReviewJobResponse {
   job: ReviewJobState;
   listings: ReviewJobListing[];
+  duplicatePairs: ReviewJobDuplicatePair[];
   events: ReviewJobEvent[];
 }
 


### PR DESCRIPTION
## Summary
- add a deterministic, versioned Airbnb-to-Booking detector with a 250 m candidate envelope, strong card or host name evidence for likely matches, and inert possible suggestions
- persist detector evidence and owner confirm, dismiss, undo, and manual-link decisions without overwriting user choices on search or analysis resync
- keep offers and evidence separate while surfacing linked verdict, availability, affordability, price, and review-sample provenance in owner and public results
- move materially contradictory likely or confirmed pairs out of the hero and comparable peer ranks while preserving their full priorities-matrix evidence in a labeled conflict group

## Detection boundary
- geo is a weak candidate prior because Airbnb coordinates are intentionally offset
- likely_same requires strong distinctive name or exact captured-address evidence; one-to-many strong matches remain possible_same
- Airbnb host.name is co-equal with the card name; real private-host and reseller controls are pinned for Jeniffer and RoomPicks
- fixtures cover Merchant 2.4 m, 17John and AMTD 36.8 m, NoMo 81.4 m, UNTITLED 151.1 m, Walker, ambiguous Chinatown candidates, radius edges, and order independence
- v1 surfaces links only; it does not merge reviews, prices, availability, inventory scope, or verdicts

## Persistence and access
- add ReviewJobDuplicatePair with detector confidence, decision, source, distance and name evidence, and detector version
- reruns refresh current detector evidence, delete stale detector-only suggestions, and preserve user decisions
- owner-only API mutation; public results are read-only and omit dismissed suggestions

## Verification
- pnpm test: 163 passed
- pnpm run build
- pnpm run lint
- web npm run test:pricing: 3 passed
- web npm run test:ui: 17 passed
- web npm run lint
- web npm run build
- Prisma validate and generate
- git diff --check

Closes #55