### PR TITLE
fix: restore Airbnb PDP details extraction

### DIFF
--- a/src/airbnb/listing.ts
+++ b/src/airbnb/listing.ts
@@ -133,11 +133,104 @@ function stripHtml(html: string): string {
 export interface AirbnbPdpPageData {
   sections: any[];
   metadata: any;
+  node?: any;
 }
 
 type AirbnbRequest = typeof makeRequest;
 
 const MAX_DOMAIN_SWITCHES = 2;
+export const AIRBNB_DETAILS_PARSER_VERSION = 'airbnb-pdp-v2';
+
+export type AirbnbDetailsDegradationReason =
+  | 'missing_title'
+  | 'missing_rating'
+  | 'missing_amenities';
+
+function asFiniteNumber(value: unknown): number | null {
+  if (
+    value == null
+    || (typeof value === 'string' && value.trim() === '')
+  ) {
+    return null;
+  }
+
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function localizedText(value: any): string | null {
+  if (typeof value === 'string') {
+    const normalized = value.trim();
+    return normalized || null;
+  }
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidates = [
+    value.localizedStringWithTranslationPreference,
+    value.localizedString,
+    value.source,
+    value.text,
+    value.content,
+  ];
+  for (const candidate of candidates) {
+    const normalized = localizedText(candidate);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return null;
+}
+
+function parseAmenityGroups(groups: any[]): AirbnbAmenity[] {
+  const amenities: AirbnbAmenity[] = [];
+  for (const group of groups) {
+    const category = typeof group?.title === 'string' && group.title.trim()
+      ? group.title.trim()
+      : null;
+    for (const amenity of (group?.amenities || [])) {
+      const name = typeof amenity?.title === 'string'
+        ? amenity.title.trim()
+        : '';
+      if (!name) {
+        continue;
+      }
+      amenities.push({
+        name,
+        available: amenity.available ?? true,
+        category,
+      });
+    }
+  }
+  return amenities;
+}
+
+export function getAirbnbDetailsDegradationReasons(
+  details: Pick<
+    AirbnbListingDetails,
+    'title' | 'rating' | 'reviewCount' | 'amenities'
+  >,
+): AirbnbDetailsDegradationReason[] {
+  const reasons: AirbnbDetailsDegradationReason[] = [];
+  if (!details.title?.trim()) {
+    reasons.push('missing_title');
+  }
+
+  const rating = asFiniteNumber(details.rating);
+  const reviewCount = asFiniteNumber(details.reviewCount);
+  if (rating == null && reviewCount !== 0) {
+    reasons.push('missing_rating');
+  }
+
+  if (
+    !Array.isArray(details.amenities)
+    || !details.amenities.some((amenity) => amenity?.name?.trim())
+  ) {
+    reasons.push('missing_amenities');
+  }
+  return reasons;
+}
 
 export function extractAirbnbDomainSwitchOrigin(html: string): string | null {
   const formAction = html.match(
@@ -191,6 +284,7 @@ export function extractPdpSectionsFromHtml(html: string): AirbnbPdpPageData | nu
       return {
         sections,
         metadata: page?.sections?.metadata || {},
+        node: entry?.[1]?.data?.node || null,
       };
     } catch {
       // Ignore malformed script blocks and continue scanning.
@@ -298,8 +392,16 @@ function buildListingDetails(
 
 // --- Parsing ---
 
-function parseSections(sections: any[], metadata: any): Partial<AirbnbListingDetails> {
+function parseSections(
+  sections: any[],
+  metadata: any,
+  listingNode?: any,
+): Partial<AirbnbListingDetails> {
   const result: Partial<AirbnbListingDetails> = {};
+  const nodePresentation = listingNode?.pdpPresentation || {};
+  const availabilitySection = findSection(sections, 'AVAILABILITY_CALENDAR_DEFAULT')
+    || findSection(sections, 'AVAILABILITY_CALENDAR_INLINE');
+  const photoSection = findSection(sections, 'PHOTO_TOUR_SCROLLABLE_MODAL');
 
   // Title
   const titleSection = findSection(sections, 'TITLE_DEFAULT');
@@ -318,6 +420,19 @@ function parseSections(sections: any[], metadata: any): Partial<AirbnbListingDet
       result.propertyType = titleSection.shareSave?.embedData?.propertyType || null;
     }
   }
+  if (!result.title?.trim()) {
+    result.title = localizedText(nodePresentation.title)
+      || localizedText(listingNode?.description?.name)
+      || localizedText(availabilitySection?.listingTitle)
+      || localizedText(photoSection?.shareSave?.embedData?.name)
+      || '';
+  }
+  if (!result.propertyType) {
+    result.propertyType = nodePresentation.sharingConfig?.propertyType
+      || metadata?.sharingConfig?.propertyType
+      || availabilitySection?.descriptionItems?.[0]?.title
+      || null;
+  }
 
   // Description
   const descSection = findSection(sections, 'DESCRIPTION_DEFAULT');
@@ -327,7 +442,6 @@ function parseSections(sections: any[], metadata: any): Partial<AirbnbListingDet
   }
 
   // Photos from PHOTO_TOUR_SCROLLABLE_MODAL (has all photos)
-  const photoSection = findSection(sections, 'PHOTO_TOUR_SCROLLABLE_MODAL');
   if (photoSection) {
     const mediaItems = photoSection.mediaItems || [];
     result.photos = mediaItems
@@ -358,23 +472,29 @@ function parseSections(sections: any[], metadata: any): Partial<AirbnbListingDet
       result.coordinates = { lat, lng };
     }
   }
+  if (!result.coordinates) {
+    const lat = asFiniteNumber(listingNode?.location?.coordinate?.latitude);
+    const lng = asFiniteNumber(listingNode?.location?.coordinate?.longitude);
+    if (lat != null && lng != null) {
+      result.coordinates = { lat, lng };
+    }
+  }
 
   // Amenities (full list from seeAllAmenitiesGroups)
   const amenitiesSection = findSection(sections, 'AMENITIES_DEFAULT');
-  if (amenitiesSection) {
-    const groups = amenitiesSection.seeAllAmenitiesGroups || amenitiesSection.previewAmenitiesGroups || [];
-    const amenities: AirbnbAmenity[] = [];
-    for (const group of groups) {
-      const category = group.title || null;
-      for (const a of (group.amenities || [])) {
-        amenities.push({
-          name: a.title || '',
-          available: a.available ?? true,
-          category,
-        });
-      }
+  const amenitySources = [
+    amenitiesSection,
+    nodePresentation.amenities,
+  ];
+  for (const source of amenitySources) {
+    const groups = source?.seeAllAmenitiesGroups?.length
+      ? source.seeAllAmenitiesGroups
+      : source?.previewAmenitiesGroups || [];
+    const amenities = parseAmenityGroups(groups);
+    if (amenities.length > 0) {
+      result.amenities = amenities;
+      break;
     }
-    result.amenities = amenities;
   }
 
   // Host
@@ -460,6 +580,32 @@ function parseSections(sections: any[], metadata: any): Partial<AirbnbListingDet
       result.subRatings = subRatings;
     }
   }
+  const quality = nodePresentation.quality;
+  const ratingStats = quality?.listingRatingStats?.overallRatingStats;
+  if (result.rating == null) {
+    result.rating = asFiniteNumber(ratingStats?.ratingAverage)
+      ?? asFiniteNumber(metadata?.sharingConfig?.starRating);
+  }
+  if (result.reviewCount == null) {
+    result.reviewCount = asFiniteNumber(ratingStats?.ratingCount)
+      ?? asFiniteNumber(listingNode?.listingRatingStats?.overallRatingStats?.ratingCount)
+      ?? asFiniteNumber(metadata?.sharingConfig?.reviewCount);
+  }
+  if (!result.subRatings) {
+    const subRatings: Record<string, number> = {};
+    for (const category of (quality?.listingRatingStats?.categoryRatingStats || [])) {
+      const name = category?.categoryTypeA || category?.categoryType;
+      const rating = asFiniteNumber(
+        category?.value?.ratingAverage ?? category?.ratingAverage,
+      );
+      if (name && rating != null) {
+        subRatings[name] = rating;
+      }
+    }
+    if (Object.keys(subRatings).length > 0) {
+      result.subRatings = subRatings;
+    }
+  }
 
   // Pricing (from BOOK_IT_SIDEBAR)
   const bookItSection = findSection(sections, 'BOOK_IT_SIDEBAR');
@@ -487,6 +633,10 @@ function parseSections(sections: any[], metadata: any): Partial<AirbnbListingDet
         priceBreakdown: Object.keys(priceBreakdown).length > 0 ? priceBreakdown : null,
       };
     }
+  }
+  if (result.capacity == null) {
+    result.capacity = asFiniteNumber(nodePresentation.personCapacity)
+      ?? asFiniteNumber(listingNode?.personCapacity);
   }
 
   // Sleeping arrangements
@@ -545,6 +695,16 @@ function parseSections(sections: any[], metadata: any): Partial<AirbnbListingDet
   return result;
 }
 
+export function parseAirbnbPdpPageData(
+  pageData: AirbnbPdpPageData,
+): Partial<AirbnbListingDetails> {
+  return parseSections(
+    pageData.sections,
+    pageData.metadata,
+    pageData.node,
+  );
+}
+
 // --- Main API functions ---
 
 export async function fetchListingDetails(
@@ -555,7 +715,7 @@ export async function fetchListingDetails(
   let htmlFallback: AirbnbListingDetails | null = null;
   try {
     const pageData = await fetchListingPageData(roomId, options);
-    const parsedFromHtml = parseSections(pageData.sections, pageData.metadata);
+    const parsedFromHtml = parseAirbnbPdpPageData(pageData);
     const capturedAt = new Date().toISOString();
     const staySnapshot = parseAirbnbStaySnapshot({
       sections: pageData.sections,
@@ -701,7 +861,8 @@ export async function fetchListingDetails(
 
   let sections = page.sections?.sections || [];
   let snapshotSections = sections;
-  const metadata = page.sections?.metadata || {};
+  let metadata = page.sections?.metadata || {};
+  let listingNode = json?.data?.node || null;
 
   if (sections.length === 0) {
     throw new Error('No sections returned from API');
@@ -724,6 +885,8 @@ export async function fetchListingDetails(
         if (page) {
           sections = page.sections?.sections || sections;
           snapshotSections = sections;
+          metadata = page.sections?.metadata || metadata;
+          listingNode = json?.data?.node || listingNode;
         }
       } catch (err: any) {
         console.error(`Warning: Hash refresh failed: ${err.message}`);
@@ -731,7 +894,7 @@ export async function fetchListingDetails(
     }
   }
 
-  const parsed = parseSections(sections, metadata);
+  const parsed = parseSections(sections, metadata, listingNode);
 
   // If dates are provided but pricing wasn't returned, make a second request
   // specifically for BOOK_IT sections (Airbnb requires explicit sectionIds for pricing)

--- a/src/artifact-cache.ts
+++ b/src/artifact-cache.ts
@@ -65,13 +65,18 @@ export function buildDetailsCacheVariant(input: {
   checkOut?: string;
   adults?: number;
   linkedRoomId?: string | null;
+  parserVersion?: string;
 }): CacheVariant {
-  return {
+  const variant: CacheVariant = {
     checkIn: input.checkIn ?? null,
     checkOut: input.checkOut ?? null,
     adults: input.adults ?? null,
     linkedRoomId: input.linkedRoomId ?? null,
   };
+  if (input.parserVersion?.trim()) {
+    variant.parserVersion = input.parserVersion.trim();
+  }
+  return variant;
 }
 
 export function buildPhotosCacheVariant(input: {

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -171,9 +171,13 @@ interface PhaseResult {
   failed: number;
 }
 
+interface DetailsPhaseResult extends PhaseResult {
+  partial: number;
+}
+
 interface PlatformResult {
   total: number;
-  details: PhaseResult;
+  details: DetailsPhaseResult;
   reviews: PhaseResult & { totalReviewCount: number };
   photos: PhaseResult;
   aiReviews: PhaseResult;
@@ -244,6 +248,46 @@ function cacheProvenance(hit: ArtifactCacheHit) {
     cachedAt: hit.cachedAt,
     cacheAgeMs: hit.ageMs,
   };
+}
+
+function classifyAirbnbDetailsPhase(
+  details: airbnbListing.AirbnbListingDetails,
+  completeStatus: 'fetched' | 'skipped',
+  base: Omit<ManifestPhase, 'status' | 'reason'>,
+): {
+  phase: ManifestPhase;
+  degradationReasons: airbnbListing.AirbnbDetailsDegradationReason[];
+} {
+  const degradationReasons =
+    airbnbListing.getAirbnbDetailsDegradationReasons(details);
+  if (degradationReasons.length > 0) {
+    const missingFields = formatAirbnbDetailsDegradation(degradationReasons);
+    return {
+      phase: {
+        ...base,
+        status: 'partial',
+        reason: `missing_core_fields:${degradationReasons.join(',')}`,
+        error: `Airbnb details incomplete: missing ${missingFields}`,
+      },
+      degradationReasons,
+    };
+  }
+
+  return {
+    phase: {
+      ...base,
+      status: completeStatus,
+    },
+    degradationReasons,
+  };
+}
+
+function formatAirbnbDetailsDegradation(
+  reasons: airbnbListing.AirbnbDetailsDegradationReason[],
+): string {
+  return reasons
+    .map((reason) => reason.replace(/^missing_/, ''))
+    .join(', ');
 }
 
 function restoreCachedJson<T>(input: {
@@ -570,7 +614,7 @@ function shouldRetryPhase(manifest: BatchManifest, key: string, phase: 'details'
 function newPlatformResult(total: number): PlatformResult {
   return {
     total,
-    details: { fetched: 0, skipped: 0, failed: 0 },
+    details: { fetched: 0, skipped: 0, failed: 0, partial: 0 },
     reviews: { fetched: 0, skipped: 0, failed: 0, totalReviewCount: 0 },
     photos: { fetched: 0, skipped: 0, failed: 0 },
     aiReviews: { fetched: 0, skipped: 0, failed: 0 },
@@ -898,7 +942,10 @@ export async function runBatch(
         platform: 'airbnb',
         listingId: roomId,
         artifact: 'details',
-        variant: buildDetailsCacheVariant(dateOpts),
+        variant: buildDetailsCacheVariant({
+          ...dateOpts,
+          parserVersion: airbnbListing.AIRBNB_DETAILS_PARSER_VERSION,
+        }),
       };
       const reviewsCacheKey: ArtifactCacheKey = {
         platform: 'airbnb',
@@ -937,22 +984,36 @@ export async function runBatch(
         const listingsDir = getListingsDir(airbnbOutputDir);
         const detailsFile = path.join(listingsDir, `listing_${roomId}.json`);
         const relativeDetailsFile = `listings/listing_${roomId}.json`;
-        const localDetails = !options.force
+        const retryingPartialDetails =
+          isRetryListing && entry.details.status === 'partial';
+        const localDetails = !options.force && !retryingPartialDetails
           ? readJsonFile<airbnbListing.AirbnbListingDetails>(detailsFile)
           : null;
 
         if (localDetails) {
           details = localDetails;
-          statusParts.push('details \u2298 local');
-          airbnbResult.details.skipped++;
-          entry.details = {
-            status: 'skipped',
-            file: relativeDetailsFile,
-            source: 'local',
-          };
+          const classification = classifyAirbnbDetailsPhase(
+            details,
+            'skipped',
+            {
+              file: relativeDetailsFile,
+              source: 'local',
+            },
+          );
+          entry.details = classification.phase;
+          if (classification.degradationReasons.length > 0) {
+            statusParts.push(
+              `details \u26a0 local (missing: `
+              + `${formatAirbnbDetailsDegradation(classification.degradationReasons)})`,
+            );
+            airbnbResult.details.partial++;
+          } else {
+            statusParts.push('details \u2298 local');
+            airbnbResult.details.skipped++;
+          }
           await persistPhaseUpdate(options, manifest, manifestPath, manifestKey, 'details');
         } else {
-          const cachedDetails = !options.force
+          const cachedDetails = !options.force && !retryingPartialDetails
             ? restoreCachedJson<airbnbListing.AirbnbListingDetails>({
                 cache: artifactCache,
                 key: detailsCacheKey,
@@ -963,13 +1024,27 @@ export async function runBatch(
           if (cachedDetails) {
             details = cachedDetails.data;
             cacheHits.push('details');
-            statusParts.push(`details \u26a1 cache (${formatCacheAge(cachedDetails.hit.ageMs)})`);
-            airbnbResult.details.skipped++;
-            entry.details = {
-              status: 'fetched',
-              file: relativeDetailsFile,
-              ...cacheProvenance(cachedDetails.hit),
-            };
+            const classification = classifyAirbnbDetailsPhase(
+              details,
+              'fetched',
+              {
+                file: relativeDetailsFile,
+                ...cacheProvenance(cachedDetails.hit),
+              },
+            );
+            entry.details = classification.phase;
+            if (classification.degradationReasons.length > 0) {
+              statusParts.push(
+                `details \u26a0 cache (missing: `
+                + `${formatAirbnbDetailsDegradation(classification.degradationReasons)})`,
+              );
+              airbnbResult.details.partial++;
+            } else {
+              statusParts.push(
+                `details \u26a1 cache (${formatCacheAge(cachedDetails.hit.ageMs)})`,
+              );
+              airbnbResult.details.skipped++;
+            }
             await persistPhaseUpdate(options, manifest, manifestPath, manifestKey, 'details');
           } else {
             const resolvedApiKey = await ensureAirbnbApiKey();
@@ -987,13 +1062,24 @@ export async function runBatch(
                   roomId,
                   dateOpts,
                 );
+                const classification = classifyAirbnbDetailsPhase(
+                  details,
+                  'fetched',
+                  {
+                    file: relativeDetailsFile,
+                    source: 'network',
+                  },
+                );
                 if (!options.print) {
                   airbnbListing.saveListingDetails(
                     details,
                     `listing_${roomId}.json`,
                     listingsDir,
                   );
-                  if (isStaySnapshotCacheable(details.staySnapshot)) {
+                  if (
+                    classification.degradationReasons.length === 0
+                    && isStaySnapshotCacheable(details.staySnapshot)
+                  ) {
                     publishCachedFile({
                       cache: artifactCache,
                       key: detailsCacheKey,
@@ -1001,13 +1087,17 @@ export async function runBatch(
                     });
                   }
                 }
-                statusParts.push(`details \u2713 (${formatDuration(Date.now() - t)})`);
-                airbnbResult.details.fetched++;
-                entry.details = {
-                  status: 'fetched',
-                  file: relativeDetailsFile,
-                  source: 'network',
-                };
+                entry.details = classification.phase;
+                if (classification.degradationReasons.length > 0) {
+                  statusParts.push(
+                    `details \u26a0 (${formatDuration(Date.now() - t)}; missing: `
+                    + `${formatAirbnbDetailsDegradation(classification.degradationReasons)})`,
+                  );
+                  airbnbResult.details.partial++;
+                } else {
+                  statusParts.push(`details \u2713 (${formatDuration(Date.now() - t)})`);
+                  airbnbResult.details.fetched++;
+                }
                 await persistPhaseUpdate(options, manifest, manifestPath, manifestKey, 'details');
               } catch (err: any) {
                 statusParts.push('details \u2717 error');
@@ -2395,7 +2485,10 @@ export async function runBatch(
   if (preprocessed.airbnb.count > 0) {
     const { details: d, reviews: r, photos: p, aiReviews: ai, aiPhotos: ap, triage: t } = airbnbResult;
     let line = `  Airbnb:  ${airbnbResult.total} listings`;
-    if (d.fetched + d.skipped + d.failed > 0) line += ` | details: ${d.fetched}\u2713 ${d.skipped}\u2298 ${d.failed}\u2717`;
+    if (d.fetched + d.skipped + d.failed + d.partial > 0) {
+      line += ` | details: ${d.fetched}\u2713 ${d.skipped}\u2298 ${d.failed}\u2717`;
+      if (d.partial > 0) line += ` ${d.partial}\u26a0`;
+    }
     if (r.fetched + r.skipped + r.failed > 0) line += ` | reviews: ${r.fetched}\u2713 ${r.skipped}\u2298 ${r.failed}\u2717`;
     if (p.fetched + p.skipped + p.failed > 0) line += ` | photos: ${p.fetched}\u2713 ${p.skipped}\u2298 ${p.failed}\u2717`;
     if (ai.fetched + ai.skipped + ai.failed > 0) line += ` | ai-reviews: ${ai.fetched}\u2713 ${ai.skipped}\u2298 ${ai.failed}\u2717`;
@@ -2406,7 +2499,10 @@ export async function runBatch(
   if (preprocessed.booking.count > 0) {
     const { details: d, reviews: r, photos: p, aiReviews: ai, aiPhotos: ap, triage: t } = bookingResult;
     let line = `  Booking: ${bookingResult.total} listings`;
-    if (d.fetched + d.skipped + d.failed > 0) line += ` | details: ${d.fetched}\u2713 ${d.skipped}\u2298 ${d.failed}\u2717`;
+    if (d.fetched + d.skipped + d.failed + d.partial > 0) {
+      line += ` | details: ${d.fetched}\u2713 ${d.skipped}\u2298 ${d.failed}\u2717`;
+      if (d.partial > 0) line += ` ${d.partial}\u26a0`;
+    }
     if (r.fetched + r.skipped + r.failed > 0) line += ` | reviews: ${r.fetched}\u2713 ${r.skipped}\u2298 ${r.failed}\u2717`;
     if (p.fetched + p.skipped + p.failed > 0) line += ` | photos: ${p.fetched}\u2713 ${p.skipped}\u2298 ${p.failed}\u2717`;
     if (ai.fetched + ai.skipped + ai.failed > 0) line += ` | ai-reviews: ${ai.fetched}\u2713 ${ai.skipped}\u2298 ${ai.failed}\u2717`;

--- a/tests/airbnb-listing-html.test.ts
+++ b/tests/airbnb-listing-html.test.ts
@@ -1,10 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
 import {
   extractAirbnbDomainSwitchOrigin,
   extractPdpSectionsFromHtml,
   fetchListingPageData,
+  getAirbnbDetailsDegradationReasons,
+  parseAirbnbPdpPageData,
 } from '../src/airbnb/listing.js';
+
+const fixtureDir = path.resolve('tests/fixtures/airbnb-pdp');
 
 function makePdpHtml(): string {
   return `
@@ -61,6 +67,64 @@ test('extractPdpSectionsFromHtml reads PDP sections from niobeClientData script 
   assert.equal(extracted.sections.length, 2);
   assert.equal(extracted.sections[0].sectionId, 'TITLE_DEFAULT');
   assert.equal(extracted.metadata.pageTitle, 'Test Airbnb Listing page');
+});
+
+test('captured Airbnb PDP restores fields moved onto the listing node', () => {
+  const html = fs.readFileSync(
+    path.join(fixtureDir, '51945222-deferred.html'),
+    'utf8',
+  );
+  const pageData = extractPdpSectionsFromHtml(html);
+  assert.ok(pageData);
+  assert.equal(pageData.node?.__typename, 'DemandStayListing');
+
+  const parsed = parseAirbnbPdpPageData(pageData);
+  assert.equal(
+    parsed.title,
+    'Untitled 3 Freeman - Studio Queen City View',
+  );
+  assert.equal(parsed.propertyType, 'Room in hotel');
+  assert.equal(parsed.capacity, 2);
+  assert.equal(parsed.rating, 4.88);
+  assert.equal(parsed.reviewCount, 1094);
+  assert.deepEqual(parsed.subRatings, {
+    ACCURACY: 4.86,
+    CLEANLINESS: 4.9,
+  });
+  assert.deepEqual(parsed.amenities, [
+    {
+      name: 'Hair dryer',
+      available: true,
+      category: 'Bathroom',
+    },
+    {
+      name: 'Kitchen',
+      available: false,
+      category: 'Privacy and safety',
+    },
+  ]);
+});
+
+test('Airbnb details degradation distinguishes missing extraction from a new listing', () => {
+  assert.deepEqual(
+    getAirbnbDetailsDegradationReasons({
+      title: '',
+      rating: null,
+      reviewCount: null,
+      amenities: [],
+    }),
+    ['missing_title', 'missing_rating', 'missing_amenities'],
+  );
+
+  assert.deepEqual(
+    getAirbnbDetailsDegradationReasons({
+      title: 'New listing',
+      rating: null,
+      reviewCount: 0,
+      amenities: [{ name: 'Wifi', available: true, category: null }],
+    }),
+    [],
+  );
 });
 
 test('extractPdpSectionsFromHtml returns null when niobe PDP data is absent', () => {

--- a/tests/artifact-cache.test.ts
+++ b/tests/artifact-cache.test.ts
@@ -11,6 +11,7 @@ import {
   resolveArtifactCachePolicy,
   type ArtifactCacheKey,
 } from '../src/artifact-cache.js';
+import { AIRBNB_DETAILS_PARSER_VERSION } from '../src/airbnb/listing.js';
 import { runBatch } from '../src/batch.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -83,6 +84,21 @@ test('details cache isolates request variants and expires from metadata time', (
       }),
     };
     assert.equal(cache.restoreFile(differentDates, restoredPath), null);
+
+    const differentParser = {
+      ...key,
+      variant: buildDetailsCacheVariant({
+        checkIn: '2026-08-01',
+        checkOut: '2026-08-05',
+        adults: 2,
+        linkedRoomId: '123',
+        parserVersion: AIRBNB_DETAILS_PARSER_VERSION,
+      }),
+    };
+    assert.notEqual(
+      cache.getEntryPath(differentParser),
+      cache.getEntryPath(key),
+    );
 
     now += DAY_MS / 2 + 1;
     assert.equal(cache.restoreFile(key, restoredPath), null);
@@ -160,7 +176,9 @@ test('shared batch path restores all Airbnb scrape artifacts without an upstream
     JSON.stringify({
       id: roomId,
       title: 'Cached listing',
+      rating: 4.9,
       reviewCount: 1,
+      amenities: [{ name: 'Wifi', available: true, category: 'Internet' }],
       photos: [{ url: 'https://example.com/photo.jpeg', caption: null }],
     }),
   );
@@ -178,7 +196,9 @@ test('shared batch path restores all Airbnb scrape artifacts without an upstream
     platform: 'airbnb',
     listingId: roomId,
     artifact: 'details',
-    variant: buildDetailsCacheVariant({}),
+    variant: buildDetailsCacheVariant({
+      parserVersion: AIRBNB_DETAILS_PARSER_VERSION,
+    }),
   }, detailsPath);
   cache.publishFile({
     platform: 'airbnb',

--- a/tests/batch-output-paths.test.ts
+++ b/tests/batch-output-paths.test.ts
@@ -83,6 +83,79 @@ test('default batch output directories are platform-specific', () => {
   );
 });
 
+test('Airbnb details with missing core fields are recorded as partial', async () => {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'reviewr-airbnb-details-partial-'),
+  );
+  const outputDir = path.join(tempDir, 'output');
+  const listingsDir = path.join(outputDir, 'listings');
+  const urlsFile = path.join(tempDir, 'urls.txt');
+  const roomId = '51945222';
+
+  try {
+    fs.mkdirSync(listingsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(listingsDir, `listing_${roomId}.json`),
+      JSON.stringify({
+        id: roomId,
+        url: `https://www.airbnb.com/rooms/${roomId}`,
+        title: '',
+        rating: null,
+        reviewCount: null,
+        amenities: [],
+        photos: [],
+      }),
+    );
+    fs.writeFileSync(
+      urlsFile,
+      `https://www.airbnb.com/rooms/${roomId}\n`,
+    );
+
+    const result = await runBatch(
+      [urlsFile],
+      {
+        fetchDetails: true,
+        fetchReviews: false,
+        fetchPhotos: false,
+        aiReviews: false,
+        aiPhotos: false,
+        triage: false,
+        aiReviewsExplicit: false,
+        aiPhotosExplicit: false,
+        triageExplicit: false,
+        force: false,
+        retryFailed: true,
+        downloadPhotosAll: false,
+        outputDir,
+        scopeManifestToInput: true,
+        print: false,
+        artifactCache: null,
+      },
+    );
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(outputDir, 'batch_manifest.json'), 'utf8'),
+    );
+    assert.deepEqual(
+      manifest.listings[`airbnb/${roomId}`].details,
+      {
+        status: 'partial',
+        file: `listings/listing_${roomId}.json`,
+        source: 'local',
+        reason:
+          'missing_core_fields:missing_title,missing_rating,missing_amenities',
+        error:
+          'Airbnb details incomplete: missing title, rating, amenities',
+      },
+    );
+    assert.equal(result.airbnb.details.partial, 1);
+    assert.equal(result.airbnb.details.fetched, 0);
+    assert.equal(result.airbnb.details.skipped, 0);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('batch freezes one canonical requirement set and reloads it on rerun', async () => {
   const tempDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'reviewr-requirement-set-'),

--- a/tests/fixtures/airbnb-pdp/51945222-deferred.html
+++ b/tests/fixtures/airbnb-pdp/51945222-deferred.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<!--
+  Distilled provider evidence captured from the public Airbnb PDP for room
+  51945222 on 2026-07-27. The visible section wrappers are intentionally
+  typename-only; the current response stores title, rating, and amenities on
+  data.node instead.
+-->
+<html>
+  <body>
+    <script id="data-deferred-state-0" type="application/json">
+      {
+        "niobeClientData": [
+          [
+            "StaysPdpSections:{\"id\":\"U3RheUxpc3Rpbmc6NTE5NDUyMjI=\"}",
+            {
+              "data": {
+                "presentation": {
+                  "stayProductDetailPage": {
+                    "sections": {
+                      "sections": [
+                        {
+                          "sectionId": "TITLE_DEFAULT",
+                          "section": {
+                            "__typename": "PdpTitleSection"
+                          }
+                        },
+                        {
+                          "sectionId": "REVIEWS_DEFAULT",
+                          "section": {
+                            "__typename": "StayPdpReviewsSection"
+                          }
+                        },
+                        {
+                          "sectionId": "AMENITIES_DEFAULT",
+                          "section": {
+                            "__typename": "AmenitiesSection"
+                          }
+                        },
+                        {
+                          "sectionId": "AVAILABILITY_CALENDAR_DEFAULT",
+                          "section": {
+                            "__typename": "AvailabilityCalendarSection",
+                            "listingTitle": "Untitled 3 Freeman - Studio Queen City View",
+                            "descriptionItems": [
+                              {
+                                "title": "Room in hotel"
+                              }
+                            ],
+                            "maxGuestCapacity": 2
+                          }
+                        }
+                      ],
+                      "metadata": {
+                        "sharingConfig": {
+                          "propertyType": "Room in hotel",
+                          "personCapacity": 2,
+                          "reviewCount": 1094,
+                          "starRating": 4.88
+                        }
+                      }
+                    }
+                  }
+                },
+                "node": {
+                  "__typename": "DemandStayListing",
+                  "description": {
+                    "name": {
+                      "localizedStringWithTranslationPreference": "Untitled 3 Freeman - Studio Queen City View",
+                      "localizedString": "Untitled 3 Freeman - Studio Queen City View",
+                      "source": "Untitled 3 Freeman - Studio Queen City View"
+                    }
+                  },
+                  "personCapacity": 2,
+                  "pdpPresentation": {
+                    "title": {
+                      "content": {
+                        "localizedStringWithTranslationPreference": "Untitled 3 Freeman - Studio Queen City View",
+                        "localizedString": "Untitled 3 Freeman - Studio Queen City View",
+                        "source": "Untitled 3 Freeman - Studio Queen City View"
+                      }
+                    },
+                    "sharingConfig": {
+                      "propertyType": "Room in hotel"
+                    },
+                    "personCapacity": 2,
+                    "amenities": {
+                      "title": "What this place offers",
+                      "previewAmenitiesGroups": [
+                        {
+                          "title": null,
+                          "amenities": [
+                            {
+                              "available": true,
+                              "title": "Wifi"
+                            }
+                          ]
+                        }
+                      ],
+                      "seeAllAmenitiesGroups": [
+                        {
+                          "title": "Bathroom",
+                          "amenities": [
+                            {
+                              "available": true,
+                              "title": "Hair dryer"
+                            }
+                          ]
+                        },
+                        {
+                          "title": "Privacy and safety",
+                          "amenities": [
+                            {
+                              "available": false,
+                              "title": "Kitchen"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "quality": {
+                      "listingRatingStats": {
+                        "overallRatingStats": {
+                          "ratingAverage": 4.88,
+                          "ratingCount": "1094"
+                        },
+                        "categoryRatingStats": [
+                          {
+                            "categoryTypeA": "ACCURACY",
+                            "value": {
+                              "ratingAverage": 4.86
+                            }
+                          },
+                          {
+                            "categoryTypeA": "CLEANLINESS",
+                            "value": {
+                              "ratingAverage": 4.9
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        ]
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #77.

## What changed

- Read the current Airbnb PDP payload from the deferred Niobe entry's `data.node`, while preserving the legacy section-based extraction paths as first-choice fallbacks.
- Restore title, property type, capacity, rating, review count, subratings, coordinates, and full amenity groups from the current node shape.
- Classify Airbnb details as `partial` when title, rating, or amenities are unexpectedly absent, with durable manifest reason/error metadata instead of a clean `fetched` status.
- Do not publish incomplete network results to the shared details cache, and bypass an incomplete local/cache artifact on retry.
- Version the Airbnb details parser in the cache variant (`airbnb-pdp-v2`) so pre-fix cache entries miss immediately; Booking details cache keys are unchanged.
- Add a distilled fixture from the public room 51945222 PDP plus parser, degradation, manifest, and cache regressions.

## Root cause

Airbnb still returns `TITLE_DEFAULT`, `REVIEWS_DEFAULT`, and `AMENITIES_DEFAULT`, but their current section wrappers can contain only `__typename`. The populated fields moved to the same deferred-state Niobe entry's `data.node` under `pdpPresentation.title`, `pdpPresentation.amenities`, and `pdpPresentation.quality.listingRatingStats`. The old parser treated the presence of those empty shells as a successful details fetch.

## Impact

New and retried Airbnb details scrapes now restore the evidence used by triage and duplicate detection. Future extraction drift in these core fields is visible as a partial result rather than silent success.

The existing NYC job still contains pre-fix persisted Airbnb detail artifacts. After deployment it needs a details-only re-scrape (no AI phases) to receive the repaired fields; this PR intentionally does not mutate persisted jobs automatically.

## Validation

- `pnpm run build`
- `pnpm test` — 167 passed
- `pnpm run lint`
- `git diff --check`
- Live direct PDP smoke, room 51945222: exact title restored, rating 4.88 / 1,094 reviews, 36 amenities, 18 photos.
- Live direct PDP smoke, room 1481795634184063118: exact title restored, rating 4.85 / 75 reviews, 37 amenities, 7 photos.
- Temp details-only batch for room 51945222 completed with manifest status `fetched` from `network`.

No live checkout, database, Docker service, or persisted job artifact was changed.
