### PR TITLE
feat: add listings by URL to existing review jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ reviewr report -o data/rome --priorities-matrix
 reviewr ask "Is there free parking? ZTL zone?" --picks liked -o data/rome
 reviewr ask "How noisy at night?" --ids 12345,mamomi-house -o data/rome
 
+# Add URLs to an existing StayReviewr job and analyze only the new listings
+STAYREVIEWR_OWNER_KEY="<stayreviewr_owner cookie>" \
+  reviewr job add <job-id> \
+  "https://www.booking.com/hotel/us/hotel-hugo.html" \
+  "https://www.airbnb.com/rooms/12345"
+
 # Analytics
 reviewr analytics --booking
 reviewr analytics --airbnb --12m
@@ -142,6 +148,7 @@ npx tsx src/cli.ts <command> [options]
 | `reviewr analyze-photos <dir>` | AI photo analysis using Gemini vision |
 | `reviewr triage <file>` | AI triage -- grade listing against guest priorities |
 | `reviewr ask <question>` | Ask a question about shortlisted properties |
+| `reviewr job add <job-id> <urls...>` | Add URLs to a persistent StayReviewr job and analyze only new listings |
 | `reviewr report` | Generate HTML report; add `--priorities-matrix [file]` for the evidence matrix JSON |
 | `reviewr scrape [path]` | Batch scrape reviews from CSV files |
 | `reviewr analytics [path]` | Run analytics on JSON output |
@@ -180,6 +187,12 @@ PROXY_PASSWORD=your_password
 Set `USE_PROXY=false` to disable proxy usage.
 `PROXY_PROTOCOL` defaults to `http` for existing configurations. Set it to `https` for a TLS
 connection to the proxy endpoint; both values can still carry HTTPS destination traffic.
+
+`reviewr job add` calls the running StayReviewr web app. Pass its URL with
+`--base-url` or `STAYREVIEWR_BASE_URL` (default `http://localhost:3000`) and authenticate with
+`--owner-key` or `STAYREVIEWR_OWNER_KEY`. The owner key is the value of the browser's
+`stayreviewr_owner` cookie and should be treated as a credential. URLs already present in the
+job are reported as no-ops and are not queued again.
 
 AI analysis has two configurable cost guardrails:
 

--- a/docs/review-job-analysis-parity.md
+++ b/docs/review-job-analysis-parity.md
@@ -152,6 +152,23 @@ the same temporary file inputs that `runAnalyze`, `runAnalyzePhotos`, and
 - One review job has one snapshot date range. Run separate jobs for multi-leg trips; issue #70
   tracks multi-leg support.
 
+## Targeted URL additions
+
+- Adding Airbnb or Booking.com URLs to an existing job uses an additive run workspace. The
+  prior manifest and artifacts are cloned without pruning existing entries.
+- Only newly created listing rows are input to the scrape phases. Existing URLs are explicit
+  no-ops, so a repeat cannot create a second row or spend money.
+- AI and triage phases are explicitly scoped to the new input keys, even when a pre-existing
+  entry is partial or failed. The cost profile is therefore scrape plus AI for the new URLs only;
+  untouched listings are persisted reads only.
+- Database synchronization is restricted to the new listing row IDs. Existing analyses,
+  verdicts, per-listing costs, selection/like/hide flags, and duplicate-pair decisions are not
+  rewritten. Job-level costs remain the exact aggregate of the unchanged prior costs plus the
+  new listing costs.
+- Duplicate detection is incremental: it may create a new suggested pair involving an added
+  listing, but never updates or deletes a pre-existing pair during the add run.
+- The combined HTML report is regenerated from the merged manifest after the targeted run.
+
 ## Persistence Goals For The Web Job
 
 The web job should persist:

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -71,6 +71,8 @@ export interface BatchOptions {
   outputDir?: string;
   /** Keep a normal file-backed run's manifest limited to its current input. */
   scopeManifestToInput?: boolean;
+  /** Run AI and triage only for current input while retaining other manifest entries. */
+  scopePostScrapePhasesToInput?: boolean;
   print: boolean;
   programmatic?: boolean;
   hooks?: BatchHooks;
@@ -783,25 +785,32 @@ export async function runBatch(
   const preprocessed = filePaths.length > 0
     ? preprocessFiles(filePaths)
     : { airbnb: { urls: [] as string[], count: 0, duplicatesRemoved: 0 }, booking: { urls: [] as string[], count: 0, duplicatesRemoved: 0 }, dates: { source: 'none' as const, checkIn: undefined, checkOut: undefined, adults: undefined } };
+  const currentInputManifestKeys = new Set<string>();
+  for (const url of preprocessed.airbnb.urls) {
+    currentInputManifestKeys.add(
+      `airbnb/${airbnbListing.parseAirbnbUrl(url).roomId}`,
+    );
+  }
+  for (const url of preprocessed.booking.urls) {
+    const hotelInfo = bookingScraper.extractHotelInfo(url);
+    if (hotelInfo) {
+      currentInputManifestKeys.add(`booking/${hotelInfo.hotel_name}`);
+    }
+  }
+
+  if (
+    (options.scopeManifestToInput || options.scopePostScrapePhasesToInput)
+    && !options.retryFailed
+    && filePaths.length > 0
+    && currentInputManifestKeys.size === 0
+  ) {
+    throw new Error('No valid Airbnb or Booking URLs found in the input files.');
+  }
 
   if (options.scopeManifestToInput && !options.retryFailed && filePaths.length > 0) {
-    const currentManifestKeys = new Set<string>();
-
-    for (const url of preprocessed.airbnb.urls) {
-      currentManifestKeys.add(`airbnb/${airbnbListing.parseAirbnbUrl(url).roomId}`);
-    }
-    for (const url of preprocessed.booking.urls) {
-      const hotelInfo = bookingScraper.extractHotelInfo(url);
-      if (hotelInfo) currentManifestKeys.add(`booking/${hotelInfo.hotel_name}`);
-    }
-
-    if (currentManifestKeys.size === 0) {
-      throw new Error('No valid Airbnb or Booking URLs found in the input files.');
-    }
-
     const scopedListings = Object.fromEntries(
       Object.entries(manifest.listings)
-        .filter(([key]) => currentManifestKeys.has(key)),
+        .filter(([key]) => currentInputManifestKeys.has(key)),
     );
     const removedListingCount =
       Object.keys(manifest.listings).length - Object.keys(scopedListings).length;
@@ -818,6 +827,13 @@ export async function runBatch(
   // 3. If --retry, merge retry URLs from manifest
   if (options.retryFailed) {
     for (const [key, entry] of Object.entries(manifest.listings)) {
+      if (
+        options.scopePostScrapePhasesToInput
+        && currentInputManifestKeys.size > 0
+        && !currentInputManifestKeys.has(key)
+      ) {
+        continue;
+      }
       const needsRetry = entry.details.status === 'failed' || entry.details.status === 'partial'
         || entry.reviews.status === 'failed' || entry.reviews.status === 'partial'
         || entry.photos.status === 'failed' || entry.photos.status === 'partial'
@@ -1858,7 +1874,10 @@ export async function runBatch(
         message: `Starting AI review analysis (${modelConfig.model})`,
       });
       let aiIndex = 0;
-      const aiEntries = Object.entries(manifest.listings);
+      const aiEntries = Object.entries(manifest.listings)
+        .filter(([manifestKey]) =>
+          !options.scopePostScrapePhasesToInput
+          || currentInputManifestKeys.has(manifestKey));
       for (const [manifestKey, entry] of aiEntries) {
         aiIndex++;
         const prefix = `[${aiIndex}/${aiEntries.length}] ${manifestKey}`;
@@ -2041,7 +2060,10 @@ export async function runBatch(
         message: `Starting AI photo analysis (${modelConfig.model})`,
       });
       let aiIndex = 0;
-      const aiEntries = Object.entries(manifest.listings);
+      const aiEntries = Object.entries(manifest.listings)
+        .filter(([manifestKey]) =>
+          !options.scopePostScrapePhasesToInput
+          || currentInputManifestKeys.has(manifestKey));
       for (const [manifestKey, entry] of aiEntries) {
         aiIndex++;
         const prefix = `[${aiIndex}/${aiEntries.length}] ${manifestKey}`;
@@ -2238,7 +2260,10 @@ export async function runBatch(
         );
       }
       let triageIndex = 0;
-      const triageEntries = Object.entries(manifest.listings);
+      const triageEntries = Object.entries(manifest.listings)
+        .filter(([manifestKey]) =>
+          !options.scopePostScrapePhasesToInput
+          || currentInputManifestKeys.has(manifestKey));
       for (const [manifestKey, entry] of triageEntries) {
         triageIndex++;
         const prefix = `[${triageIndex}/${triageEntries.length}] ${manifestKey}`;
@@ -2514,13 +2539,26 @@ export async function runBatch(
 
   // Sum AI costs from manifest
   let totalCost = 0;
-  for (const entry of Object.values(manifest.listings)) {
+  for (const [manifestKey, entry] of Object.entries(manifest.listings)) {
+    if (
+      options.scopePostScrapePhasesToInput
+      && !currentInputManifestKeys.has(manifestKey)
+    ) {
+      continue;
+    }
     if (entry.aiReviews?.cost) totalCost += entry.aiReviews.cost;
     if (entry.aiPhotos?.cost) totalCost += entry.aiPhotos.cost;
     if (entry.triage?.cost) totalCost += entry.triage.cost;
   }
   if (totalCost > 0) {
-    console.log(`  AI cost: $${totalCost.toFixed(2)} (all phases, all listings in manifest)`);
+    console.log(
+      `  AI cost: $${totalCost.toFixed(2)} `
+      + (
+        options.scopePostScrapePhasesToInput
+          ? '(current input only)'
+          : '(all phases, all listings in manifest)'
+      ),
+    );
   }
 
   const allErrors = [...airbnbResult.errors, ...bookingResult.errors];
@@ -2533,7 +2571,13 @@ export async function runBatch(
 
   // Count failures/partials in manifest for retry hint
   let failureCount = 0;
-  for (const entry of Object.values(manifest.listings)) {
+  for (const [manifestKey, entry] of Object.entries(manifest.listings)) {
+    if (
+      options.scopePostScrapePhasesToInput
+      && !currentInputManifestKeys.has(manifestKey)
+    ) {
+      continue;
+    }
     if (entry.details.status === 'failed' || entry.details.status === 'partial'
       || entry.reviews.status === 'failed' || entry.reviews.status === 'partial'
       || entry.photos.status === 'failed' || entry.photos.status === 'partial'
@@ -2555,7 +2599,11 @@ export async function runBatch(
       message: `${failureCount} listing${failureCount > 1 ? 's' : ''} with failures \u2014 auto-retrying`,
       payload: { failureCount },
     });
-    await runBatch([], { ...options, retryFailed: true }, dependencies);
+    await runBatch(
+      options.scopePostScrapePhasesToInput ? filePaths : [],
+      { ...options, retryFailed: true },
+      dependencies,
+    );
   } else if (failureCount > 0) {
     console.log(`  ${failureCount} listing${failureCount > 1 ? 's' : ''} still failing \u2014 retry with: reviewr batch ${manifestPath} --retry`);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -651,6 +651,54 @@ program
     }
   });
 
+// --- job command: persistent StayReviewr job operations ---
+const jobCommand = program
+  .command('job')
+  .description('Manage persistent StayReviewr review jobs');
+
+jobCommand
+  .command('add <job-id> <urls...>')
+  .description(
+    'Add Airbnb or Booking.com URLs to an existing job and analyze only the new listings',
+  )
+  .option(
+    '--base-url <url>',
+    'StayReviewr web URL (default: STAYREVIEWR_BASE_URL or http://localhost:3000)',
+  )
+  .option(
+    '--owner-key <key>',
+    'Job owner key (default: STAYREVIEWR_OWNER_KEY)',
+  )
+  .action(async (
+    jobId: string,
+    urls: string[],
+    cmdOpts: {
+      baseUrl?: string;
+      ownerKey?: string;
+    },
+  ) => {
+    const {
+      addListingsToReviewJob,
+      DEFAULT_REVIEW_JOB_BASE_URL,
+      REVIEW_JOB_BASE_URL_ENV,
+      REVIEW_JOB_OWNER_KEY_ENV,
+    } = await import('./review-job-client.js');
+    const result = await addListingsToReviewJob({
+      jobId,
+      urls,
+      ownerKey:
+        cmdOpts.ownerKey
+        ?? process.env[REVIEW_JOB_OWNER_KEY_ENV]
+        ?? '',
+      baseUrl:
+        cmdOpts.baseUrl
+        ?? process.env[REVIEW_JOB_BASE_URL_ENV]
+        ?? DEFAULT_REVIEW_JOB_BASE_URL,
+    });
+
+    console.log(result.message);
+  });
+
 // --- auth command ---
 program
   .command('auth [proxy-url]')

--- a/src/listing-url.ts
+++ b/src/listing-url.ts
@@ -1,0 +1,164 @@
+import type { Platform } from './utils.js';
+
+export interface ParsedListingUrl {
+  platform: Platform;
+  listingId: string;
+  normalizedUrl: string;
+  matchKey: string;
+  displayName: string;
+}
+
+export interface InvalidListingUrl {
+  input: string;
+  error: string;
+}
+
+export interface ParsedListingUrlBatch {
+  listings: ParsedListingUrl[];
+  invalid: InvalidListingUrl[];
+  duplicateCount: number;
+}
+
+function parseUrl(input: string): URL {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('URL is empty');
+  }
+
+  const withProtocol = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(withProtocol);
+  } catch {
+    throw new Error('URL is malformed');
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error('URL must use http or https');
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error('URL credentials are not supported');
+  }
+
+  return parsed;
+}
+
+function isBookingHost(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  return lower === 'booking.com' || lower.endsWith('.booking.com');
+}
+
+function isAirbnbHost(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  return (
+    lower === 'airbnb.com'
+    || lower.endsWith('.airbnb.com')
+    || /(^|\.)airbnb\.(?:com(?:\.[a-z]{2})?|[a-z]{2}(?:\.[a-z]{2})?)$/.test(lower)
+  );
+}
+
+function titleFromSlug(slug: string): string {
+  return slug
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function parseAirbnbListingUrl(parsed: URL): ParsedListingUrl {
+  const roomId = parsed.pathname.match(/^\/rooms\/(\d+)(?:\/|$)/i)?.[1];
+  if (!roomId) {
+    throw new Error('Airbnb URL must contain /rooms/<numeric-id>');
+  }
+
+  return {
+    platform: 'airbnb',
+    listingId: roomId,
+    normalizedUrl: `https://www.airbnb.com/rooms/${roomId}`,
+    matchKey: `airbnb:${roomId}`,
+    displayName: `Airbnb ${roomId}`,
+  };
+}
+
+function parseBookingListingUrl(parsed: URL): ParsedListingUrl {
+  const pathMatch = parsed.pathname.match(
+    /^\/hotel\/([a-z]{2})\/([^/]+)\.html\/?$/i,
+  );
+  if (!pathMatch) {
+    throw new Error(
+      'Booking.com URL must contain /hotel/<country>/<hotel>.html',
+    );
+  }
+
+  const countryCode = pathMatch[1].toLowerCase();
+  const filenameStem = pathMatch[2];
+  const hotelSlug = filenameStem
+    .replace(/\.[a-z]{2}(?:-[a-z]{2})?$/i, '')
+    .toLowerCase();
+  if (!hotelSlug || !/^[a-z0-9][a-z0-9_-]*$/i.test(hotelSlug)) {
+    throw new Error('Booking.com URL has an invalid hotel slug');
+  }
+
+  const normalized = new URL(
+    `https://www.booking.com/hotel/${countryCode}/${hotelSlug}.en-gb.html`,
+  );
+  const matchingBlockId =
+    parsed.searchParams.get('matching_block_id')
+    ?? parsed.searchParams.get('highlighted_blocks');
+  if (matchingBlockId) {
+    normalized.searchParams.set('matching_block_id', matchingBlockId);
+  }
+
+  return {
+    platform: 'booking',
+    listingId: `${countryCode}/${hotelSlug}`,
+    normalizedUrl: normalized.toString(),
+    matchKey: `booking:${countryCode}/${hotelSlug}`,
+    displayName: titleFromSlug(hotelSlug),
+  };
+}
+
+export function parseListingUrl(input: string): ParsedListingUrl {
+  const parsed = parseUrl(input);
+
+  if (isAirbnbHost(parsed.hostname)) {
+    return parseAirbnbListingUrl(parsed);
+  }
+  if (isBookingHost(parsed.hostname)) {
+    return parseBookingListingUrl(parsed);
+  }
+
+  throw new Error('Only Airbnb and Booking.com listing URLs are supported');
+}
+
+export function parseListingUrls(
+  inputs: readonly string[],
+): ParsedListingUrlBatch {
+  const listingsByKey = new Map<string, ParsedListingUrl>();
+  const invalid: InvalidListingUrl[] = [];
+  let duplicateCount = 0;
+
+  for (const input of inputs) {
+    try {
+      const parsed = parseListingUrl(input);
+      if (listingsByKey.has(parsed.matchKey)) {
+        duplicateCount += 1;
+        continue;
+      }
+      listingsByKey.set(parsed.matchKey, parsed);
+    } catch (error) {
+      invalid.push({
+        input,
+        error: error instanceof Error ? error.message : 'URL is invalid',
+      });
+    }
+  }
+
+  return {
+    listings: [...listingsByKey.values()],
+    invalid,
+    duplicateCount,
+  };
+}

--- a/src/review-job-client.ts
+++ b/src/review-job-client.ts
@@ -1,0 +1,94 @@
+import { parseListingUrls } from './listing-url.js';
+
+export const REVIEW_JOB_OWNER_KEY_ENV = 'STAYREVIEWR_OWNER_KEY';
+export const REVIEW_JOB_BASE_URL_ENV = 'STAYREVIEWR_BASE_URL';
+export const DEFAULT_REVIEW_JOB_BASE_URL = 'http://localhost:3000';
+const OWNER_KEY_COOKIE = 'stayreviewr_owner';
+
+export interface AddReviewJobListingsResponse {
+  jobId: string;
+  status: 'queued' | 'unchanged';
+  addedCount: number;
+  duplicateCount: number;
+  listingCount: number;
+  message: string;
+}
+
+interface AddReviewJobListingsOptions {
+  jobId: string;
+  urls: string[];
+  ownerKey: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+function formatInvalidUrls(
+  invalid: Array<{ input: string; error: string }>,
+): string {
+  return invalid
+    .map((item) => `${item.input || '(empty)'}: ${item.error}`)
+    .join('; ');
+}
+
+export async function addListingsToReviewJob(
+  options: AddReviewJobListingsOptions,
+): Promise<AddReviewJobListingsResponse> {
+  const ownerKey = options.ownerKey.trim();
+  if (!ownerKey) {
+    throw new Error(
+      `An owner key is required. Pass --owner-key or set `
+      + `${REVIEW_JOB_OWNER_KEY_ENV}.`,
+    );
+  }
+
+  const parsed = parseListingUrls(options.urls);
+  if (parsed.invalid.length > 0) {
+    throw new Error(`Invalid listing URL(s): ${formatInvalidUrls(parsed.invalid)}`);
+  }
+  if (parsed.listings.length === 0) {
+    throw new Error('Provide at least one Airbnb or Booking.com listing URL.');
+  }
+
+  const baseUrl = options.baseUrl?.trim() || DEFAULT_REVIEW_JOB_BASE_URL;
+  let endpoint: URL;
+  try {
+    endpoint = new URL(
+      `/api/jobs/${encodeURIComponent(options.jobId)}/listings`,
+      baseUrl,
+    );
+  } catch {
+    throw new Error(`Invalid StayReviewr base URL: ${baseUrl}`);
+  }
+  if (endpoint.protocol !== 'http:' && endpoint.protocol !== 'https:') {
+    throw new Error('StayReviewr base URL must use http or https.');
+  }
+
+  const response = await (options.fetchImpl ?? fetch)(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Cookie: `${OWNER_KEY_COOKIE}=${encodeURIComponent(ownerKey)}`,
+    },
+    body: JSON.stringify({
+      urls: parsed.listings.map((listing) => listing.normalizedUrl),
+    }),
+  });
+  const payload = await response.json().catch(() => null) as
+    | Partial<AddReviewJobListingsResponse> & { error?: string }
+    | null;
+  if (!response.ok) {
+    throw new Error(
+      payload?.error
+      || `StayReviewr returned HTTP ${response.status}.`,
+    );
+  }
+  if (
+    !payload
+    || typeof payload.message !== 'string'
+    || (payload.status !== 'queued' && payload.status !== 'unchanged')
+  ) {
+    throw new Error('StayReviewr returned an invalid add-listings response.');
+  }
+
+  return payload as AddReviewJobListingsResponse;
+}

--- a/tests/batch-output-paths.test.ts
+++ b/tests/batch-output-paths.test.ts
@@ -514,6 +514,221 @@ test('default-dir resumed Booking artifacts remain eligible for every AI phase',
   }
 });
 
+test('additive batch analysis never retries incomplete old AI and preserves its artifacts', async () => {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'reviewr-targeted-add-ai-'),
+  );
+  const outputDir = path.join(tempDir, 'output');
+  const urlsFile = path.join(tempDir, 'new-urls.txt');
+  const oldId = 'existing-hotel';
+  const newId = 'new-hotel';
+  const oldUrl =
+    `https://www.booking.com/hotel/us/${oldId}.en-gb.html`;
+  const newUrl =
+    `https://www.booking.com/hotel/us/${newId}.en-gb.html`;
+  const originalGeminiApiKey = process.env.GEMINI_API_KEY;
+
+  try {
+    const oldFixture = writeBookingFixture(outputDir, oldId, oldUrl);
+    const newFixture = writeBookingFixture(outputDir, newId, newUrl);
+    const oldAiReviews = path.join(outputDir, 'ai-reviews', `${oldId}.json`);
+    const oldAiPhotos = path.join(outputDir, 'ai-photos', `${oldId}.json`);
+    const oldTriage = path.join(outputDir, 'triage', `${oldId}.json`);
+    fs.mkdirSync(path.dirname(oldAiReviews), { recursive: true });
+    fs.mkdirSync(path.dirname(oldAiPhotos), { recursive: true });
+    fs.mkdirSync(path.dirname(oldTriage), { recursive: true });
+    fs.writeFileSync(oldAiReviews, '{"summary":"paid review evidence"}\n');
+    fs.writeFileSync(oldAiPhotos, '{"summary":"paid photo evidence"}\n');
+    fs.writeFileSync(oldTriage, '{"tier":"shortlist","fitScore":93}\n');
+
+    const oldEntry = {
+      platform: 'booking',
+      id: oldId,
+      url: oldUrl,
+      details: {
+        status: 'partial',
+        file: `listings/listing_${oldId}.json`,
+        source: 'network',
+        reason: 'prior partial details',
+      },
+      reviews: {
+        status: 'partial',
+        file: `reviews/${oldId}_reviews.json`,
+        count: 1,
+        source: 'network',
+        reason: 'prior partial reviews',
+      },
+      photos: {
+        status: 'failed',
+        dir: `photos/${oldId}`,
+        count: 1,
+        source: 'network',
+        error: 'prior failed photos',
+      },
+      aiReviews: {
+        status: 'partial',
+        file: `ai-reviews/${oldId}.json`,
+        model: 'paid-model',
+        cost: 0.41,
+        reason: 'prior partial result',
+      },
+      aiPhotos: {
+        status: 'failed',
+        file: `ai-photos/${oldId}.json`,
+        model: 'paid-model',
+        cost: 0.22,
+        error: 'prior failed result',
+      },
+      triage: {
+        status: 'partial',
+        file: `triage/${oldId}.json`,
+        model: 'paid-model',
+        cost: 0.03,
+        reason: 'prior partial verdict',
+        evidenceGaps: [],
+      },
+    };
+    const manifestPath = path.join(outputDir, 'batch_manifest.json');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      version: 2,
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+      dates: {},
+      listings: {
+        [`booking/${oldId}`]: oldEntry,
+      },
+    }, null, 2));
+    fs.writeFileSync(urlsFile, `${newUrl}\n`);
+
+    const oldArtifactPaths = [
+      oldFixture.listingFile,
+      oldFixture.reviewsFile,
+      path.join(oldFixture.photosDir, 'one.jpg'),
+      oldAiReviews,
+      oldAiPhotos,
+      oldTriage,
+    ];
+    const oldArtifactBytes = new Map(
+      oldArtifactPaths.map((filePath) => [
+        filePath,
+        fs.readFileSync(filePath),
+      ]),
+    );
+    const analyzerListingIds: string[] = [];
+    const phaseEventListingIds: string[] = [];
+    process.env.GEMINI_API_KEY = 'fixture-key';
+
+    const result = await runBatch(
+      [urlsFile],
+      {
+        fetchDetails: true,
+        fetchReviews: true,
+        fetchPhotos: true,
+        aiReviews: true,
+        aiPhotos: true,
+        triage: true,
+        aiReviewsExplicit: true,
+        aiPhotosExplicit: true,
+        triageExplicit: true,
+        force: false,
+        retryFailed: false,
+        downloadPhotosAll: false,
+        scopeManifestToInput: false,
+        scopePostScrapePhasesToInput: true,
+        outputDir,
+        print: false,
+        artifactCache: null,
+        hooks: {
+          onEvent: (event) => {
+            if (event.listingId) {
+              phaseEventListingIds.push(event.listingId);
+            }
+          },
+        },
+      },
+      {
+        runAnalyze: async (options) => {
+          analyzerListingIds.push(
+            `reviews:${path.basename(options.listingFile!)}`,
+          );
+          return {
+            data: { summary: 'new review evidence' },
+            model: 'fixture-model',
+            provider: 'gemini',
+            multiYear: false,
+            reviewSelection: {
+              eligibleCount: 1,
+              includedCount: 1,
+              limit: 250,
+              capped: false,
+            },
+          };
+        },
+        runAnalyzePhotos: async (options) => {
+          analyzerListingIds.push(
+            `photos:${path.basename(options.listingFile!)}`,
+          );
+          return {
+            data: { highlights: ['new photo evidence'] },
+            model: 'fixture-model',
+            provider: 'gemini',
+            photoCount: 1,
+          };
+        },
+        runTriage: async (options) => {
+          analyzerListingIds.push(
+            `triage:${path.basename(options.listingFile)}`,
+          );
+          return {
+            data: { tier: 'consider', fitScore: 72 },
+            model: 'fixture-model',
+            provider: 'gemini',
+            classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+            modelId: 'gemini:fixture-model:default',
+            requirementSet:
+              options.requirementSet ?? fixtureRequirementSet,
+            evidenceGaps: [],
+          };
+        },
+      },
+    );
+
+    assert.deepEqual(analyzerListingIds, [
+      `reviews:${path.basename(newFixture.listingFile)}`,
+      `photos:${path.basename(newFixture.listingFile)}`,
+      `triage:${path.basename(newFixture.listingFile)}`,
+    ]);
+    assert.equal(phaseEventListingIds.includes(oldId), false);
+    const finalManifest = JSON.parse(
+      fs.readFileSync(manifestPath, 'utf8'),
+    );
+    assert.deepEqual(
+      finalManifest.listings[`booking/${oldId}`],
+      oldEntry,
+    );
+    for (const [filePath, bytes] of oldArtifactBytes) {
+      assert.deepEqual(
+        fs.readFileSync(filePath),
+        bytes,
+        `existing artifact changed: ${filePath}`,
+      );
+    }
+    assert.equal(result.booking.aiReviews.fetched, 1);
+    assert.equal(result.booking.aiReviews.skipped, 0);
+    assert.equal(result.booking.aiPhotos.fetched, 1);
+    assert.equal(result.booking.aiPhotos.skipped, 0);
+    assert.equal(result.booking.triage.fetched, 1);
+    assert.equal(result.booking.triage.skipped, 0);
+  } finally {
+    if (originalGeminiApiKey == null) {
+      delete process.env.GEMINI_API_KEY;
+    } else {
+      process.env.GEMINI_API_KEY = originalGeminiApiKey;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('triage records missing review evidence in its artifact and manifest', async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reviewr-triage-gaps-'));
   const outputDir = path.join(tempDir, 'output');

--- a/tests/listing-url.test.ts
+++ b/tests/listing-url.test.ts
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseListingUrl,
+  parseListingUrls,
+} from '../src/listing-url.js';
+
+test('listing URL parsing normalizes Airbnb and Booking identities', () => {
+  assert.deepEqual(
+    parseListingUrl(
+      'https://www.airbnb.co.uk/rooms/12345678?check_in=2026-08-01',
+    ),
+    {
+      platform: 'airbnb',
+      listingId: '12345678',
+      normalizedUrl: 'https://www.airbnb.com/rooms/12345678',
+      matchKey: 'airbnb:12345678',
+      displayName: 'Airbnb 12345678',
+    },
+  );
+
+  assert.deepEqual(
+    parseListingUrl(
+      'www.booking.com/hotel/US/hotel-hugo.en-gb.html'
+      + '?aid=1&highlighted_blocks=123_456',
+    ),
+    {
+      platform: 'booking',
+      listingId: 'us/hotel-hugo',
+      normalizedUrl:
+        'https://www.booking.com/hotel/us/hotel-hugo.en-gb.html'
+        + '?matching_block_id=123_456',
+      matchKey: 'booking:us/hotel-hugo',
+      displayName: 'Hotel Hugo',
+    },
+  );
+});
+
+test('listing URL batches reject unsupported inputs and deduplicate by identity', () => {
+  const parsed = parseListingUrls([
+    'https://www.airbnb.com/rooms/123',
+    'https://airbnb.pl/rooms/123?source=map',
+    'https://www.booking.com/hotel/us/hotel-hugo.html',
+    'https://example.com/rooms/999',
+    'not a URL',
+  ]);
+
+  assert.deepEqual(
+    parsed.listings.map((listing) => listing.matchKey),
+    ['airbnb:123', 'booking:us/hotel-hugo'],
+  );
+  assert.equal(parsed.duplicateCount, 1);
+  assert.equal(parsed.invalid.length, 2);
+  assert.match(parsed.invalid[0].error, /Only Airbnb and Booking/);
+  assert.match(parsed.invalid[1].error, /Only Airbnb and Booking|malformed/);
+});
+
+test('listing URL parsing rejects lookalike hosts and non-listing paths', () => {
+  assert.throws(
+    () => parseListingUrl('https://evil-airbnb.com/rooms/123'),
+    /Only Airbnb and Booking/,
+  );
+  assert.throws(
+    () => parseListingUrl('https://www.booking.com/searchresults.html'),
+    /must contain/,
+  );
+  assert.throws(
+    () => parseListingUrl('javascript://www.airbnb.com/rooms/123'),
+    /http or https/,
+  );
+});

--- a/tests/review-job-add-listings.test.ts
+++ b/tests/review-job-add-listings.test.ts
@@ -1,0 +1,142 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseListingUrls } from '../src/listing-url.js';
+import {
+  addNewReviewJobListings,
+  toAddedReviewJobListingRecord,
+} from '../web/src/lib/reviewJobAddListings.js';
+
+test('added listing rows use stable URL-derived identities and placeholders', () => {
+  const parsed = parseListingUrls([
+    'https://www.booking.com/hotel/us/hotel-hugo.html',
+  ]).listings[0];
+
+  assert.deepEqual(
+    toAddedReviewJobListingRecord('job_1', parsed),
+    {
+      jobId: 'job_1',
+      listingId: 'us/hotel-hugo',
+      platform: 'booking',
+      name: 'Hotel Hugo',
+      url: 'https://www.booking.com/hotel/us/hotel-hugo.en-gb.html',
+      reviewCount: 0,
+    },
+  );
+});
+
+test('duplicate URLs are byte-preserving no-ops, including search-derived Booking rows', async () => {
+  const existingRows = [{
+    id: 'row_existing',
+    jobId: 'job_1',
+    listingId: '987654',
+    platform: 'booking' as const,
+    name: 'Hotel Hugo',
+    url: 'https://www.booking.com/hotel/us/hotel-hugo.html',
+    selected: true,
+    liked: true,
+    hidden: false,
+    analysis: {
+      status: 'completed',
+      triage: { fitScore: 91 },
+      totalAiCostUsd: 1.23,
+    },
+  }];
+  const before = structuredClone(existingRows);
+  let createCalls = 0;
+  let analysisCreateCalls = 0;
+  const client = {
+    reviewJobListing: {
+      findMany: async () => existingRows,
+      createMany: async () => {
+        createCalls += 1;
+        return { count: 1 };
+      },
+    },
+    reviewJobListingAnalysis: {
+      createMany: async () => {
+        analysisCreateCalls += 1;
+        return { count: 1 };
+      },
+    },
+  };
+
+  const result = await addNewReviewJobListings(
+    client as never,
+    'job_1',
+    parseListingUrls([
+      'https://www.booking.com/hotel/us/hotel-hugo.en-gb.html?aid=123',
+    ]).listings,
+  );
+
+  assert.deepEqual(result, {
+    addedListingRowIds: [],
+    addedCount: 0,
+    existingCount: 1,
+  });
+  assert.equal(createCalls, 0);
+  assert.equal(analysisCreateCalls, 0);
+  assert.deepEqual(existingRows, before);
+});
+
+test('only genuinely new URLs create listing and analysis rows', async () => {
+  const rows = [{
+    id: 'row_existing',
+    listingId: '123',
+    platform: 'airbnb' as const,
+    url: 'https://www.airbnb.com/rooms/123',
+  }];
+  const createdRecords: Array<Record<string, unknown>> = [];
+  const analysisRecords: Array<Record<string, unknown>> = [];
+  const client = {
+    reviewJobListing: {
+      findMany: async (args: {
+        where?: { OR?: Array<{ listingId: string; platform: string }> };
+      }) => {
+        if (!args.where?.OR) {
+          return rows;
+        }
+        return rows.filter((row) =>
+          args.where?.OR?.some((candidate) =>
+            candidate.listingId === row.listingId
+            && candidate.platform === row.platform));
+      },
+      createMany: async (args: {
+        data: Array<Record<string, unknown>>;
+      }) => {
+        const record = args.data[0];
+        createdRecords.push(record);
+        rows.push({
+          id: `row_${record.listingId}`,
+          listingId: String(record.listingId),
+          platform: record.platform as 'airbnb',
+          url: String(record.url),
+        });
+        return { count: 1 };
+      },
+    },
+    reviewJobListingAnalysis: {
+      createMany: async (args: {
+        data: Array<Record<string, unknown>>;
+      }) => {
+        analysisRecords.push(...args.data);
+        return { count: args.data.length };
+      },
+    },
+  };
+
+  const result = await addNewReviewJobListings(
+    client as never,
+    'job_1',
+    parseListingUrls([
+      'https://www.airbnb.com/rooms/123',
+      'https://www.airbnb.com/rooms/456',
+    ]).listings,
+  );
+
+  assert.equal(result.addedCount, 1);
+  assert.equal(result.existingCount, 1);
+  assert.deepEqual(result.addedListingRowIds, ['row_456']);
+  assert.equal(createdRecords.length, 1);
+  assert.deepEqual(analysisRecords, [{ jobListingId: 'row_456' }]);
+});

--- a/tests/review-job-analysis.test.ts
+++ b/tests/review-job-analysis.test.ts
@@ -15,11 +15,14 @@ import {
   pruneAnalysisManifestToListings,
   readJsonFile,
   reconcilePriceRefreshManifest,
+  resolveReviewJobAnalysisCostScope,
+  resolveReviewJobAnalysisScope,
   summarizeAnalysisStatus,
   summarizeManifestEntryStatus,
   writeJsonFile,
   type AnalysisManifest,
 } from '../web/src/lib/review-job-analysis.js';
+import { addPersistedAiCostFields } from '../web/src/lib/aiCosts.js';
 import { REVIEW_JOB_ARTIFACT_DIR_ENV } from '../web/src/lib/reviewJobArtifacts.js';
 
 test('pruneAnalysisManifestToListings keeps only active listings and refreshes dates', () => {
@@ -166,6 +169,81 @@ test('summarizeAnalysisStatus treats pending listings as partial results', () =>
     summarizeAnalysisStatus([{ status: 'running' }] as any),
     'partial',
   );
+});
+
+test('targeted add scope never resets or selects a pre-existing listing', () => {
+  const existing = {
+    id: 'row_existing',
+    selected: true,
+    liked: true,
+    hidden: false,
+    analysis: {
+      status: 'completed',
+      triage: { fitScore: 94, verdict: 'shortlist' },
+      totalAiCostUsd: 1.25,
+    },
+  };
+  const added = {
+    id: 'row_added',
+    selected: false,
+    liked: false,
+    hidden: false,
+    analysis: {
+      status: 'pending',
+      triage: null,
+      totalAiCostUsd: 0,
+    },
+  };
+  const existingBefore = structuredClone(existing);
+
+  const scope = resolveReviewJobAnalysisScope(
+    [existing, added] as any,
+    'full',
+    ['row_added'],
+  );
+
+  assert.equal(scope.isTargetedAdd, true);
+  assert.deepEqual(
+    scope.activeListings.map((listing) => listing.id),
+    ['row_added'],
+  );
+  assert.deepEqual(scope.inactiveListingIds, []);
+  assert.equal(scope.hasSelectedSubset, false);
+  assert.deepEqual(existing, existingBefore);
+});
+
+test('targeted add cost scope preserves the prior job aggregate and budgets only new rows', () => {
+  const previousJobCosts = {
+    aiReviewsCostUsd: 1.2,
+    aiPhotosCostUsd: 0.7,
+    triageCostUsd: 0.1,
+    totalAiCostUsd: 2,
+  };
+  const previousJobCostsBefore = structuredClone(previousJobCosts);
+  const scope = resolveReviewJobAnalysisCostScope(
+    ['row_added'],
+    true,
+  );
+
+  assert.equal(scope.resetJobCostsAtStart, false);
+  assert.deepEqual(scope.currentRunListingIds, ['row_added']);
+  assert.equal(scope.jobAggregateListingIds, undefined);
+  assert.deepEqual(previousJobCosts, previousJobCostsBefore);
+  assert.deepEqual(
+    addPersistedAiCostFields(previousJobCosts, {
+      aiReviewsCostUsd: 0.11,
+      aiPhotosCostUsd: 0.07,
+      triageCostUsd: 0.02,
+      totalAiCostUsd: 0.2,
+    }),
+    {
+      aiReviewsCostUsd: 1.31,
+      aiPhotosCostUsd: 0.77,
+      triageCostUsd: 0.12,
+      totalAiCostUsd: 2.2,
+    },
+  );
+  assert.deepEqual(previousJobCosts, previousJobCostsBefore);
 });
 
 test('triage evidence gaps make an otherwise completed listing partial', () => {
@@ -325,6 +403,132 @@ test('prepareReviewJobRunWorkspace stages a fresh rerun with AI outputs invalida
       fs.existsSync(path.join(regrade.rootDir, 'triage', '12345.json')),
       false,
     );
+  } finally {
+    if (previousArtifactDir == null) {
+      delete process.env[REVIEW_JOB_ARTIFACT_DIR_ENV];
+    } else {
+      process.env[REVIEW_JOB_ARTIFACT_DIR_ENV] = previousArtifactDir;
+    }
+    fs.rmSync(sourceRoot, { recursive: true, force: true });
+    fs.rmSync(artifactStore, { recursive: true, force: true });
+  }
+});
+
+test('targeted add staging preserves every existing manifest entry and artifact byte-for-byte', () => {
+  const jobId = 'job_targeted_add';
+  const artifactStore = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'review-job-targeted-store-'),
+  );
+  const sourceRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'review-job-targeted-source-'),
+  );
+  const previousArtifactDir = process.env[REVIEW_JOB_ARTIFACT_DIR_ENV];
+  process.env[REVIEW_JOB_ARTIFACT_DIR_ENV] = artifactStore;
+
+  try {
+    const existingEntry: AnalysisManifest['listings'][string] = {
+      platform: 'airbnb',
+      id: '12345',
+      url: 'https://www.airbnb.com/rooms/12345',
+      details: {
+        status: 'fetched',
+        file: 'listings/listing_12345.json',
+        source: 'network',
+      },
+      reviews: {
+        status: 'fetched',
+        file: 'reviews/room_12345_reviews.json',
+        count: 42,
+      },
+      photos: {
+        status: 'fetched',
+        dir: 'photos/12345',
+        count: 12,
+      },
+      aiReviews: {
+        status: 'fetched',
+        file: 'ai-reviews/12345.json',
+        cost: 0.41,
+      },
+      aiPhotos: {
+        status: 'fetched',
+        file: 'ai-photos/12345.json',
+        cost: 0.22,
+      },
+      triage: {
+        status: 'fetched',
+        file: 'triage/12345.json',
+        cost: 0.03,
+      },
+    };
+    const manifest: AnalysisManifest = {
+      version: 2,
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+      dates: {
+        checkIn: '2026-08-01',
+        checkOut: '2026-08-05',
+        adults: 2,
+      },
+      listings: {
+        'airbnb/12345': existingEntry,
+      },
+    };
+    const artifactContents = new Map([
+      ['listings/listing_12345.json', '{"title":"Existing","verdict":94}\n'],
+      ['reviews/room_12345_reviews.json', '[{"id":"r1"}]\n'],
+      ['ai-reviews/12345.json', '{"cost":0.41,"summary":"quiet"}\n'],
+      ['ai-photos/12345.json', '{"cost":0.22,"summary":"bright"}\n'],
+      ['triage/12345.json', '{"cost":0.03,"tier":"shortlist"}\n'],
+    ]);
+    fs.writeFileSync(
+      getManifestPathFromRoot(sourceRoot),
+      JSON.stringify(manifest, null, 2),
+    );
+    for (const [relativePath, contents] of artifactContents) {
+      const filePath = path.join(sourceRoot, relativePath);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, contents);
+    }
+
+    const existingEntryBefore = structuredClone(existingEntry);
+    const staged = prepareReviewJobRunWorkspace({
+      jobId,
+      runId: 'add_1',
+      previousArtifactRoot: sourceRoot,
+      listings: [{
+        platform: 'booking',
+        url: 'https://www.booking.com/hotel/us/hotel-hugo.en-gb.html',
+      }],
+      dates: {
+        checkIn: '2026-08-02',
+        checkOut: '2026-08-11',
+        adults: 2,
+      },
+      mode: 'full',
+      preserveOtherListings: true,
+    });
+    const stagedManifest = readJsonFile<AnalysisManifest>(
+      getManifestPathFromRoot(staged.rootDir),
+    );
+
+    assert.ok(stagedManifest);
+    assert.deepEqual(
+      stagedManifest.listings['airbnb/12345'],
+      existingEntryBefore,
+    );
+    for (const [relativePath, contents] of artifactContents) {
+      assert.deepEqual(
+        fs.readFileSync(path.join(staged.rootDir, relativePath)),
+        Buffer.from(contents),
+        `existing artifact changed: ${relativePath}`,
+      );
+    }
+    assert.deepEqual(stagedManifest.dates, {
+      checkIn: '2026-08-02',
+      checkOut: '2026-08-11',
+      adults: 2,
+    });
   } finally {
     if (previousArtifactDir == null) {
       delete process.env[REVIEW_JOB_ARTIFACT_DIR_ENV];

--- a/tests/review-job-client.test.ts
+++ b/tests/review-job-client.test.ts
@@ -1,0 +1,113 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { addListingsToReviewJob } from '../src/review-job-client.js';
+
+test('review job client sends normalized URLs with owner authentication', async () => {
+  let requestedUrl = '';
+  let requestedInit: RequestInit | undefined;
+  const result = await addListingsToReviewJob({
+    jobId: 'job with spaces',
+    ownerKey: 'owner-key',
+    baseUrl: 'http://127.0.0.1:3000',
+    urls: [
+      'https://www.airbnb.com/rooms/123?source=map',
+      'https://airbnb.co.uk/rooms/123',
+      'https://www.booking.com/hotel/us/hotel-hugo.html',
+    ],
+    fetchImpl: (async (
+      input: URL | RequestInfo,
+      init?: RequestInit,
+    ) => {
+      requestedUrl = input.toString();
+      requestedInit = init;
+      return new Response(JSON.stringify({
+        jobId: 'job with spaces',
+        status: 'queued',
+        addedCount: 2,
+        duplicateCount: 0,
+        listingCount: 2,
+        message: 'Queued analysis for 2 newly added listings.',
+      }), {
+        status: 202,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch,
+  });
+
+  assert.equal(
+    requestedUrl,
+    'http://127.0.0.1:3000/api/jobs/job%20with%20spaces/listings',
+  );
+  assert.equal(
+    (requestedInit?.headers as Record<string, string>).Cookie,
+    'stayreviewr_owner=owner-key',
+  );
+  assert.deepEqual(
+    JSON.parse(requestedInit?.body as string),
+    {
+      urls: [
+        'https://www.airbnb.com/rooms/123',
+        'https://www.booking.com/hotel/us/hotel-hugo.en-gb.html',
+      ],
+    },
+  );
+  assert.equal(result.status, 'queued');
+  assert.equal(result.addedCount, 2);
+});
+
+test('review job client surfaces duplicate no-op and API errors', async () => {
+  const unchanged = await addListingsToReviewJob({
+    jobId: 'job_1',
+    ownerKey: 'owner_1',
+    urls: ['https://www.airbnb.com/rooms/123'],
+    fetchImpl: (async () => new Response(JSON.stringify({
+      jobId: 'job_1',
+      status: 'unchanged',
+      addedCount: 0,
+      duplicateCount: 1,
+      listingCount: 0,
+      message: 'That listing is already in this job. Nothing was queued.',
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as typeof fetch,
+  });
+  assert.equal(unchanged.status, 'unchanged');
+  assert.match(unchanged.message, /already in this job/);
+
+  await assert.rejects(
+    addListingsToReviewJob({
+      jobId: 'job_1',
+      ownerKey: 'wrong',
+      urls: ['https://www.airbnb.com/rooms/123'],
+      fetchImpl: (async () => new Response(JSON.stringify({
+        error: 'Review job not found',
+      }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      })) as typeof fetch,
+    }),
+    /Review job not found/,
+  );
+});
+
+test('review job client validates owner key and URLs before HTTP', async () => {
+  await assert.rejects(
+    addListingsToReviewJob({
+      jobId: 'job_1',
+      ownerKey: '',
+      urls: ['https://www.airbnb.com/rooms/123'],
+    }),
+    /owner key is required/i,
+  );
+
+  await assert.rejects(
+    addListingsToReviewJob({
+      jobId: 'job_1',
+      ownerKey: 'owner_1',
+      urls: ['https://example.com/not-a-listing'],
+    }),
+    /Invalid listing URL/,
+  );
+});

--- a/tests/review-job-duplicate-persistence.test.ts
+++ b/tests/review-job-duplicate-persistence.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  syncAddedReviewJobDuplicatePairs,
   syncReviewJobDuplicatePairs,
 } from '../web/src/lib/reviewJobDuplicatePersistence.js';
 
@@ -109,4 +110,91 @@ test('detector resync updates evidence without overwriting user decisions', asyn
   );
   assert.deepEqual(deletedIds, ['stale_detector_suggestion']);
   assert.deepEqual(clearedDetectorIds, ['stale_user_dismissal']);
+});
+
+test('targeted add creates only new pairs and leaves prior decisions byte-identical', async () => {
+  const existingPairs = [{
+    id: 'confirmed_pair',
+    airbnbListingId: 'nomo-airbnb',
+    bookingListingId: 'nomo-booking',
+    detectorVersion: 'existing-version',
+    detectorConfidence: 'likely_same',
+    decision: 'confirmed',
+    decisionSource: 'user',
+    evidence: { manuallyReviewed: true },
+    updatedAt: '2026-07-27T00:00:00.000Z',
+  }];
+  const existingPairsBefore = structuredClone(existingPairs);
+  const createdPairs: Array<Record<string, any>> = [];
+  let updateCalls = 0;
+  let deleteCalls = 0;
+  const client = {
+    reviewJobListing: {
+      findMany: async () => [
+        {
+          id: 'row_airbnb',
+          listingId: 'nomo-airbnb',
+          platform: 'airbnb',
+          name: 'Hotel in SoHo',
+          lat: 40.72,
+          lng: -74,
+          propertyType: 'Hotel room',
+          analysis: {
+            details: { host: { name: 'NoMo SoHo New York City' } },
+          },
+        },
+        {
+          id: 'row_booking_existing',
+          listingId: 'nomo-booking',
+          platform: 'booking',
+          name: 'NoMo SoHo',
+          lat: 40.72,
+          lng: -73.99903,
+          propertyType: 'Hotel',
+          analysis: { details: {} },
+        },
+        {
+          id: 'row_booking_added',
+          listingId: 'us/nomo-soho-added',
+          platform: 'booking',
+          name: 'NoMo SoHo New York',
+          lat: 40.72001,
+          lng: -73.99904,
+          propertyType: 'Hotel',
+          analysis: { details: {} },
+        },
+      ],
+    },
+    reviewJobDuplicatePair: {
+      findMany: async () => existingPairs,
+      createMany: async (args: {
+        data: Array<Record<string, any>>;
+      }) => {
+        createdPairs.push(...args.data);
+        return { count: args.data.length };
+      },
+      updateMany: async () => {
+        updateCalls += 1;
+        return { count: 0 };
+      },
+      deleteMany: async () => {
+        deleteCalls += 1;
+        return { count: 0 };
+      },
+    },
+  };
+
+  const additions = await syncAddedReviewJobDuplicatePairs(
+    client as any,
+    'job_1',
+    ['row_booking_added'],
+  );
+
+  assert.equal(additions.length, 1);
+  assert.equal(createdPairs.length, 1);
+  assert.equal(createdPairs[0].bookingListingId, 'us/nomo-soho-added');
+  assert.equal(createdPairs[0].decision, 'suggested');
+  assert.equal(updateCalls, 0);
+  assert.equal(deleteCalls, 0);
+  assert.deepEqual(existingPairs, existingPairsBefore);
 });

--- a/web/src/app/api/jobs/[jobId]/listings/route.ts
+++ b/web/src/app/api/jobs/[jobId]/listings/route.ts
@@ -1,0 +1,221 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { enqueueReviewJobAnalysis } from '@/lib/review-job-queue';
+import { getReviewJobOwnerKey } from '@/lib/reviewJobOwner';
+import { addNewReviewJobListings } from '@/lib/reviewJobAddListings';
+import { parseListingUrls } from '@cli/listing-url';
+
+export const runtime = 'nodejs';
+
+const MAX_URLS_PER_REQUEST = 50;
+
+interface Params {
+  params: Promise<{ jobId: string }>;
+}
+
+function duplicateMessage(count: number): string {
+  return count === 1
+    ? 'That listing is already in this job. Nothing was queued.'
+    : `All ${count} listings are already in this job. Nothing was queued.`;
+}
+
+export async function POST(request: Request, { params }: Params) {
+  const { jobId } = await params;
+  const ownerKey = await getReviewJobOwnerKey();
+  if (!ownerKey) {
+    return NextResponse.json({ error: 'Review job not found' }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return NextResponse.json(
+      { error: 'JSON body must be an object' },
+      { status: 400 },
+    );
+  }
+
+  const urls = (body as { urls?: unknown }).urls;
+  if (
+    !Array.isArray(urls)
+    || urls.length === 0
+    || !urls.every((url) => typeof url === 'string')
+  ) {
+    return NextResponse.json(
+      { error: 'urls must be a non-empty array of strings' },
+      { status: 400 },
+    );
+  }
+  if (urls.length > MAX_URLS_PER_REQUEST) {
+    return NextResponse.json(
+      { error: `A maximum of ${MAX_URLS_PER_REQUEST} URLs can be added at once` },
+      { status: 400 },
+    );
+  }
+
+  const parsed = parseListingUrls(urls);
+  if (parsed.invalid.length > 0) {
+    return NextResponse.json({
+      error: 'One or more listing URLs are invalid',
+      invalidUrls: parsed.invalid,
+    }, { status: 400 });
+  }
+  if (parsed.listings.length === 0) {
+    return NextResponse.json(
+      { error: 'No Airbnb or Booking.com listing URLs were provided' },
+      { status: 400 },
+    );
+  }
+
+  const job = await prisma.reviewJob.findFirst({
+    where: { id: jobId, ownerKey },
+    select: {
+      id: true,
+      status: true,
+      analysisStatus: true,
+      analysisCurrentPhase: true,
+      analysisQueueJobId: true,
+      priceRefreshStatus: true,
+      priceRefreshCurrentPhase: true,
+    },
+  });
+  if (!job) {
+    return NextResponse.json({ error: 'Review job not found' }, { status: 404 });
+  }
+  if (job.status === 'pending' || job.status === 'running') {
+    return NextResponse.json(
+      { error: 'Wait for the current search or analysis run to finish' },
+      { status: 409 },
+    );
+  }
+  if (
+    job.analysisStatus === 'running'
+    || job.analysisCurrentPhase === 'queued'
+    || job.priceRefreshStatus === 'running'
+    || job.priceRefreshCurrentPhase === 'queued'
+  ) {
+    return NextResponse.json(
+      { error: 'Wait for the current analysis or price refresh to finish' },
+      { status: 409 },
+    );
+  }
+
+  const addition = await prisma.$transaction(async (tx) => {
+    const result = await addNewReviewJobListings(
+      tx,
+      jobId,
+      parsed.listings,
+    );
+    if (result.addedCount > 0) {
+      await tx.reviewJob.update({
+        where: { id: jobId },
+        data: {
+          totalResults: { increment: result.addedCount },
+          analysisCurrentPhase: 'queued',
+        },
+      });
+    }
+    return result;
+  });
+  const duplicateCount =
+    parsed.duplicateCount + addition.existingCount;
+
+  if (addition.addedCount === 0) {
+    return NextResponse.json({
+      jobId,
+      status: 'unchanged',
+      addedCount: 0,
+      duplicateCount,
+      listingCount: 0,
+      message: duplicateMessage(duplicateCount),
+    });
+  }
+
+  let queueJob;
+  try {
+    queueJob = await enqueueReviewJobAnalysis(
+      jobId,
+      'full',
+      {
+        listingRowIds: addition.addedListingRowIds,
+        previousAnalysisCurrentPhase: job.analysisCurrentPhase,
+      },
+    );
+  } catch (error) {
+    try {
+      await prisma.$transaction(async (tx) => {
+        await tx.reviewJobListing.deleteMany({
+          where: {
+            jobId,
+            id: { in: addition.addedListingRowIds },
+          },
+        });
+        await tx.reviewJob.update({
+          where: { id: jobId },
+          data: {
+            totalResults: { decrement: addition.addedCount },
+            analysisCurrentPhase: job.analysisCurrentPhase,
+            analysisQueueJobId: job.analysisQueueJobId,
+          },
+        });
+      });
+    } catch (rollbackError) {
+      console.error(
+        `[review-job] failed to roll back added listings for ${jobId}`,
+        rollbackError,
+      );
+    }
+
+    return NextResponse.json({
+      error:
+        error instanceof Error
+          ? error.message
+          : 'Failed to queue added listings',
+    }, { status: 500 });
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.reviewJob.update({
+      where: { id: jobId },
+      data: {
+        analysisQueueJobId:
+          queueJob.id != null ? String(queueJob.id) : null,
+      },
+    });
+    await tx.reviewJobEvent.create({
+      data: {
+        jobId,
+        phase: 'analysis',
+        level: 'info',
+        message:
+          `Added ${addition.addedCount} listing`
+          + `${addition.addedCount === 1 ? '' : 's'} by URL and queued targeted analysis`,
+        payload: {
+          addedCount: addition.addedCount,
+          duplicateCount,
+          listingRowIds: addition.addedListingRowIds,
+          mode: 'targeted-add',
+        },
+      },
+    });
+  });
+
+  const skipped =
+    duplicateCount > 0
+      ? ` ${duplicateCount} duplicate${duplicateCount === 1 ? ' was' : 's were'} already in the job.`
+      : '';
+  return NextResponse.json({
+    jobId,
+    status: 'queued',
+    addedCount: addition.addedCount,
+    duplicateCount,
+    listingCount: addition.addedCount,
+    message:
+      `Queued scrape and analysis for ${addition.addedCount} newly added listing`
+      + `${addition.addedCount === 1 ? '' : 's'}.${skipped}`,
+  }, { status: 202 });
+}

--- a/web/src/components/AddListingsByUrl.test.tsx
+++ b/web/src/components/AddListingsByUrl.test.tsx
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { ReviewJobResponse } from '@/types';
+import AddListingsByUrl from './AddListingsByUrl.js';
+
+test('add-by-URL control explains its additive analysis boundary', () => {
+  const html = renderToStaticMarkup(
+    <AddListingsByUrl
+      job={{
+        id: 'job_1',
+        viewerCanEdit: true,
+        status: 'completed',
+        analysisStatus: 'completed',
+        analysisCurrentPhase: 'completed',
+        priceRefreshStatus: 'pending',
+        priceRefreshCurrentPhase: null,
+      } as ReviewJobResponse['job']}
+      onQueued={async () => {}}
+    />,
+  );
+
+  assert.match(html, /Add listings by URL/);
+  assert.match(html, /Airbnb or Booking\.com/);
+  assert.match(html, /Only new listings are scraped and analyzed/);
+  assert.match(html, /existing results and your shortlist stay unchanged/);
+  assert.match(html, /Add and analyze/);
+});
+
+test('add-by-URL control is owner-only', () => {
+  const html = renderToStaticMarkup(
+    <AddListingsByUrl
+      job={{
+        id: 'job_1',
+        viewerCanEdit: false,
+        status: 'completed',
+        analysisStatus: 'completed',
+        analysisCurrentPhase: 'completed',
+        priceRefreshStatus: 'pending',
+        priceRefreshCurrentPhase: null,
+      } as ReviewJobResponse['job']}
+      onQueued={async () => {}}
+    />,
+  );
+
+  assert.equal(html, '');
+});

--- a/web/src/components/AddListingsByUrl.tsx
+++ b/web/src/components/AddListingsByUrl.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import React, { useState } from 'react';
+import type { ReviewJobResponse } from '@/types';
+
+interface AddListingsByUrlProps {
+  job: Pick<
+    ReviewJobResponse['job'],
+    | 'id'
+    | 'viewerCanEdit'
+    | 'status'
+    | 'analysisStatus'
+    | 'analysisCurrentPhase'
+    | 'priceRefreshStatus'
+    | 'priceRefreshCurrentPhase'
+  >;
+  onQueued: () => Promise<void>;
+}
+
+function splitUrls(value: string): string[] {
+  return value
+    .split(/\s+/)
+    .map((url) => url.trim())
+    .filter(Boolean);
+}
+
+export default function AddListingsByUrl({
+  job,
+  onQueued,
+}: AddListingsByUrlProps) {
+  const [value, setValue] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const urls = splitUrls(value);
+  const locked =
+    !job.viewerCanEdit
+    || job.status === 'pending'
+    || job.status === 'running'
+    || job.analysisStatus === 'running'
+    || job.analysisCurrentPhase === 'queued'
+    || job.priceRefreshStatus === 'running'
+    || job.priceRefreshCurrentPhase === 'queued';
+
+  if (!job.viewerCanEdit) {
+    return null;
+  }
+
+  async function submit() {
+    if (locked || urls.length === 0) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setMessage(null);
+    try {
+      const response = await fetch(`/api/jobs/${job.id}/listings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ urls }),
+      });
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        const invalidDetail =
+          Array.isArray(payload?.invalidUrls)
+          && payload.invalidUrls.length > 0
+            ? `: ${payload.invalidUrls[0].input} (${payload.invalidUrls[0].error})`
+            : '';
+        throw new Error(
+          `${payload?.error || 'Failed to add listings'}${invalidDetail}`,
+        );
+      }
+
+      setMessage(payload?.message || 'Listing URLs processed.');
+      if (payload?.status === 'queued') {
+        setValue('');
+        await onQueued();
+      }
+    } catch (error) {
+      setMessage(
+        error instanceof Error ? error.message : 'Failed to add listings',
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
+        <div className="min-w-0 flex-1">
+          <label
+            htmlFor="add-listing-urls"
+            className="text-sm font-semibold text-white"
+          >
+            Add listings by URL
+          </label>
+          <p className="mt-1 text-xs text-stone-500">
+            Paste Airbnb or Booking.com listing URLs. Only new listings are
+            scraped and analyzed; existing results and your shortlist stay
+            unchanged.
+          </p>
+          <textarea
+            id="add-listing-urls"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            placeholder={'https://www.booking.com/hotel/…\nhttps://www.airbnb.com/rooms/…'}
+            rows={3}
+            disabled={locked || isSubmitting}
+            className="mt-3 w-full resize-y rounded-2xl border border-white/10 bg-black/20 px-3 py-2 text-sm text-stone-100 outline-none transition placeholder:text-stone-600 focus:border-[#ff6b5f]/40 disabled:cursor-not-allowed disabled:opacity-50"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            void submit();
+          }}
+          disabled={locked || isSubmitting || urls.length === 0}
+          className="rounded-2xl border border-[#ff6b5f]/20 bg-[#ff6b5f]/12 px-4 py-2 text-xs font-semibold text-[#ffcabf] transition hover:bg-[#ff6b5f]/18 disabled:cursor-not-allowed disabled:border-white/[0.08] disabled:bg-white/[0.03] disabled:text-stone-500"
+        >
+          {isSubmitting
+            ? 'Adding…'
+            : urls.length > 1
+              ? `Add and analyze ${urls.length}`
+              : 'Add and analyze'}
+        </button>
+      </div>
+      {message && (
+        <p className="mt-3 text-xs text-stone-300" role="status">
+          {message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/JobWorkspace.tsx
+++ b/web/src/components/JobWorkspace.tsx
@@ -22,6 +22,7 @@ import {
   normalizeQualityBriefForComparison,
 } from '@/lib/reviewJobEdits';
 import AiBudgetNotice from './AiBudgetNotice';
+import AddListingsByUrl from './AddListingsByUrl';
 import EvidenceGapBadge from './EvidenceGapBadge';
 import ResultCard from './ResultCard';
 import StaySnapshotStatus from './StaySnapshotStatus';
@@ -822,6 +823,10 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
           </div>
 
           <AiBudgetNotice job={data.job} />
+          <AddListingsByUrl
+            job={data.job}
+            onQueued={refreshJob}
+          />
           <PriceRefreshControls
             job={data.job}
             selectedListings={selectedListings}

--- a/web/src/lib/aiCosts.ts
+++ b/web/src/lib/aiCosts.ts
@@ -28,6 +28,37 @@ export function buildAiCostBreakdown(input: {
   };
 }
 
+export interface PersistedAiCostFields {
+  [key: string]: number;
+  aiReviewsCostUsd: number;
+  aiPhotosCostUsd: number;
+  triageCostUsd: number;
+  totalAiCostUsd: number;
+}
+
+export function addPersistedAiCostFields(
+  previous: PersistedAiCostFields,
+  currentRun: PersistedAiCostFields,
+): PersistedAiCostFields {
+  const combined = buildAiCostBreakdown({
+    aiReviewsCostUsd:
+      previous.aiReviewsCostUsd + currentRun.aiReviewsCostUsd,
+    aiPhotosCostUsd:
+      previous.aiPhotosCostUsd + currentRun.aiPhotosCostUsd,
+    triageCostUsd:
+      previous.triageCostUsd + currentRun.triageCostUsd,
+    totalAiCostUsd:
+      previous.totalAiCostUsd + currentRun.totalAiCostUsd,
+  });
+
+  return {
+    aiReviewsCostUsd: combined.aiReviewsUsd,
+    aiPhotosCostUsd: combined.aiPhotosUsd,
+    triageCostUsd: combined.triageUsd,
+    totalAiCostUsd: combined.totalUsd,
+  };
+}
+
 export function formatUsdCost(amount: number | null | undefined): string {
   const safeAmount = sanitizeCost(amount);
 

--- a/web/src/lib/review-job-analysis.ts
+++ b/web/src/lib/review-job-analysis.ts
@@ -136,6 +136,54 @@ export function summarizeAnalysisStatus(
   return 'completed';
 }
 
+export function resolveReviewJobAnalysisScope<
+  T extends Pick<ReviewJobListing, 'id' | 'selected'>,
+>(
+  listings: T[],
+  analysisMode: 'full' | 'triage',
+  listingRowIds?: string[],
+) {
+  const isTargetedAdd = listingRowIds !== undefined;
+  const targetIds = new Set(listingRowIds ?? []);
+  const selectedListings = listings.filter((listing) => listing.selected);
+  const activeListings =
+    isTargetedAdd
+      ? listings.filter((listing) => targetIds.has(listing.id))
+      : analysisMode === 'triage'
+        ? listings
+        : selectedListings.length > 0
+          ? selectedListings
+          : listings;
+  const hasSelectedSubset =
+    !isTargetedAdd
+    && analysisMode === 'full'
+    && selectedListings.length > 0;
+
+  return {
+    activeListings,
+    inactiveListingIds:
+      hasSelectedSubset
+        ? listings
+          .filter((listing) => !listing.selected)
+          .map((listing) => listing.id)
+        : [],
+    hasSelectedSubset,
+    isTargetedAdd,
+  };
+}
+
+export function resolveReviewJobAnalysisCostScope(
+  activeListingIds: string[],
+  isTargetedAdd: boolean,
+) {
+  return {
+    resetJobCostsAtStart: !isTargetedAdd,
+    currentRunListingIds: activeListingIds,
+    jobAggregateListingIds:
+      isTargetedAdd ? undefined : activeListingIds,
+  };
+}
+
 export interface AnalysisManifestPhase {
   status: 'fetched' | 'skipped' | 'failed' | 'partial' | 'not_requested';
   file?: string;
@@ -341,6 +389,7 @@ export function prepareReviewJobRunWorkspace(input: {
   listings: Array<Pick<ReviewJobListing, 'platform' | 'url'>>;
   dates?: { checkIn?: string; checkOut?: string; adults?: number };
   mode?: 'full' | 'triage';
+  preserveOtherListings?: boolean;
 }) {
   const runRoot = getReviewJobRunDir(input.jobId, input.runId);
   removeDirIfExists(runRoot);
@@ -356,11 +405,25 @@ export function prepareReviewJobRunWorkspace(input: {
     });
   }
 
-  pruneAnalysisManifestToListings({
-    rootDir: runRoot,
-    listings: input.listings,
-    dates: input.dates,
-  });
+  if (input.preserveOtherListings) {
+    const manifestPath = getManifestPathFromRoot(runRoot);
+    const manifest = readJsonFile<AnalysisManifest>(manifestPath);
+    if (manifest && input.dates) {
+      manifest.dates = {
+        checkIn: input.dates.checkIn,
+        checkOut: input.dates.checkOut,
+        adults: input.dates.adults,
+      };
+      manifest.updatedAt = new Date().toISOString();
+      writeJsonFile(manifestPath, manifest);
+    }
+  } else {
+    pruneAnalysisManifestToListings({
+      rootDir: runRoot,
+      listings: input.listings,
+      dates: input.dates,
+    });
+  }
   if (input.mode === 'triage') {
     invalidateTriageOutputsForListings({
       rootDir: runRoot,
@@ -643,6 +706,7 @@ export function injectPoiContextIntoListingArtifacts(input: {
   manifest: AnalysisManifest;
   poi: MapPoint | null;
   fallbackListings?: ListingArtifactPoiFallback[];
+  targetKeys?: ReadonlySet<string>;
 }) {
   if (!input.poi) {
     return;
@@ -656,6 +720,10 @@ export function injectPoiContextIntoListingArtifacts(input: {
   );
 
   for (const entry of Object.values(input.manifest.listings)) {
+    const entryKey = getListingMatchKey(entry.platform, entry.url);
+    if (input.targetKeys && !input.targetKeys.has(entryKey)) {
+      continue;
+    }
     if (!entry.details.file) {
       continue;
     }
@@ -666,9 +734,7 @@ export function injectPoiContextIntoListingArtifacts(input: {
       continue;
     }
 
-    const fallback = fallbackByKey.get(
-      getListingMatchKey(entry.platform, entry.url),
-    );
+    const fallback = fallbackByKey.get(entryKey);
     const listingCoordinates = asCoordinates(listingData.coordinates);
     const fallbackCoordinates =
       fallback && fallback.lat != null && fallback.lng != null

--- a/web/src/lib/review-job-queue.ts
+++ b/web/src/lib/review-job-queue.ts
@@ -8,6 +8,7 @@ export interface ReviewJobQueueData {
   phase: 'search' | 'analyze' | 'refresh-prices';
   analysisMode?: 'full' | 'triage';
   listingRowIds?: string[];
+  previousAnalysisCurrentPhase?: string | null;
 }
 
 export function getReviewJobQueueJobId(
@@ -72,6 +73,10 @@ export async function enqueueReviewJobSearch(reviewJobId: string) {
 export async function enqueueReviewJobAnalysis(
   reviewJobId: string,
   analysisMode: 'full' | 'triage' = 'full',
+  options: {
+    listingRowIds?: string[];
+    previousAnalysisCurrentPhase?: string | null;
+  } = {},
 ) {
   const queue = getReviewJobQueue();
   const jobId = getReviewJobQueueJobId('analyze', reviewJobId);
@@ -88,6 +93,15 @@ export async function enqueueReviewJobAnalysis(
     reviewJobId,
     phase: 'analyze',
     analysisMode,
+    ...(options.listingRowIds
+      ? { listingRowIds: options.listingRowIds }
+      : {}),
+    ...(Object.hasOwn(options, 'previousAnalysisCurrentPhase')
+      ? {
+          previousAnalysisCurrentPhase:
+            options.previousAnalysisCurrentPhase,
+        }
+      : {}),
   }, {
     jobId,
   });

--- a/web/src/lib/reviewJobAddListings.ts
+++ b/web/src/lib/reviewJobAddListings.ts
@@ -1,0 +1,116 @@
+import type { Prisma } from '@prisma/client';
+import {
+  parseListingUrl,
+  type ParsedListingUrl,
+} from '@cli/listing-url';
+
+type AddListingsClient = Pick<
+  Prisma.TransactionClient,
+  'reviewJobListing' | 'reviewJobListingAnalysis'
+>;
+
+export interface AddNewReviewJobListingsResult {
+  addedListingRowIds: string[];
+  addedCount: number;
+  existingCount: number;
+}
+
+function storedListingMatchKey(listing: {
+  listingId: string;
+  platform: 'airbnb' | 'booking';
+  url: string;
+}): string {
+  try {
+    const parsed = parseListingUrl(listing.url);
+    if (parsed.platform === listing.platform) {
+      return parsed.matchKey;
+    }
+  } catch {
+    // Legacy rows can contain URLs that predate strict URL normalization.
+  }
+
+  return `${listing.platform}:${listing.listingId.toLowerCase()}`;
+}
+
+export function toAddedReviewJobListingRecord(
+  jobId: string,
+  listing: ParsedListingUrl,
+): Prisma.ReviewJobListingCreateManyInput {
+  return {
+    jobId,
+    listingId: listing.listingId,
+    platform: listing.platform,
+    name: listing.displayName,
+    url: listing.normalizedUrl,
+    reviewCount: 0,
+  };
+}
+
+export async function addNewReviewJobListings(
+  client: AddListingsClient,
+  jobId: string,
+  requestedListings: ParsedListingUrl[],
+): Promise<AddNewReviewJobListingsResult> {
+  const existingRows = await client.reviewJobListing.findMany({
+    where: { jobId },
+    select: {
+      id: true,
+      listingId: true,
+      platform: true,
+      url: true,
+    },
+  });
+  const existingKeys = new Set(existingRows.map(storedListingMatchKey));
+  const addedListings: ParsedListingUrl[] = [];
+  let existingCount = 0;
+
+  for (const listing of requestedListings) {
+    if (existingKeys.has(listing.matchKey)) {
+      existingCount += 1;
+      continue;
+    }
+
+    const inserted = await client.reviewJobListing.createMany({
+      data: [toAddedReviewJobListingRecord(jobId, listing)],
+      skipDuplicates: true,
+    });
+    if (inserted.count === 0) {
+      existingCount += 1;
+      continue;
+    }
+
+    existingKeys.add(listing.matchKey);
+    addedListings.push(listing);
+  }
+
+  if (addedListings.length === 0) {
+    return {
+      addedListingRowIds: [],
+      addedCount: 0,
+      existingCount,
+    };
+  }
+
+  const addedRows = await client.reviewJobListing.findMany({
+    where: {
+      jobId,
+      OR: addedListings.map((listing) => ({
+        listingId: listing.listingId,
+        platform: listing.platform,
+      })),
+    },
+    select: { id: true },
+  });
+  await client.reviewJobListingAnalysis.createMany({
+    data: addedRows.map((listing) => ({
+      jobListingId: listing.id,
+    })),
+    skipDuplicates: true,
+  });
+
+  return {
+    addedListingRowIds: addedRows.map((listing) => listing.id),
+    addedCount: addedRows.length,
+    existingCount,
+  };
+}

--- a/web/src/lib/reviewJobDuplicatePersistence.ts
+++ b/web/src/lib/reviewJobDuplicatePersistence.ts
@@ -24,6 +24,7 @@ export async function syncReviewJobDuplicatePairs(
   const rows = await client.reviewJobListing.findMany({
     where: { jobId },
     select: {
+      id: true,
       listingId: true,
       platform: true,
       name: true,
@@ -148,4 +149,94 @@ export async function syncReviewJobDuplicatePairs(
   }
 
   return detected;
+}
+
+export async function syncAddedReviewJobDuplicatePairs(
+  client: DuplicateSyncClient,
+  jobId: string,
+  addedListingRowIds: string[],
+) {
+  if (addedListingRowIds.length === 0) {
+    return [];
+  }
+
+  const rows = await client.reviewJobListing.findMany({
+    where: { jobId },
+    select: {
+      id: true,
+      listingId: true,
+      platform: true,
+      name: true,
+      lat: true,
+      lng: true,
+      propertyType: true,
+      analysis: {
+        select: {
+          details: true,
+        },
+      },
+    },
+  });
+  const addedRowIdSet = new Set(addedListingRowIds);
+  const addedListingKeys = new Set(
+    rows
+      .filter((row) => addedRowIdSet.has(row.id))
+      .map((row) => `${row.platform}:${row.listingId}`),
+  );
+  const listings: DuplicateListingInput[] = rows.map((row) => ({
+    listingId: row.listingId,
+    platform: row.platform,
+    name: row.name,
+    coordinates:
+      row.lat != null && row.lng != null
+        ? { lat: row.lat, lng: row.lng }
+        : null,
+    propertyType: row.propertyType,
+    details: row.analysis?.details,
+  }));
+  const detected = detectReviewJobDuplicatePairs(listings).filter((pair) =>
+    addedListingKeys.has(`airbnb:${pair.airbnbListingId}`)
+    || addedListingKeys.has(`booking:${pair.bookingListingId}`));
+  if (detected.length === 0) {
+    return [];
+  }
+
+  const existing = await client.reviewJobDuplicatePair.findMany({
+    where: { jobId },
+    select: {
+      airbnbListingId: true,
+      bookingListingId: true,
+    },
+  });
+  const existingKeys = new Set(
+    existing.map((pair) =>
+      pairKey(pair.airbnbListingId, pair.bookingListingId)),
+  );
+  const additions = detected.filter((pair) =>
+    !existingKeys.has(pairKey(
+      pair.airbnbListingId,
+      pair.bookingListingId,
+    )));
+
+  if (additions.length > 0) {
+    await client.reviewJobDuplicatePair.createMany({
+      data: additions.map((pair) => ({
+        jobId,
+        airbnbListingId: pair.airbnbListingId,
+        bookingListingId: pair.bookingListingId,
+        detectorVersion: pair.detectorVersion,
+        detectorConfidence: pair.confidence,
+        decision: 'suggested' as const,
+        decisionSource: 'detector' as const,
+        distanceMeters: pair.distanceMeters,
+        nameScore: pair.nameScore,
+        nameSource: pair.nameSource,
+        evidence:
+          pair.evidence as unknown as Prisma.InputJsonValue,
+      })),
+      skipDuplicates: true,
+    });
+  }
+
+  return additions;
 }

--- a/web/src/lib/search-worker.ts
+++ b/web/src/lib/search-worker.ts
@@ -38,6 +38,8 @@ import {
   prepareReviewJobRunWorkspace,
   readJsonFile,
   reconcilePriceRefreshManifest,
+  resolveReviewJobAnalysisCostScope,
+  resolveReviewJobAnalysisScope,
   summarizeAnalysisStatus,
   summarizeManifestEntryStatus,
   toPhaseStatus,
@@ -49,7 +51,10 @@ import {
   type ReviewJobSearchPlatformFailure,
 } from './reviewJobSearch.js';
 import { createSearchLogger } from './searchLog.js';
-import { buildAiCostBreakdown } from './aiCosts.js';
+import {
+  addPersistedAiCostFields,
+  buildAiCostBreakdown,
+} from './aiCosts.js';
 import {
   AiJobBudgetExceededError,
   hasReachedAiJobBudget,
@@ -72,6 +77,7 @@ import {
 } from './staySnapshots.js';
 import { regradeRequiredAfterAnalysis } from './reviewJobEdits.js';
 import {
+  syncAddedReviewJobDuplicatePairs,
   syncReviewJobDuplicatePairs,
 } from './reviewJobDuplicatePersistence.js';
 
@@ -631,8 +637,21 @@ type PersistableManifestEntry = AnalysisManifest['listings'][string] | BatchPhas
 interface ReviewJobListingPersistenceRow {
   id: string;
   jobId: string;
+  listingId: string;
   platform: 'airbnb' | 'booking';
+  name: string;
   url: string;
+  rating: number | null;
+  reviewCount: number;
+  propertyType: string | null;
+  photoUrl: string | null;
+  bedrooms: number | null;
+  beds: number | null;
+  bathrooms: number | null;
+  maxGuests: number | null;
+  superhost: boolean | null;
+  hostId: string | null;
+  stars: number | null;
   lat: number | null;
   lng: number | null;
   poiDistanceMeters: number | null;
@@ -971,6 +990,88 @@ function getDetailsJsonWithPoiContext(input: {
   };
 }
 
+function finiteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function listingCardUpdatesFromDetails(
+  listing: ReviewJobListingPersistenceRow,
+  details: Record<string, unknown> | null,
+): Prisma.ReviewJobListingUpdateInput {
+  if (
+    !details
+    || listing.rating != null
+    || listing.reviewCount !== 0
+    || listing.photoUrl != null
+    || listing.lat != null
+    || listing.lng != null
+  ) {
+    return {};
+  }
+
+  const coordinates = asStoredMapPoint(details.coordinates);
+  const photos = Array.isArray(details.photos) ? details.photos : [];
+  const firstPhoto = photos.find((photo) =>
+      photo
+      && typeof photo === 'object'
+      && !Array.isArray(photo)
+      && nonEmptyString((photo as Record<string, unknown>).url),
+  ) as Record<string, unknown> | undefined;
+  const host =
+    details.host
+    && typeof details.host === 'object'
+    && !Array.isArray(details.host)
+      ? details.host as Record<string, unknown>
+      : null;
+  const reviewCount = finiteNumber(details.reviewCount);
+
+  return {
+    ...(nonEmptyString(details.title)
+      ? { name: nonEmptyString(details.title) as string }
+      : {}),
+    ...(finiteNumber(details.rating) != null
+      ? { rating: finiteNumber(details.rating) }
+      : {}),
+    ...(reviewCount != null && Number.isInteger(reviewCount) && reviewCount >= 0
+      ? { reviewCount }
+      : {}),
+    ...(nonEmptyString(details.propertyType)
+      ? { propertyType: nonEmptyString(details.propertyType) as string }
+      : {}),
+    ...(firstPhoto
+      ? { photoUrl: nonEmptyString(firstPhoto.url) }
+      : {}),
+    ...(coordinates
+      ? { lat: coordinates.lat, lng: coordinates.lng }
+      : {}),
+    ...(finiteNumber(details.bedrooms) != null
+      ? { bedrooms: finiteNumber(details.bedrooms) }
+      : {}),
+    ...(finiteNumber(details.beds) != null
+      ? { beds: finiteNumber(details.beds) }
+      : {}),
+    ...(finiteNumber(details.bathrooms) != null
+      ? { bathrooms: finiteNumber(details.bathrooms) }
+      : {}),
+    ...(finiteNumber(details.capacity) != null
+      ? { maxGuests: finiteNumber(details.capacity) }
+      : {}),
+    ...(typeof host?.isSuperhost === 'boolean'
+      ? { superhost: host.isSuperhost }
+      : {}),
+    ...(nonEmptyString(host?.id)
+      ? { hostId: nonEmptyString(host?.id) as string }
+      : {}),
+    ...(finiteNumber(details.stars) != null
+      ? { stars: finiteNumber(details.stars) }
+      : {}),
+  };
+}
+
 async function persistReviewJobManifestEntryToDb(input: {
   artifactRoot: string;
   poi: { lat: number; lng: number } | null;
@@ -1004,6 +1105,7 @@ async function persistReviewJobManifestEntryToDb(input: {
     await tx.reviewJobListing.update({
       where: { id: input.listing.id },
       data: {
+        ...listingCardUpdatesFromDetails(input.listing, details),
         poiDistanceMeters: poiDistanceMeters ?? null,
         ...(staySnapshot
           ? {
@@ -1071,6 +1173,7 @@ async function syncReviewJobArtifactsToDb(input: {
   reviewJobId: string;
   artifactRoot: string;
   poi: { lat: number; lng: number } | null;
+  listingRowIds?: string[];
 }) {
   const manifestPath = getManifestPathFromRoot(input.artifactRoot);
   const manifest = readJsonFile<AnalysisManifest>(manifestPath);
@@ -1079,7 +1182,13 @@ async function syncReviewJobArtifactsToDb(input: {
   }
 
   const listings = await prisma.reviewJobListing.findMany({
-    where: { jobId: input.reviewJobId, hidden: false },
+    where: {
+      jobId: input.reviewJobId,
+      hidden: false,
+      ...(input.listingRowIds
+        ? { id: { in: input.listingRowIds } }
+        : {}),
+    },
     include: { analysis: true },
   });
 
@@ -1555,6 +1664,8 @@ async function runReviewJobPriceRefresh(
 async function runReviewJobAnalysis(
   reviewJobId: string,
   analysisMode: 'full' | 'triage' = 'full',
+  listingRowIds?: string[],
+  previousAnalysisCurrentPhase?: string | null,
 ) {
   await cleanupExpiredReviewJobArtifactRuns('before-analysis');
   await ensureReviewJobAnalysisRows(reviewJobId);
@@ -1578,13 +1689,23 @@ async function runReviewJobAnalysis(
     throw new Error(`Review job ${reviewJobId} has no listings to analyze`);
   }
 
-  const selectedListings = jobRecord.listings.filter((listing) => listing.selected);
-  const activeListings =
-    analysisMode === 'triage'
-      ? jobRecord.listings
-      : selectedListings.length > 0
-        ? selectedListings
-        : jobRecord.listings;
+  const {
+    activeListings,
+    inactiveListingIds,
+    hasSelectedSubset,
+    isTargetedAdd,
+  } = resolveReviewJobAnalysisScope(
+    jobRecord.listings,
+    analysisMode,
+    listingRowIds,
+  );
+  if (activeListings.length === 0) {
+    throw new Error(
+      isTargetedAdd
+        ? `Review job ${reviewJobId} has no matching added listings to analyze`
+        : `Review job ${reviewJobId} has no listings to analyze`,
+    );
+  }
   if (analysisMode === 'triage' && !jobRecord.artifactRoot) {
     throw new Error(
       `Review job ${reviewJobId} has no saved artifacts for a triage-only regrade`,
@@ -1603,6 +1724,7 @@ async function runReviewJobAnalysis(
       adults: jobRecord.adults,
     },
     mode: analysisMode,
+    preserveOtherListings: isTargetedAdd,
   });
   const analysisModel = process.env.LLM_MODEL || 'gemini-3-flash-preview:high';
   const aiBudgetUsd = resolveAiJobBudgetUsd();
@@ -1616,6 +1738,7 @@ async function runReviewJobAnalysis(
       },
     ]),
   );
+  const activeListingKeys = new Set(activeListingByKey.keys());
   const previousAnalysisSnapshots = activeListings
     .map((listing) => createReviewJobAnalysisSnapshot(listing))
     .filter((snapshot): snapshot is ReviewJobListingAnalysisSnapshot => snapshot != null);
@@ -1625,7 +1748,11 @@ async function runReviewJobAnalysis(
     status: jobRecord.status,
     currentPhase: jobRecord.currentPhase,
     analysisStatus: jobRecord.analysisStatus,
-    analysisCurrentPhase: jobRecord.analysisCurrentPhase,
+    analysisCurrentPhase:
+      isTargetedAdd
+      && previousAnalysisCurrentPhase !== undefined
+        ? previousAnalysisCurrentPhase
+        : jobRecord.analysisCurrentPhase,
     analysisProgress: jobRecord.analysisProgress,
     analysisStartedAt: jobRecord.analysisStartedAt,
     analysisCompletedAt: jobRecord.analysisCompletedAt,
@@ -1637,15 +1764,37 @@ async function runReviewJobAnalysis(
     triageCostUsd: jobRecord.triageCostUsd,
     totalAiCostUsd: jobRecord.totalAiCostUsd,
   };
+  const previousJobAiCosts = {
+    aiReviewsCostUsd: previousJobState.aiReviewsCostUsd,
+    aiPhotosCostUsd: previousJobState.aiPhotosCostUsd,
+    triageCostUsd: previousJobState.triageCostUsd,
+    totalAiCostUsd: previousJobState.totalAiCostUsd,
+  };
   const activeListingIds = activeListings.map((listing) => listing.id);
-  const hasSelectedSubset =
-    analysisMode === 'full' && selectedListings.length > 0;
-  const inactiveListingIds = hasSelectedSubset
-    ? jobRecord.listings
-      .filter((listing) => !listing.selected)
-      .map((listing) => listing.id)
-    : [];
-  let persistedAiCosts = {
+  const costScope = resolveReviewJobAnalysisCostScope(
+    activeListingIds,
+    isTargetedAdd,
+  );
+  const syncArtifactsAndDuplicates = async () => {
+    await syncReviewJobArtifactsToDb({
+      reviewJobId,
+      artifactRoot,
+      poi,
+      ...(isTargetedAdd
+        ? { listingRowIds: activeListingIds }
+        : {}),
+    });
+    if (isTargetedAdd) {
+      await syncAddedReviewJobDuplicatePairs(
+        prisma,
+        reviewJobId,
+        activeListingIds,
+      );
+    } else {
+      await syncReviewJobDuplicatePairs(prisma, reviewJobId);
+    }
+  };
+  let currentRunAiCosts = {
     aiReviewsCostUsd: 0,
     aiPhotosCostUsd: 0,
     triageCostUsd: 0,
@@ -1697,16 +1846,18 @@ async function runReviewJobAnalysis(
         analysisStartedAt: startedAt,
         analysisCompletedAt: null,
         analysisDurationMs: null,
-        ...(analysisMode === 'full'
-          ? {
-              aiReviewsCostUsd: 0,
-              aiPhotosCostUsd: 0,
-              triageCostUsd: 0,
-              totalAiCostUsd: 0,
-            }
-          : {
-              triageCostUsd: 0,
-            }),
+        ...(costScope.resetJobCostsAtStart
+          ? analysisMode === 'full'
+            ? {
+                aiReviewsCostUsd: 0,
+                aiPhotosCostUsd: 0,
+                triageCostUsd: 0,
+                totalAiCostUsd: 0,
+              }
+            : {
+                triageCostUsd: 0,
+              }
+          : {}),
       },
     });
   });
@@ -1717,6 +1868,8 @@ async function runReviewJobAnalysis(
     message:
       analysisMode === 'triage'
         ? `Started triage-only regrade for ${activeListings.length} listings`
+        : isTargetedAdd
+          ? `Started targeted analysis for ${activeListings.length} newly added listings`
         : `Started analysis for ${activeListings.length} listings`,
     payload: {
       listingCount: activeListings.length,
@@ -1724,6 +1877,7 @@ async function runReviewJobAnalysis(
       model: analysisModel,
       aiBudgetUsd,
       analysisMode,
+      targetedAdd: isTargetedAdd,
     },
   });
 
@@ -1757,6 +1911,8 @@ async function runReviewJobAnalysis(
       retryFailed: false,
       downloadPhotosAll: false,
       outputDir: artifactRoot,
+      scopeManifestToInput: !isTargetedAdd,
+      scopePostScrapePhasesToInput: isTargetedAdd,
       print: false,
       programmatic: true,
       hooks: {
@@ -1811,22 +1967,36 @@ async function runReviewJobAnalysis(
           }
         },
         onAiCheckpoint: async () => {
-          persistedAiCosts = await prisma.$transaction(async (tx) => {
-            const costs = await getAggregatedReviewJobAiCostFields(
+          currentRunAiCosts = await prisma.$transaction(async (tx) => {
+            const runCosts = await getAggregatedReviewJobAiCostFields(
               tx,
               reviewJobId,
-              activeListingIds,
+              costScope.currentRunListingIds,
             );
+            const jobCosts =
+              isTargetedAdd
+                ? addPersistedAiCostFields(
+                    previousJobAiCosts,
+                    runCosts,
+                  )
+                : costScope.jobAggregateListingIds
+                  === costScope.currentRunListingIds
+                  ? runCosts
+                  : await getAggregatedReviewJobAiCostFields(
+                      tx,
+                      reviewJobId,
+                      costScope.jobAggregateListingIds,
+                    );
             await tx.reviewJob.update({
               where: { id: reviewJobId },
-              data: costs,
+              data: jobCosts,
             });
-            return costs;
+            return runCosts;
           });
           currentRunAiCostUsd =
             analysisMode === 'triage'
-              ? persistedAiCosts.triageCostUsd
-              : persistedAiCosts.totalAiCostUsd;
+              ? currentRunAiCosts.triageCostUsd
+              : currentRunAiCosts.totalAiCostUsd;
         },
         onScrapeComplete: async ({ outputDir, manifest }) => {
           injectPoiContextIntoListingArtifacts({
@@ -1840,6 +2010,9 @@ async function runReviewJobAnalysis(
               lng: listing.lng,
               poiDistanceMeters: listing.poiDistanceMeters,
             })),
+            ...(isTargetedAdd
+              ? { targetKeys: activeListingKeys }
+              : {}),
           });
           await prisma.reviewJob.update({
             where: { id: reviewJobId },
@@ -1876,12 +2049,7 @@ async function runReviewJobAnalysis(
       });
     }
 
-    await syncReviewJobArtifactsToDb({
-      reviewJobId,
-      artifactRoot,
-      poi,
-    });
-    await syncReviewJobDuplicatePairs(prisma, reviewJobId);
+    await syncArtifactsAndDuplicates();
 
     const completedAt = new Date();
     let overallStatus: 'completed' | 'partial' | 'failed' = 'completed';
@@ -1900,7 +2068,17 @@ async function runReviewJobAnalysis(
       overallStatus = summarizeAnalysisStatus(finalAnalyses);
       const resultsReady =
         overallStatus === 'completed' || overallStatus === 'partial';
-      const aggregatedAiCosts = await getAggregatedReviewJobAiCostFields(tx, reviewJobId);
+      const aggregatedAiCosts =
+        isTargetedAdd
+          ? addPersistedAiCostFields(
+              previousJobAiCosts,
+              await getAggregatedReviewJobAiCostFields(
+                tx,
+                reviewJobId,
+                activeListingIds,
+              ),
+            )
+          : await getAggregatedReviewJobAiCostFields(tx, reviewJobId);
 
       await tx.reviewJob.update({
         where: { id: reviewJobId },
@@ -1913,10 +2091,13 @@ async function runReviewJobAnalysis(
           analysisErrorMessage: null,
           analysisCompletedAt: completedAt,
           analysisDurationMs: completedAt.getTime() - startedAt.getTime(),
-          regradeRequired: regradeRequiredAfterAnalysis(
-            jobRecord.regradeRequired,
-            overallStatus,
-          ),
+          regradeRequired:
+            isTargetedAdd
+              ? jobRecord.regradeRequired
+              : regradeRequiredAfterAnalysis(
+                  jobRecord.regradeRequired,
+                  overallStatus,
+                ),
           artifactRoot,
           reportPath,
           ...aggregatedAiCosts,
@@ -1929,6 +2110,8 @@ async function runReviewJobAnalysis(
             message:
               analysisMode === 'triage'
                 ? 'Triage-only regrade completed'
+                : isTargetedAdd
+                  ? 'Targeted analysis completed for newly added listings'
                 : 'Analysis completed',
           payload: {
             status: overallStatus,
@@ -1936,6 +2119,7 @@ async function runReviewJobAnalysis(
             resultsReady,
             legacyReportAvailable: !!reportPath,
             selectedSubset: hasSelectedSubset,
+            targetedAdd: isTargetedAdd,
             analysisMode,
             costs: aggregatedAiCosts,
           },
@@ -1950,12 +2134,7 @@ async function runReviewJobAnalysis(
     if (error instanceof AiJobBudgetExceededError) {
       const completedAt = new Date();
 
-      await syncReviewJobArtifactsToDb({
-        reviewJobId,
-        artifactRoot,
-        poi,
-      });
-      await syncReviewJobDuplicatePairs(prisma, reviewJobId);
+      await syncArtifactsAndDuplicates();
 
       await prisma.$transaction(async (tx) => {
         await resetReviewJobListingAnalyses(tx, inactiveListingIds);
@@ -1977,11 +2156,20 @@ async function runReviewJobAnalysis(
           },
         });
 
-        const aggregatedAiCosts = await getAggregatedReviewJobAiCostFields(
-          tx,
-          reviewJobId,
-          activeListingIds,
-        );
+        const aggregatedAiCosts =
+          isTargetedAdd
+            ? addPersistedAiCostFields(
+                previousJobAiCosts,
+                await getAggregatedReviewJobAiCostFields(
+                  tx,
+                  reviewJobId,
+                  activeListingIds,
+                ),
+              )
+            : await getAggregatedReviewJobAiCostFields(
+                tx,
+                reviewJobId,
+              );
         await tx.reviewJob.update({
           where: { id: reviewJobId },
           data: {
@@ -2105,6 +2293,8 @@ const reviewJobWorker = new Worker<ReviewJobQueueData>(
     await runReviewJobAnalysis(
       job.data.reviewJobId,
       job.data.analysisMode ?? 'full',
+      job.data.listingRowIds,
+      job.data.previousAnalysisCurrentPhase,
     );
   },
   {


### PR DESCRIPTION
Closes #63

## What changed

- Adds an owner-only workspace control and `POST /api/jobs/:jobId/listings` endpoint for adding one or more Booking.com or Airbnb URLs to an existing job.
- Adds CLI parity via `reviewr job add <job-id> <url...>` with cookie-based owner authentication.
- Canonicalizes supported URLs, rejects the whole request on invalid input, and treats already-present URLs as a strict no-op: no second row and no queued work.
- Queues explicit new listing-row IDs and preserves the existing workspace, curation, analyses, verdicts, duplicate decisions, and persisted artifacts.
- Regenerates the combined report from the merged manifest while scoping scrape, photos, AI analysis, triage, retry, and failure accounting to only the newly added listings—even if an older listing is partial or failed.
- Extends duplicate detection incrementally: only new pairs involving an added listing can be created; existing pair decisions are never updated or deleted.

## Safety and cost contract

- Provider work and new spend: scrape + downstream AI only for newly added URLs.
- Existing listings: persisted reads only; no AI rerun and no mutation of their analyses, verdicts, costs, selected/liked/hidden state, or duplicate-pair decisions.
- Job aggregate AI cost remains the exact previously persisted aggregate plus costs from the added listings.
- If queue submission fails, newly inserted rows, the listing count, phase claim, and queue identifier are rolled back.

## Validation

- `pnpm test` — 181 passed
- `pnpm run lint`
- `pnpm run build`
- `npm run test:ui` — 19 passed
- `npm run test:pricing` — 3 passed
- `npm run test:dependencies` — 1 passed
- `npm run lint` in `web/`
- `npm run build` in `web/`
- Disposable real Prisma/Postgres + BullMQ/Redis smoke: duplicate-only request returned 200 with one unchanged row and no queue; mixed duplicate/new request returned 202 with exactly one new row and a queue payload containing only that row ID; unauthenticated request returned 404. The old row's analysis, curation flags, and exact cost fields remained unchanged.

The live checkout and its Postgres/Redis services were not modified.
