### PR TITLE
chore: add fail-closed job details repair command

### DIFF
--- a/tests/review-job-details-repair.test.ts
+++ b/tests/review-job-details-repair.test.ts
@@ -1,0 +1,567 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import test from 'node:test';
+import type {
+  BatchManifest,
+  BatchOptions,
+} from '../src/batch.js';
+import {
+  DETAILS_REPAIR_PLAN_FILE,
+  fingerprintDetailsRepairValue,
+  getDetailsRepairCoverage,
+  readReviewJobDetailsRepairPlan,
+  stageReviewJobDetailsRepair,
+  validateReviewJobDetailsRepairForApply,
+  type DetailsRepairJobInput,
+} from '../web/src/lib/review-job-details-repair.js';
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+}
+
+function manifestEntry(
+  platform: 'airbnb' | 'booking',
+  id: string,
+  url: string,
+) {
+  const detailsFile = `listings/listing_${id}.json`;
+  return {
+    platform,
+    id,
+    url,
+    details: {
+      status: 'fetched' as const,
+      file: detailsFile,
+      source: 'network' as const,
+    },
+    reviews: {
+      status: 'fetched' as const,
+      file:
+        platform === 'airbnb'
+          ? `reviews/room_${id}_reviews.json`
+          : `reviews/${id}_reviews.json`,
+      count: 10,
+      source: 'network' as const,
+    },
+    photos: {
+      status: 'fetched' as const,
+      dir: `photos/${id}`,
+      count: 1,
+      source: 'network' as const,
+    },
+    aiReviews: {
+      status: 'fetched' as const,
+      file: `ai-reviews/${id}.json`,
+      model: 'test-model',
+      cost: 0.2,
+    },
+    aiPhotos: {
+      status: 'fetched' as const,
+      file: `ai-photos/${id}.json`,
+      model: 'test-model',
+      cost: 0.3,
+    },
+    triage: {
+      status: 'fetched' as const,
+      file: `triage/${id}.json`,
+      model: 'test-model',
+      cost: 0.1,
+    },
+    verdict: 'shortlisted' as const,
+    verdictReason: 'keep this exact decision',
+  };
+}
+
+function seedEntryArtifacts(
+  rootDir: string,
+  entry: ReturnType<typeof manifestEntry>,
+  details: unknown,
+): void {
+  writeJson(path.join(rootDir, entry.details.file), details);
+  writeJson(path.join(rootDir, entry.reviews.file), {
+    reviews: [{ id: 'review-1' }],
+  });
+  fs.mkdirSync(path.join(rootDir, entry.photos.dir), { recursive: true });
+  fs.writeFileSync(
+    path.join(rootDir, entry.photos.dir, '01.jpg'),
+    `photo:${entry.platform}:${entry.id}`,
+  );
+  writeJson(path.join(rootDir, entry.aiReviews.file), {
+    analysis: `reviews:${entry.id}`,
+  });
+  writeJson(path.join(rootDir, entry.aiPhotos.file), {
+    analysis: `photos:${entry.id}`,
+  });
+  writeJson(path.join(rootDir, entry.triage.file), {
+    verdict: 'unchanged',
+    listingId: entry.id,
+  });
+}
+
+test('coverage treats a zero review count as populated but empty collections as missing', () => {
+  assert.deepEqual(
+    getDetailsRepairCoverage({
+      title: 'A real title',
+      rating: null,
+      reviewCount: 0,
+      subRatings: {},
+      amenities: [],
+    }),
+    {
+      title: true,
+      rating: false,
+      reviewCount: true,
+      subRatings: false,
+      amenities: false,
+      total: 2,
+    },
+  );
+});
+
+test('details repair stages only missing core fields and preserves every non-details byte', async () => {
+  const tempRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'reviewr-details-repair-'),
+  );
+  const sourceRoot = path.join(tempRoot, 'source');
+  const stagedRoot = path.join(tempRoot, 'staged');
+  fs.mkdirSync(sourceRoot, { recursive: true });
+
+  const airbnbOneUrl = 'https://www.airbnb.com/rooms/111';
+  const airbnbTwoUrl = 'https://www.airbnb.com/rooms/222';
+  const bookingUrl =
+    'https://www.booking.com/hotel/us/example.html';
+  const airbnbOne = manifestEntry('airbnb', '111', airbnbOneUrl);
+  const airbnbTwo = manifestEntry('airbnb', '222', airbnbTwoUrl);
+  const booking = manifestEntry('booking', 'example', bookingUrl);
+  const firstBefore = {
+    title: '',
+    rating: 4.7,
+    reviewCount: null,
+    subRatings: {},
+    amenities: [],
+    host: { name: 'Original Host' },
+    description: 'Original description',
+    staySnapshot: { capturedAt: 'original' },
+  };
+  const secondBefore = {
+    title: '',
+    rating: null,
+    reviewCount: null,
+    subRatings: {},
+    amenities: [],
+    host: { name: 'Second Host' },
+  };
+  const bookingBefore = {
+    title: 'Booking stays untouched',
+    rating: 8.9,
+    reviewCount: 500,
+    amenities: [{ name: 'Elevator' }],
+  };
+  const manifest: BatchManifest = {
+    version: 2,
+    createdAt: '2026-07-23T00:00:00.000Z',
+    updatedAt: '2026-07-23T00:00:00.000Z',
+    dates: {
+      checkIn: '2026-07-29',
+      checkOut: '2026-08-11',
+      adults: 2,
+    },
+    requirementSet: {
+      id: 'requirements-v1',
+      parserVersion: 'parser-v1',
+      file: 'requirements.json',
+    },
+    listings: {
+      'airbnb/111': airbnbOne,
+      'airbnb/222': airbnbTwo,
+      'booking/example': booking,
+    },
+  };
+  writeJson(path.join(sourceRoot, 'batch_manifest.json'), manifest);
+  writeJson(path.join(sourceRoot, 'requirements.json'), {
+    keep: 'byte-identical',
+  });
+  seedEntryArtifacts(sourceRoot, airbnbOne, firstBefore);
+  seedEntryArtifacts(sourceRoot, airbnbTwo, secondBefore);
+  seedEntryArtifacts(sourceRoot, booking, bookingBefore);
+  fs.writeFileSync(path.join(sourceRoot, 'report.html'), 'original report');
+
+  const sourceFilesBefore = new Map(
+    [
+      'batch_manifest.json',
+      'requirements.json',
+      airbnbOne.details.file,
+      airbnbOne.reviews.file,
+      `${airbnbOne.photos.dir}/01.jpg`,
+      airbnbOne.aiReviews.file,
+      airbnbOne.aiPhotos.file,
+      airbnbOne.triage.file,
+      airbnbTwo.details.file,
+      booking.details.file,
+      booking.reviews.file,
+      booking.aiReviews.file,
+      booking.aiPhotos.file,
+      booking.triage.file,
+      'report.html',
+    ].map((relativePath) => [
+      relativePath,
+      fs.readFileSync(path.join(sourceRoot, relativePath)),
+    ]),
+  );
+
+  const job: DetailsRepairJobInput = {
+    id: 'job-nyc',
+    status: 'completed',
+    currentPhase: 'results-ready',
+    analysisStatus: 'completed',
+    analysisCurrentPhase: 'completed',
+    priceRefreshStatus: 'pending',
+    priceRefreshCurrentPhase: null,
+    artifactRoot: sourceRoot,
+    reportPath: path.join(sourceRoot, 'report.html'),
+    checkin: '2026-07-29',
+    checkout: '2026-08-11',
+    adults: 2,
+    sourceStateFingerprint: 'db-state-before',
+    listings: [
+      {
+        rowId: 'row-111',
+        analysisId: 'analysis-111',
+        listingId: '111',
+        platform: 'airbnb',
+        url: airbnbOneUrl,
+        detailsStatus: 'completed',
+        details: firstBefore,
+      },
+      {
+        rowId: 'row-222',
+        analysisId: 'analysis-222',
+        listingId: '222',
+        platform: 'airbnb',
+        url: airbnbTwoUrl,
+        detailsStatus: 'completed',
+        details: secondBefore,
+      },
+      {
+        rowId: 'row-booking',
+        analysisId: 'analysis-booking',
+        listingId: 'example',
+        platform: 'booking',
+        url: bookingUrl,
+        detailsStatus: 'completed',
+        details: bookingBefore,
+      },
+    ],
+  };
+
+  const capturedBatchOptions: BatchOptions[] = [];
+  let capturedUrls: string[] = [];
+  const plan = await stageReviewJobDetailsRepair({
+    job,
+    platform: 'airbnb',
+    stagedRoot,
+    now: new Date('2026-07-27T13:00:00.000Z'),
+    runBatch: async (filePaths, options) => {
+      capturedBatchOptions.push(options);
+      capturedUrls = fs.readFileSync(filePaths[0], 'utf8')
+        .trim()
+        .split('\n');
+      const stagedManifest = readJson<BatchManifest>(
+        path.join(stagedRoot, 'batch_manifest.json'),
+      );
+      writeJson(path.join(stagedRoot, airbnbOne.details.file), {
+        title: 'Recovered title',
+        rating: 4.9,
+        reviewCount: 0,
+        subRatings: { cleanliness: 4.8 },
+        amenities: [{ name: 'Elevator' }, { name: 'Air conditioning' }],
+        host: { name: 'Replacement Host' },
+        description: 'Replacement description',
+        staySnapshot: { capturedAt: 'replacement' },
+      });
+      stagedManifest.listings['airbnb/111'].details = {
+        status: 'fetched',
+        file: airbnbOne.details.file,
+        source: 'network',
+      };
+      stagedManifest.listings['airbnb/222'].details = {
+        status: 'failed',
+        error: 'provider timeout',
+      };
+      writeJson(
+        path.join(stagedRoot, 'batch_manifest.json'),
+        stagedManifest,
+      );
+      return {};
+    },
+    generateReport: async ({ outputFile }) => {
+      fs.writeFileSync(outputFile as string, 'regenerated report');
+      return outputFile as string;
+    },
+  });
+
+  try {
+    assert.deepEqual(capturedUrls, [airbnbOneUrl, airbnbTwoUrl]);
+    const capturedOptions = capturedBatchOptions[0];
+    assert.ok(capturedOptions);
+    assert.deepEqual(
+      {
+        details: capturedOptions.fetchDetails,
+        reviews: capturedOptions.fetchReviews,
+        photos: capturedOptions.fetchPhotos,
+        aiReviews: capturedOptions.aiReviews,
+        aiPhotos: capturedOptions.aiPhotos,
+        triage: capturedOptions.triage,
+        force: capturedOptions.force,
+        retry: capturedOptions.retryFailed,
+        scopeManifest: capturedOptions.scopeManifestToInput,
+        scopePostScrape: capturedOptions.scopePostScrapePhasesToInput,
+      },
+      {
+        details: true,
+        reviews: false,
+        photos: false,
+        aiReviews: false,
+        aiPhotos: false,
+        triage: false,
+        force: false,
+        retry: false,
+        scopeManifest: false,
+        scopePostScrape: true,
+      },
+    );
+
+    assert.equal(plan.listings.length, 2);
+    assert.equal(plan.listings[0].outcome, 'repaired');
+    assert.deepEqual(plan.listings[0].addedFields, [
+      'title',
+      'reviewCount',
+      'subRatings',
+      'amenities',
+    ]);
+    assert.equal(plan.listings[1].outcome, 'preserved');
+    assert.match(plan.listings[1].message ?? '', /provider timeout/);
+    assert.equal(plan.totalAddedFields, 4);
+
+    const repairedDetails = readJson<Record<string, unknown>>(
+      path.join(stagedRoot, airbnbOne.details.file),
+    );
+    assert.deepEqual(repairedDetails, {
+      ...firstBefore,
+      title: 'Recovered title',
+      reviewCount: 0,
+      subRatings: { cleanliness: 4.8 },
+      amenities: [{ name: 'Elevator' }, { name: 'Air conditioning' }],
+    });
+    assert.deepEqual(
+      readJson(path.join(stagedRoot, airbnbTwo.details.file)),
+      secondBefore,
+    );
+    assert.deepEqual(
+      readJson(path.join(stagedRoot, booking.details.file)),
+      bookingBefore,
+    );
+    assert.ok(fs.existsSync(path.join(stagedRoot, DETAILS_REPAIR_PLAN_FILE)));
+
+    for (const [relativePath, expected] of sourceFilesBefore) {
+      assert.deepEqual(
+        fs.readFileSync(path.join(sourceRoot, relativePath)),
+        expected,
+        `source changed: ${relativePath}`,
+      );
+    }
+    for (const relativePath of [
+      'requirements.json',
+      airbnbOne.reviews.file,
+      `${airbnbOne.photos.dir}/01.jpg`,
+      airbnbOne.aiReviews.file,
+      airbnbOne.aiPhotos.file,
+      airbnbOne.triage.file,
+      booking.details.file,
+      booking.reviews.file,
+      booking.aiReviews.file,
+      booking.aiPhotos.file,
+      booking.triage.file,
+    ]) {
+      assert.deepEqual(
+        fs.readFileSync(path.join(stagedRoot, relativePath)),
+        sourceFilesBefore.get(relativePath),
+        `preserved staged artifact changed: ${relativePath}`,
+      );
+    }
+
+    const loadedPlan = readReviewJobDetailsRepairPlan(stagedRoot);
+    const updates = validateReviewJobDetailsRepairForApply({
+      plan: loadedPlan,
+      job,
+    });
+    assert.equal(updates.length, 1);
+    assert.equal(updates[0].analysisId, 'analysis-111');
+    assert.equal(updates[0].detailsStatus, 'completed');
+    assert.equal(
+      fingerprintDetailsRepairValue(updates[0].details),
+      plan.listings[0].afterDetailsFingerprint,
+    );
+
+    assert.throws(
+      () => validateReviewJobDetailsRepairForApply({
+        plan: loadedPlan,
+        job: {
+          ...job,
+          sourceStateFingerprint: 'concurrent-change',
+        },
+      }),
+      /state changed after the dry run/,
+    );
+
+    const sourceDetailsPath = path.join(
+      sourceRoot,
+      airbnbOne.details.file,
+    );
+    const sourceDetailsBefore = fs.readFileSync(sourceDetailsPath);
+    fs.writeFileSync(sourceDetailsPath, '{"tampered":true}');
+    assert.throws(
+      () => validateReviewJobDetailsRepairForApply({
+        plan: loadedPlan,
+        job,
+      }),
+      /Source details artifact changed/,
+    );
+    fs.writeFileSync(sourceDetailsPath, sourceDetailsBefore);
+
+    const repairedDetailsPath = path.join(
+      stagedRoot,
+      airbnbOne.details.file,
+    );
+    const repairedDetailsBefore = fs.readFileSync(repairedDetailsPath);
+    const tamperedDetails = {
+      ...readJson<Record<string, unknown>>(repairedDetailsPath),
+      host: { name: 'Tampered Host' },
+    };
+    writeJson(repairedDetailsPath, tamperedDetails);
+    const tamperedPlan = structuredClone(loadedPlan);
+    tamperedPlan.listings[0].afterDetailsFingerprint =
+      fingerprintDetailsRepairValue(tamperedDetails);
+    assert.throws(
+      () => validateReviewJobDetailsRepairForApply({
+        plan: tamperedPlan,
+        job,
+      }),
+      /outside the missing-core repair/,
+    );
+    fs.writeFileSync(repairedDetailsPath, repairedDetailsBefore);
+
+    const triagePath = path.join(stagedRoot, airbnbOne.triage.file);
+    const triageBefore = fs.readFileSync(triagePath);
+    fs.writeFileSync(triagePath, 'tampered');
+    assert.throws(
+      () => validateReviewJobDetailsRepairForApply({
+        plan: loadedPlan,
+        job,
+      }),
+      /preserved artifacts changed/,
+    );
+    fs.writeFileSync(triagePath, triageBefore);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('details repair refuses a no-op plan and leaves the source root unchanged', async () => {
+  const tempRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'reviewr-details-noop-'),
+  );
+  const sourceRoot = path.join(tempRoot, 'source');
+  const stagedRoot = path.join(tempRoot, 'staged');
+  const url = 'https://www.airbnb.com/rooms/333';
+  const entry = manifestEntry('airbnb', '333', url);
+  const before = {
+    title: '',
+    rating: null,
+    reviewCount: null,
+    subRatings: {},
+    amenities: [],
+    host: { name: 'Kept' },
+  };
+  fs.mkdirSync(sourceRoot, { recursive: true });
+  writeJson(path.join(sourceRoot, 'batch_manifest.json'), {
+    version: 2,
+    createdAt: '2026-07-23T00:00:00.000Z',
+    updatedAt: '2026-07-23T00:00:00.000Z',
+    dates: {},
+    listings: { 'airbnb/333': entry },
+  });
+  seedEntryArtifacts(sourceRoot, entry, before);
+  fs.writeFileSync(path.join(sourceRoot, 'report.html'), 'original');
+  const sourceDetailsBefore = fs.readFileSync(
+    path.join(sourceRoot, entry.details.file),
+  );
+
+  try {
+    await assert.rejects(
+      stageReviewJobDetailsRepair({
+        job: {
+          id: 'job-noop',
+          status: 'completed',
+          currentPhase: 'results-ready',
+          analysisStatus: 'completed',
+          analysisCurrentPhase: 'completed',
+          priceRefreshStatus: 'pending',
+          priceRefreshCurrentPhase: null,
+          artifactRoot: sourceRoot,
+          reportPath: path.join(sourceRoot, 'report.html'),
+          checkin: null,
+          checkout: null,
+          adults: 2,
+          sourceStateFingerprint: 'state',
+          listings: [{
+            rowId: 'row-333',
+            analysisId: 'analysis-333',
+            listingId: '333',
+            platform: 'airbnb',
+            url,
+            detailsStatus: 'completed',
+            details: before,
+          }],
+        },
+        platform: 'airbnb',
+        stagedRoot,
+        runBatch: async (_files, _options) => {
+          const stagedManifest = readJson<BatchManifest>(
+            path.join(stagedRoot, 'batch_manifest.json'),
+          );
+          stagedManifest.listings['airbnb/333'].details = {
+            status: 'failed',
+            error: 'provider unavailable',
+          };
+          writeJson(
+            path.join(stagedRoot, 'batch_manifest.json'),
+            stagedManifest,
+          );
+          return {};
+        },
+        generateReport: async () => {
+          throw new Error('report should not run for a no-op plan');
+        },
+      }),
+      /recovered no missing core fields/,
+    );
+    assert.deepEqual(
+      fs.readFileSync(path.join(sourceRoot, entry.details.file)),
+      sourceDetailsBefore,
+    );
+    assert.equal(
+      fs.existsSync(path.join(stagedRoot, DETAILS_REPAIR_PLAN_FILE)),
+      false,
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/web/README.md
+++ b/web/README.md
@@ -118,6 +118,32 @@ its last known snapshot and records the attempt time and error. Partial runs rep
 failed counts. Affordability is recomputed deterministically from the refreshed public stay price
 and availability; the independent quality score and tier remain unchanged.
 
+For parser repairs that must fill missing persisted details without refreshing prices or changing
+affordability, use the separate maintenance command. It currently supports Airbnb only and is
+dry-run-first:
+
+```bash
+npm run repair:job-details -- --job <review-job-id> --platform airbnb
+```
+
+The dry run requires an idle job, clones the current artifact run, removes only the cloned target
+details files, and runs only the details phase with normal cache semantics. It fills only core
+fields that were previously missing (`title`, `rating`, `reviewCount`, `subRatings`, and
+`amenities`); existing values and every non-details artifact remain byte-identical. It prints a
+per-listing before/after coverage matrix and an explicit apply command containing the staged root.
+Apply revalidates the unchanged database baseline, original manifest, staged report, target detail
+files, and all preserved artifacts before one serializable transaction:
+
+```bash
+npm run repair:job-details -- --job <review-job-id> --platform airbnb \
+  --apply --staged-root "<path printed by the dry run>"
+```
+
+That transaction updates only repaired listing-analysis `details`/`detailsStatus` fields and the
+job's artifact/report pointers. Reviews, photos, AI artifacts, triage verdicts, costs, curation,
+duplicate decisions, and listing price snapshots are not rewritten. The previous artifact root is
+retained for operator verification; the command never deletes it.
+
 A fresh `no` is excluded from actionable ranking. `partial`, `unknown`, and stale availability
 remain visible as conditional or unknown. Signed-in and Genius rates may be lower than the public
 snapshot.

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "worker": "dotenv -e ../.env -e .env.local -- tsx src/lib/search-worker.ts",
     "worker:dev": "dotenv -e ../.env -e .env.local -- tsx watch src/lib/search-worker.ts",
     "backfill:ai-costs": "dotenv -e ../.env -e .env.local -- tsx scripts/backfill-ai-costs.ts",
+    "repair:job-details": "dotenv -e ../.env -e .env.local -- tsx scripts/refresh-job-details.ts",
     "cleanup:artifacts": "dotenv -e ../.env -e .env.local -- tsx scripts/cleanup-artifacts.ts",
     "test:pricing": "tsx --test src/lib/pricing.test.ts",
     "test:ui": "tsx --test src/components/*.test.tsx",

--- a/web/scripts/refresh-job-details.ts
+++ b/web/scripts/refresh-job-details.ts
@@ -1,0 +1,438 @@
+import * as path from 'node:path';
+import {
+  Prisma,
+  PrismaClient,
+  type Platform,
+} from '@prisma/client';
+import { config as loadDotEnv } from 'dotenv';
+import {
+  fingerprintDetailsRepairValue,
+  readReviewJobDetailsRepairPlan,
+  stageReviewJobDetailsRepair,
+  validateReviewJobDetailsRepairForApply,
+  type DetailsRepairCoverage,
+  type DetailsRepairJobInput,
+  type DetailsRepairPlatform,
+  type DetailsRepairPlan,
+} from '../src/lib/review-job-details-repair.js';
+
+for (const envPath of [
+  path.resolve(process.cwd(), '.env.local'),
+  path.resolve(process.cwd(), '.env'),
+  path.resolve(process.cwd(), '../.env'),
+]) {
+  loadDotEnv({ path: envPath, override: false, quiet: true });
+}
+
+interface CliOptions {
+  apply: boolean;
+  jobId: string;
+  platform: DetailsRepairPlatform;
+  stagedRoot?: string;
+}
+
+const jobInclude = Prisma.validator<Prisma.ReviewJobInclude>()({
+  listings: {
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    include: { analysis: true },
+  },
+  duplicatePairs: {
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+  },
+});
+
+type RepairJobRecord = Prisma.ReviewJobGetPayload<{
+  include: typeof jobInclude;
+}>;
+
+type RepairDbClient = PrismaClient | Prisma.TransactionClient;
+
+function usage(): string {
+  return (
+    'Usage:\n'
+    + '  npm run repair:job-details -- --job <id> --platform airbnb\n'
+    + '  npm run repair:job-details -- --job <id> --platform airbnb '
+    + '--apply --staged-root <dry-run-root>\n\n'
+    + 'Dry-run is the default. It fetches details into a cloned artifact run, '
+    + 'prints per-listing coverage, and does not write the database. '
+    + 'Apply revalidates that exact staged run and the unchanged live-job '
+    + 'baseline before one atomic database transaction.'
+  );
+}
+
+function parseArgs(args: string[]): CliOptions {
+  let apply = false;
+  let jobId = '';
+  let platform: DetailsRepairPlatform | null = null;
+  let stagedRoot: string | undefined;
+
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    if (argument === '--apply') {
+      apply = true;
+      continue;
+    }
+    if (argument === '--job') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error('--job requires a review-job ID');
+      }
+      jobId = value;
+      index++;
+      continue;
+    }
+    if (argument === '--platform') {
+      const value = args[index + 1];
+      if (value !== 'airbnb') {
+        throw new Error('--platform currently supports only "airbnb"');
+      }
+      platform = value;
+      index++;
+      continue;
+    }
+    if (argument === '--staged-root') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error('--staged-root requires a path');
+      }
+      stagedRoot = value;
+      index++;
+      continue;
+    }
+    if (argument === '--help' || argument === '-h') {
+      console.log(usage());
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+
+  if (!jobId) {
+    throw new Error('--job is required');
+  }
+  if (!platform) {
+    throw new Error('--platform airbnb is required');
+  }
+  if (apply && !stagedRoot) {
+    throw new Error('--apply requires --staged-root from a completed dry run');
+  }
+  if (!apply && stagedRoot) {
+    throw new Error('--staged-root is accepted only with --apply');
+  }
+
+  return {
+    apply,
+    jobId,
+    platform,
+    ...(stagedRoot ? { stagedRoot: path.resolve(stagedRoot) } : {}),
+  };
+}
+
+async function readRepairJob(
+  client: RepairDbClient,
+  jobId: string,
+): Promise<RepairJobRecord | null> {
+  return client.reviewJob.findUnique({
+    where: { id: jobId },
+    include: jobInclude,
+  });
+}
+
+function toRepairJobInput(job: RepairJobRecord): DetailsRepairJobInput {
+  return {
+    id: job.id,
+    status: job.status,
+    currentPhase: job.currentPhase,
+    analysisStatus: job.analysisStatus,
+    analysisCurrentPhase: job.analysisCurrentPhase,
+    priceRefreshStatus: job.priceRefreshStatus,
+    priceRefreshCurrentPhase: job.priceRefreshCurrentPhase,
+    artifactRoot: job.artifactRoot,
+    reportPath: job.reportPath,
+    checkin: job.checkin,
+    checkout: job.checkout,
+    adults: job.adults,
+    sourceStateFingerprint: fingerprintDetailsRepairValue(job),
+    listings: job.listings.map((listing) => {
+      if (!listing.analysis) {
+        throw new Error(
+          `Review job listing ${listing.id} has no persisted analysis row`,
+        );
+      }
+      return {
+        rowId: listing.id,
+        analysisId: listing.analysis.id,
+        listingId: listing.listingId,
+        platform: listing.platform as Platform,
+        url: listing.url,
+        detailsStatus: listing.analysis.detailsStatus,
+        details: listing.analysis.details,
+      };
+    }),
+  };
+}
+
+function flag(value: boolean): string {
+  return value ? '1' : '0';
+}
+
+function coverageCells(coverage: DetailsRepairCoverage): string {
+  return [
+    flag(coverage.title),
+    flag(coverage.rating),
+    flag(coverage.reviewCount),
+    flag(coverage.subRatings),
+    flag(coverage.amenities),
+  ].join('/');
+}
+
+function printPlan(plan: DetailsRepairPlan): void {
+  console.log(
+    'listing_id\toutcome\tadded_fields\t'
+    + 'before(title/rating/reviews/subratings/amenities)\t'
+    + 'after(title/rating/reviews/subratings/amenities)\tmessage',
+  );
+  for (const listing of plan.listings) {
+    console.log([
+      listing.listingId,
+      listing.outcome,
+      listing.addedFields.join(',') || '-',
+      coverageCells(listing.beforeCoverage),
+      coverageCells(listing.afterCoverage),
+      listing.message ?? '-',
+    ].join('\t'));
+  }
+  console.log(
+    `Summary: listings=${plan.listings.length}; `
+    + `repaired=${plan.listings.filter(
+      (listing) => listing.outcome === 'repaired',
+    ).length}; `
+    + `preserved=${plan.listings.filter(
+      (listing) => listing.outcome === 'preserved',
+    ).length}; `
+    + `added_core_fields=${plan.totalAddedFields}`,
+  );
+}
+
+function postApplyInvariant(
+  job: RepairJobRecord,
+  repairedRowIds: Set<string>,
+): string {
+  const clone = JSON.parse(JSON.stringify(job)) as {
+    artifactRoot?: unknown;
+    reportPath?: unknown;
+    listings?: Array<{
+      id: string;
+      analysis?: {
+        details?: unknown;
+        detailsStatus?: unknown;
+        updatedAt?: unknown;
+        [key: string]: unknown;
+      } | null;
+      [key: string]: unknown;
+    }>;
+    [key: string]: unknown;
+  };
+  delete clone.artifactRoot;
+  delete clone.reportPath;
+  for (const listing of clone.listings ?? []) {
+    if (!repairedRowIds.has(listing.id) || !listing.analysis) continue;
+    delete listing.analysis.details;
+    delete listing.analysis.detailsStatus;
+    delete listing.analysis.updatedAt;
+  }
+  return fingerprintDetailsRepairValue(clone);
+}
+
+async function dryRun(
+  prisma: PrismaClient,
+  options: CliOptions,
+): Promise<void> {
+  const job = await readRepairJob(prisma, options.jobId);
+  if (!job) {
+    throw new Error(`Review job ${options.jobId} not found`);
+  }
+  const plan = await stageReviewJobDetailsRepair({
+    job: toRepairJobInput(job),
+    platform: options.platform,
+  });
+
+  console.log(
+    `DRY RUN complete: source=${plan.sourceArtifactRoot}`,
+  );
+  console.log(`Staged root retained at: ${plan.stagedArtifactRoot}`);
+  printPlan(plan);
+  console.log(
+    '\nNo database rows were changed. After review and explicit approval, apply '
+    + 'this exact staged run with:\n'
+    + `npm --prefix web run repair:job-details -- --job ${plan.jobId} `
+    + `--platform ${plan.platform} --apply --staged-root `
+    + `${JSON.stringify(plan.stagedArtifactRoot)}`,
+  );
+}
+
+async function applyPlan(
+  prisma: PrismaClient,
+  options: CliOptions,
+): Promise<void> {
+  const plan = readReviewJobDetailsRepairPlan(
+    options.stagedRoot as string,
+  );
+  if (plan.jobId !== options.jobId || plan.platform !== options.platform) {
+    throw new Error('CLI job/platform do not match the staged repair plan');
+  }
+
+  const preflightJob = await readRepairJob(prisma, options.jobId);
+  if (!preflightJob) {
+    throw new Error(`Review job ${options.jobId} not found`);
+  }
+  const preflightUpdates = validateReviewJobDetailsRepairForApply({
+    plan,
+    job: toRepairJobInput(preflightJob),
+  });
+  console.log(
+    `APPLY preflight: ${preflightUpdates.length} listing update(s); `
+    + `source=${plan.sourceArtifactRoot}; staged=${plan.stagedArtifactRoot}`,
+  );
+
+  await prisma.$transaction(async (tx) => {
+    await tx.$queryRaw(
+      Prisma.sql`
+        SELECT "id"
+        FROM "ReviewJob"
+        WHERE "id" = ${options.jobId}
+        FOR UPDATE
+      `,
+    );
+    await tx.$queryRaw(
+      Prisma.sql`
+        SELECT "id"
+        FROM "ReviewJobListing"
+        WHERE "jobId" = ${options.jobId}
+        FOR UPDATE
+      `,
+    );
+    await tx.$queryRaw(
+      Prisma.sql`
+        SELECT analysis."id"
+        FROM "ReviewJobListingAnalysis" analysis
+        INNER JOIN "ReviewJobListing" listing
+          ON listing."id" = analysis."jobListingId"
+        WHERE listing."jobId" = ${options.jobId}
+        FOR UPDATE OF analysis
+      `,
+    );
+    await tx.$queryRaw(
+      Prisma.sql`
+        SELECT "id"
+        FROM "ReviewJobDuplicatePair"
+        WHERE "jobId" = ${options.jobId}
+        FOR SHARE
+      `,
+    );
+
+    const lockedJob = await readRepairJob(tx, options.jobId);
+    if (!lockedJob) {
+      throw new Error(`Review job ${options.jobId} disappeared during apply`);
+    }
+    const updates = validateReviewJobDetailsRepairForApply({
+      plan,
+      job: toRepairJobInput(lockedJob),
+    });
+
+    for (const update of updates) {
+      await tx.reviewJobListingAnalysis.update({
+        where: { id: update.analysisId },
+        data: {
+          details:
+            update.details as unknown as Prisma.InputJsonValue,
+          detailsStatus: update.detailsStatus,
+        },
+      });
+    }
+    await tx.reviewJob.update({
+      where: { id: options.jobId },
+      data: {
+        artifactRoot: plan.stagedArtifactRoot,
+        reportPath: plan.stagedReportPath,
+      },
+    });
+  }, {
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    maxWait: 10_000,
+    timeout: 30_000,
+  });
+
+  const appliedJob = await readRepairJob(prisma, options.jobId);
+  if (
+    !appliedJob
+    || path.resolve(appliedJob.artifactRoot ?? '')
+      !== plan.stagedArtifactRoot
+    || appliedJob.reportPath !== plan.stagedReportPath
+  ) {
+    throw new Error(
+      'Apply transaction committed but the canonical artifact pointers '
+      + 'did not verify',
+    );
+  }
+  const repairedRowIds = new Set(
+    plan.listings
+      .filter((listing) => listing.outcome === 'repaired')
+      .map((listing) => listing.rowId),
+  );
+  if (
+    postApplyInvariant(appliedJob, repairedRowIds)
+    !== postApplyInvariant(preflightJob, repairedRowIds)
+  ) {
+    throw new Error(
+      'Apply committed but a field outside the approved details/pointer '
+      + 'scope changed',
+    );
+  }
+  const appliedListings = new Map(
+    appliedJob.listings.map((listing) => [listing.id, listing]),
+  );
+  for (const planned of plan.listings) {
+    if (planned.outcome !== 'repaired') continue;
+    const applied = appliedListings.get(planned.rowId)?.analysis;
+    const expectedStatus =
+      planned.afterDetailsStatus === 'partial' ? 'partial' : 'completed';
+    if (
+      !applied
+      || fingerprintDetailsRepairValue(applied.details)
+        !== planned.afterDetailsFingerprint
+      || applied.detailsStatus !== expectedStatus
+    ) {
+      throw new Error(
+        `Apply committed but repaired details did not verify: `
+        + `${planned.listingId}`,
+      );
+    }
+  }
+
+  console.log(
+    `APPLY complete: ${preflightUpdates.length} listing detail row(s) updated`,
+  );
+  printPlan(plan);
+  console.log(
+    `Original artifact root retained at: ${plan.sourceArtifactRoot}`,
+  );
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const prisma = new PrismaClient();
+  try {
+    if (options.apply) {
+      await applyPlan(prisma, options);
+    } else {
+      await dryRun(prisma, options);
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/web/src/lib/review-job-details-repair.ts
+++ b/web/src/lib/review-job-details-repair.ts
@@ -1,0 +1,1156 @@
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  runBatch as defaultRunBatch,
+  type BatchManifest,
+  type BatchOptions,
+  type ManifestEntry,
+} from '../../../src/batch.js';
+import { generateReport as defaultGenerateReport } from '../../../src/report.js';
+import {
+  getListingMatchKey,
+  getManifestPathFromRoot,
+  getReportPathFromRoot,
+} from './review-job-analysis.js';
+import {
+  getReviewJobArtifactRunDir,
+  isReviewJobArtifactRootAvailable,
+} from './reviewJobArtifacts.js';
+
+export const DETAILS_REPAIR_PLAN_VERSION = 1;
+export const DETAILS_REPAIR_PLAN_FILE = 'details-repair-plan.json';
+
+export type DetailsRepairPlatform = 'airbnb';
+export type DetailsRepairCoreField =
+  | 'title'
+  | 'rating'
+  | 'reviewCount'
+  | 'subRatings'
+  | 'amenities';
+
+export interface DetailsRepairCoverage {
+  title: boolean;
+  rating: boolean;
+  reviewCount: boolean;
+  subRatings: boolean;
+  amenities: boolean;
+  total: number;
+}
+
+export interface DetailsRepairListingInput {
+  rowId: string;
+  analysisId: string;
+  listingId: string;
+  platform: 'airbnb' | 'booking';
+  url: string;
+  detailsStatus: string;
+  details: unknown;
+}
+
+export interface DetailsRepairJobInput {
+  id: string;
+  status: string;
+  currentPhase: string | null;
+  analysisStatus: string;
+  analysisCurrentPhase: string | null;
+  priceRefreshStatus: string;
+  priceRefreshCurrentPhase: string | null;
+  artifactRoot: string | null;
+  reportPath: string | null;
+  checkin: string | null;
+  checkout: string | null;
+  adults: number;
+  sourceStateFingerprint: string;
+  listings: DetailsRepairListingInput[];
+}
+
+export interface DetailsRepairPlanListing {
+  rowId: string;
+  analysisId: string;
+  listingId: string;
+  platform: DetailsRepairPlatform;
+  url: string;
+  manifestKey: string;
+  outcome: 'repaired' | 'preserved';
+  message: string | null;
+  addedFields: DetailsRepairCoreField[];
+  beforeCoverage: DetailsRepairCoverage;
+  afterCoverage: DetailsRepairCoverage;
+  beforeDetailsFingerprint: string;
+  sourceDetailsArtifactFingerprint: string;
+  afterDetailsFingerprint: string;
+  detailsFile: string;
+  beforeDetailsStatus: string;
+  afterDetailsStatus: ManifestEntry['details']['status'];
+}
+
+export interface DetailsRepairPlan {
+  version: typeof DETAILS_REPAIR_PLAN_VERSION;
+  jobId: string;
+  platform: DetailsRepairPlatform;
+  createdAt: string;
+  sourceArtifactRoot: string;
+  sourceReportPath: string | null;
+  sourceStateFingerprint: string;
+  sourceManifestFingerprint: string;
+  sourcePreservedArtifactsFingerprint: string;
+  stagedArtifactRoot: string;
+  stagedReportPath: string;
+  stagedReportFingerprint: string;
+  stagedManifestInvariantFingerprint: string;
+  stagedPreservedArtifactsFingerprint: string;
+  listings: DetailsRepairPlanListing[];
+  totalAddedFields: number;
+}
+
+export interface DetailsRepairApplyUpdate {
+  analysisId: string;
+  listingId: string;
+  details: Record<string, unknown>;
+  detailsStatus: 'completed' | 'partial';
+}
+
+type RunBatch = (
+  filePaths: string[],
+  options: BatchOptions,
+) => Promise<unknown>;
+
+type GenerateReport = (options: {
+  outputDir: string;
+  outputFile?: string;
+}) => Promise<string>;
+
+interface StageDetailsRepairInput {
+  job: DetailsRepairJobInput;
+  platform: DetailsRepairPlatform;
+  stagedRoot?: string;
+  now?: Date;
+  runBatch?: RunBatch;
+  generateReport?: GenerateReport;
+}
+
+const CORE_FIELDS: DetailsRepairCoreField[] = [
+  'title',
+  'rating',
+  'reviewCount',
+  'subRatings',
+  'amenities',
+];
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function finiteNumber(value: unknown): number | null {
+  if (
+    value == null
+    || (typeof value === 'string' && value.trim() === '')
+  ) {
+    return null;
+  }
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function hasSubRatings(value: unknown): boolean {
+  const record = asRecord(value);
+  return !!record && Object.values(record).some(
+    (rating) => finiteNumber(rating) != null,
+  );
+}
+
+function hasAmenities(value: unknown): boolean {
+  return Array.isArray(value) && value.some((amenity) => {
+    if (typeof amenity === 'string') {
+      return nonEmptyString(amenity) != null;
+    }
+    return nonEmptyString(asRecord(amenity)?.name) != null;
+  });
+}
+
+export function getDetailsRepairCoverage(
+  value: unknown,
+): DetailsRepairCoverage {
+  const details = asRecord(value);
+  const coverage = {
+    title: nonEmptyString(details?.title) != null,
+    rating: finiteNumber(details?.rating) != null,
+    reviewCount:
+      finiteNumber(details?.reviewCount) != null
+      && (finiteNumber(details?.reviewCount) as number) >= 0,
+    subRatings: hasSubRatings(details?.subRatings),
+    amenities: hasAmenities(details?.amenities),
+  };
+  return {
+    ...coverage,
+    total: CORE_FIELDS.filter((field) => coverage[field]).length,
+  };
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function normalizeForFingerprint(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeForFingerprint(item));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, child]) => child !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, normalizeForFingerprint(child)]),
+    );
+  }
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    return null;
+  }
+  return value;
+}
+
+export function fingerprintDetailsRepairValue(value: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(normalizeForFingerprint(value)))
+    .digest('hex');
+}
+
+function fingerprintFile(filePath: string): string {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function fingerprintArtifactTree(
+  rootDir: string,
+  excludedRelativePaths: Set<string>,
+): string {
+  const resolvedRoot = path.resolve(rootDir);
+  const hash = createHash('sha256');
+
+  function walk(currentDir: string): void {
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })
+      .sort((left, right) => left.name.localeCompare(right.name))) {
+      const filePath = path.join(currentDir, entry.name);
+      const stat = fs.lstatSync(filePath);
+      if (stat.isSymbolicLink()) {
+        throw new Error(
+          `Artifact tree contains a symbolic link: ${filePath}`,
+        );
+      }
+      if (stat.isDirectory()) {
+        walk(filePath);
+        continue;
+      }
+      if (!stat.isFile()) {
+        throw new Error(
+          `Artifact tree contains a non-regular entry: ${filePath}`,
+        );
+      }
+      const relativePath =
+        path.relative(resolvedRoot, filePath).split(path.sep).join('/');
+      if (excludedRelativePaths.has(relativePath)) {
+        continue;
+      }
+      hash.update(relativePath);
+      hash.update('\0');
+      hash.update(fs.readFileSync(filePath));
+      hash.update('\0');
+    }
+  }
+
+  walk(resolvedRoot);
+  return hash.digest('hex');
+}
+
+function repairMutableArtifactPaths(
+  detailsFiles: Iterable<string>,
+): Set<string> {
+  return new Set([
+    'batch_manifest.json',
+    'report.html',
+    'details_repair_urls.txt',
+    DETAILS_REPAIR_PLAN_FILE,
+    ...Array.from(detailsFiles, (filePath) =>
+      filePath.split(path.sep).join('/')),
+  ]);
+}
+
+function resolveArtifactFile(
+  rootDir: string,
+  relativePath: string,
+  label: string,
+): string {
+  if (!relativePath || path.isAbsolute(relativePath)) {
+    throw new Error(`${label} must be a relative artifact path`);
+  }
+  const resolvedRoot = path.resolve(rootDir);
+  const resolved = path.resolve(resolvedRoot, relativePath);
+  if (
+    resolved === resolvedRoot
+    || !resolved.startsWith(`${resolvedRoot}${path.sep}`)
+  ) {
+    throw new Error(`${label} escapes the artifact root`);
+  }
+  return resolved;
+}
+
+function assertRegularFile(filePath: string, label: string): void {
+  const stat = fs.lstatSync(filePath);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`${label} is not a regular file: ${filePath}`);
+  }
+}
+
+function assertIdleJob(job: DetailsRepairJobInput): void {
+  if (job.status === 'pending' || job.status === 'running') {
+    throw new Error(
+      `Review job ${job.id} is ${job.status}; details repair requires an idle job`,
+    );
+  }
+  if (
+    job.analysisStatus === 'running'
+    || job.analysisCurrentPhase === 'queued'
+  ) {
+    throw new Error(
+      `Review job ${job.id} has analysis in progress`,
+    );
+  }
+  if (
+    job.priceRefreshStatus === 'running'
+    || job.priceRefreshCurrentPhase === 'queued'
+  ) {
+    throw new Error(
+      `Review job ${job.id} has a price refresh in progress`,
+    );
+  }
+}
+
+function getManifestEntry(
+  manifest: BatchManifest,
+  platform: 'airbnb' | 'booking',
+  url: string,
+): [string, ManifestEntry] | null {
+  const matchKey = getListingMatchKey(platform, url);
+  return Object.entries(manifest.listings).find(
+    ([, entry]) =>
+      getListingMatchKey(entry.platform, entry.url) === matchKey,
+  ) ?? null;
+}
+
+function manifestInvariantValue(
+  manifest: BatchManifest,
+  mutableTargetKeys: Set<string>,
+): unknown {
+  return {
+    ...manifest,
+    updatedAt: '<ignored>',
+    listings: Object.fromEntries(
+      Object.entries(manifest.listings).map(([key, entry]) => {
+        const matchKey = getListingMatchKey(entry.platform, entry.url);
+        return [
+          key,
+          mutableTargetKeys.has(matchKey)
+            ? { ...entry, details: '<repair-target>' }
+            : entry,
+        ];
+      }),
+    ),
+  };
+}
+
+function manifestInvariantFingerprint(
+  manifest: BatchManifest,
+  mutableTargetKeys: Set<string>,
+): string {
+  return fingerprintDetailsRepairValue(
+    manifestInvariantValue(manifest, mutableTargetKeys),
+  );
+}
+
+function restoreSourceDetails(input: {
+  sourceRoot: string;
+  stagedRoot: string;
+  sourceEntry: ManifestEntry;
+  stagedEntry: ManifestEntry;
+}): void {
+  input.stagedEntry.details = cloneJson(input.sourceEntry.details);
+  if (!input.sourceEntry.details.file) {
+    throw new Error(
+      `Source details artifact is missing for ${input.sourceEntry.platform}/`
+      + `${input.sourceEntry.id}`,
+    );
+  }
+  const sourcePath = resolveArtifactFile(
+    input.sourceRoot,
+    input.sourceEntry.details.file,
+    'Source details path',
+  );
+  assertRegularFile(sourcePath, 'Source details artifact');
+  const destinationPath = resolveArtifactFile(
+    input.stagedRoot,
+    input.sourceEntry.details.file,
+    'Staged details path',
+  );
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+  fs.copyFileSync(sourcePath, destinationPath);
+}
+
+function mergeMissingCoreFields(
+  beforeValue: unknown,
+  candidateValue: unknown,
+): {
+  details: Record<string, unknown>;
+  addedFields: DetailsRepairCoreField[];
+} {
+  const before = asRecord(beforeValue) ?? {};
+  const candidate = asRecord(candidateValue) ?? {};
+  const merged = cloneJson(before);
+  const beforeCoverage = getDetailsRepairCoverage(before);
+  const candidateCoverage = getDetailsRepairCoverage(candidate);
+  const addedFields: DetailsRepairCoreField[] = [];
+
+  for (const field of CORE_FIELDS) {
+    if (!beforeCoverage[field] && candidateCoverage[field]) {
+      merged[field] = cloneJson(candidate[field]);
+      addedFields.push(field);
+    }
+  }
+
+  return { details: merged, addedFields };
+}
+
+function getCoverageRegressions(
+  before: DetailsRepairCoverage,
+  after: DetailsRepairCoverage,
+): DetailsRepairCoreField[] {
+  return CORE_FIELDS.filter((field) => before[field] && !after[field]);
+}
+
+function toDbDetailsStatus(
+  status: ManifestEntry['details']['status'],
+): 'completed' | 'partial' {
+  if (status === 'fetched' || status === 'skipped') {
+    return 'completed';
+  }
+  if (status === 'partial') {
+    return 'partial';
+  }
+  throw new Error(`Cannot persist details phase status "${status}"`);
+}
+
+function createRepairRunId(now: Date): string {
+  return `details-repair-${now.toISOString().replace(/[:.]/g, '-')}`;
+}
+
+function copyArtifactRoot(sourceRoot: string, stagedRoot: string): void {
+  if (!isReviewJobArtifactRootAvailable(sourceRoot)) {
+    throw new Error(`Saved artifact root is unavailable: ${sourceRoot}`);
+  }
+  const resolvedSource = path.resolve(sourceRoot);
+  const resolvedStaged = path.resolve(stagedRoot);
+  if (path.dirname(resolvedSource) !== path.dirname(resolvedStaged)) {
+    throw new Error(
+      'Staged artifact root must be a sibling of the source run',
+    );
+  }
+  if (
+    resolvedSource === resolvedStaged
+    || resolvedStaged.startsWith(`${resolvedSource}${path.sep}`)
+    || resolvedSource.startsWith(`${resolvedStaged}${path.sep}`)
+  ) {
+    throw new Error('Staged and source artifact roots must be separate');
+  }
+  if (fs.existsSync(resolvedStaged)) {
+    throw new Error(`Staged artifact root already exists: ${resolvedStaged}`);
+  }
+  fs.mkdirSync(path.dirname(resolvedStaged), { recursive: true });
+  fs.cpSync(resolvedSource, resolvedStaged, {
+    recursive: true,
+    force: false,
+    errorOnExist: true,
+    filter(sourcePath) {
+      return path.basename(sourcePath) !== 'runs';
+    },
+  });
+}
+
+function readManifest(rootDir: string): BatchManifest {
+  const manifestPath = getManifestPathFromRoot(rootDir);
+  assertRegularFile(manifestPath, 'Batch manifest');
+  return JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as BatchManifest;
+}
+
+function writeManifest(rootDir: string, manifest: BatchManifest): void {
+  fs.writeFileSync(
+    getManifestPathFromRoot(rootDir),
+    JSON.stringify(manifest, null, 2),
+  );
+}
+
+export async function stageReviewJobDetailsRepair(
+  input: StageDetailsRepairInput,
+): Promise<DetailsRepairPlan> {
+  assertIdleJob(input.job);
+  if (!input.job.artifactRoot) {
+    throw new Error(`Review job ${input.job.id} has no saved artifact root`);
+  }
+  const now = input.now ?? new Date();
+  const sourceRoot = path.resolve(input.job.artifactRoot);
+  const stagedRoot = path.resolve(
+    input.stagedRoot
+      ?? getReviewJobArtifactRunDir(
+        input.job.id,
+        createRepairRunId(now),
+      ),
+  );
+  const targets = input.job.listings.filter(
+    (listing): listing is DetailsRepairListingInput & {
+      platform: DetailsRepairPlatform;
+    } => listing.platform === input.platform,
+  );
+  if (targets.length === 0) {
+    throw new Error(
+      `Review job ${input.job.id} has no ${input.platform} listings`,
+    );
+  }
+  for (const target of targets) {
+    if (!target.analysisId) {
+      throw new Error(
+        `Review job listing ${target.rowId} has no persisted analysis row`,
+      );
+    }
+  }
+
+  const sourceManifest = readManifest(sourceRoot);
+  const sourceManifestFingerprint =
+    fingerprintDetailsRepairValue(sourceManifest);
+  const targetKeys = new Set(
+    targets.map((listing) =>
+      getListingMatchKey(listing.platform, listing.url)),
+  );
+  const sourceDetailsFiles = targets.map((listing) => {
+    const entry = getManifestEntry(
+      sourceManifest,
+      listing.platform,
+      listing.url,
+    )?.[1];
+    if (!entry?.details.file) {
+      throw new Error(
+        `Manifest details file not found for ${listing.platform}/`
+        + `${listing.listingId}`,
+      );
+    }
+    return entry.details.file;
+  });
+  const mutableArtifactPaths =
+    repairMutableArtifactPaths(sourceDetailsFiles);
+  const sourcePreservedArtifactsFingerprint = fingerprintArtifactTree(
+    sourceRoot,
+    mutableArtifactPaths,
+  );
+  const sourceInvariant =
+    manifestInvariantFingerprint(sourceManifest, targetKeys);
+
+  copyArtifactRoot(sourceRoot, stagedRoot);
+  if (
+    fingerprintArtifactTree(stagedRoot, mutableArtifactPaths)
+    !== sourcePreservedArtifactsFingerprint
+  ) {
+    throw new Error(
+      'Staged artifact copy changed a preserved artifact unexpectedly',
+    );
+  }
+  const stagedManifest = readManifest(stagedRoot);
+  if (
+    manifestInvariantFingerprint(stagedManifest, targetKeys)
+    !== sourceInvariant
+  ) {
+    throw new Error('Staged artifact copy changed the manifest unexpectedly');
+  }
+
+  for (const target of targets) {
+    const matched = getManifestEntry(
+      stagedManifest,
+      target.platform,
+      target.url,
+    );
+    if (!matched) {
+      throw new Error(
+        `Manifest entry not found for ${target.platform}/${target.listingId}`,
+      );
+    }
+    const [, entry] = matched;
+    if (!entry.details.file) {
+      throw new Error(
+        `Manifest details file not found for ${target.platform}/`
+        + `${target.listingId}`,
+      );
+    }
+    const stagedDetailsPath = resolveArtifactFile(
+      stagedRoot,
+      entry.details.file,
+      'Staged details path',
+    );
+    if (fs.existsSync(stagedDetailsPath)) {
+      assertRegularFile(stagedDetailsPath, 'Staged details artifact');
+      fs.rmSync(stagedDetailsPath);
+    }
+    entry.details = { status: 'not_requested' };
+  }
+  stagedManifest.updatedAt = now.toISOString();
+  writeManifest(stagedRoot, stagedManifest);
+
+  const urlsFile = path.join(stagedRoot, 'details_repair_urls.txt');
+  fs.writeFileSync(
+    urlsFile,
+    `${targets.map((listing) => listing.url).join('\n')}\n`,
+  );
+
+  const runBatch = input.runBatch ?? defaultRunBatch;
+  await runBatch([urlsFile], {
+    fetchDetails: true,
+    fetchReviews: false,
+    fetchPhotos: false,
+    aiReviews: false,
+    aiPhotos: false,
+    triage: false,
+    aiReviewsExplicit: false,
+    aiPhotosExplicit: false,
+    triageExplicit: false,
+    checkIn: input.job.checkin ?? undefined,
+    checkOut: input.job.checkout ?? undefined,
+    adults: input.job.adults,
+    force: false,
+    retryFailed: false,
+    downloadPhotosAll: false,
+    outputDir: stagedRoot,
+    scopeManifestToInput: false,
+    scopePostScrapePhasesToInput: true,
+    print: false,
+    programmatic: true,
+  });
+
+  const refreshedManifest = readManifest(stagedRoot);
+  if (
+    manifestInvariantFingerprint(refreshedManifest, targetKeys)
+    !== sourceInvariant
+  ) {
+    throw new Error(
+      'Details-only batch changed a non-details manifest field',
+    );
+  }
+
+  const plannedListings: DetailsRepairPlanListing[] = [];
+  for (const target of targets) {
+    const sourceMatch = getManifestEntry(
+      sourceManifest,
+      target.platform,
+      target.url,
+    );
+    const refreshedMatch = getManifestEntry(
+      refreshedManifest,
+      target.platform,
+      target.url,
+    );
+    if (!sourceMatch || !refreshedMatch) {
+      throw new Error(
+        `Manifest entry disappeared for ${target.platform}/`
+        + `${target.listingId}`,
+      );
+    }
+    const [manifestKey, sourceEntry] = sourceMatch;
+    const [, refreshedEntry] = refreshedMatch;
+    if (!sourceEntry.details.file) {
+      throw new Error(
+        `Source details file missing for ${target.platform}/`
+        + `${target.listingId}`,
+      );
+    }
+    const sourceDetailsPath = resolveArtifactFile(
+      sourceRoot,
+      sourceEntry.details.file,
+      'Source details path',
+    );
+    assertRegularFile(sourceDetailsPath, 'Source details artifact');
+    const beforeCoverage = getDetailsRepairCoverage(target.details);
+    const beforeDetailsFingerprint =
+      fingerprintDetailsRepairValue(target.details);
+    let message: string | null = null;
+    let outcome: DetailsRepairPlanListing['outcome'] = 'preserved';
+    let addedFields: DetailsRepairCoreField[] = [];
+    let afterDetails = asRecord(target.details) ?? {};
+
+    const candidateFile = refreshedEntry.details.file
+      ? resolveArtifactFile(
+        stagedRoot,
+        refreshedEntry.details.file,
+        'Candidate details path',
+      )
+      : null;
+    const candidateDetails =
+      candidateFile
+      && fs.existsSync(candidateFile)
+      && !fs.lstatSync(candidateFile).isSymbolicLink()
+        ? JSON.parse(fs.readFileSync(candidateFile, 'utf8')) as unknown
+        : null;
+    const candidateUsable =
+      (
+        refreshedEntry.details.status === 'fetched'
+        || refreshedEntry.details.status === 'partial'
+      )
+      && asRecord(candidateDetails) != null;
+
+    if (candidateUsable) {
+      const merged = mergeMissingCoreFields(
+        target.details,
+        candidateDetails,
+      );
+      afterDetails = merged.details;
+      addedFields = merged.addedFields;
+      if (addedFields.length > 0) {
+        outcome = 'repaired';
+        message =
+          refreshedEntry.details.error
+          ?? refreshedEntry.details.reason
+          ?? null;
+        const detailsFile = refreshedEntry.details.file as string;
+        fs.writeFileSync(
+          resolveArtifactFile(
+            stagedRoot,
+            detailsFile,
+            'Repaired details path',
+          ),
+          JSON.stringify(afterDetails, null, 2),
+        );
+      } else {
+        message = 'Provider result added no previously missing core fields';
+        restoreSourceDetails({
+          sourceRoot,
+          stagedRoot,
+          sourceEntry,
+          stagedEntry: refreshedEntry,
+        });
+        afterDetails = asRecord(target.details) ?? {};
+      }
+    } else {
+      message =
+        refreshedEntry.details.error
+        ?? refreshedEntry.details.reason
+        ?? 'Provider did not return a usable details artifact';
+      restoreSourceDetails({
+        sourceRoot,
+        stagedRoot,
+        sourceEntry,
+        stagedEntry: refreshedEntry,
+      });
+    }
+
+    const afterCoverage = getDetailsRepairCoverage(afterDetails);
+    const regressions = getCoverageRegressions(
+      beforeCoverage,
+      afterCoverage,
+    );
+    if (
+      regressions.length > 0
+      || afterCoverage.total < beforeCoverage.total
+    ) {
+      throw new Error(
+        `Core-field regression for ${target.platform}/${target.listingId}: `
+        + `${regressions.join(', ') || 'coverage count decreased'}`,
+      );
+    }
+
+    const finalDetailsFile =
+      refreshedEntry.details.file ?? sourceEntry.details.file;
+    if (!finalDetailsFile) {
+      throw new Error(
+        `Final details file missing for ${target.platform}/`
+        + `${target.listingId}`,
+      );
+    }
+    const finalDetailsPath = resolveArtifactFile(
+      stagedRoot,
+      finalDetailsFile,
+      'Final details path',
+    );
+    assertRegularFile(finalDetailsPath, 'Final details artifact');
+    const persistedDetails = JSON.parse(
+      fs.readFileSync(finalDetailsPath, 'utf8'),
+    ) as unknown;
+
+    plannedListings.push({
+      rowId: target.rowId,
+      analysisId: target.analysisId,
+      listingId: target.listingId,
+      platform: target.platform,
+      url: target.url,
+      manifestKey,
+      outcome,
+      message,
+      addedFields,
+      beforeCoverage,
+      afterCoverage,
+      beforeDetailsFingerprint,
+      sourceDetailsArtifactFingerprint:
+        fingerprintFile(sourceDetailsPath),
+      afterDetailsFingerprint:
+        fingerprintDetailsRepairValue(persistedDetails),
+      detailsFile: finalDetailsFile,
+      beforeDetailsStatus: target.detailsStatus,
+      afterDetailsStatus: refreshedEntry.details.status,
+    });
+  }
+
+  const totalAddedFields = plannedListings.reduce(
+    (sum, listing) => sum + listing.addedFields.length,
+    0,
+  );
+  if (totalAddedFields === 0) {
+    throw new Error(
+      'Details repair recovered no missing core fields; refusing a no-op plan',
+    );
+  }
+
+  writeManifest(stagedRoot, refreshedManifest);
+  const generateReport = input.generateReport ?? defaultGenerateReport;
+  const stagedReportPath = getReportPathFromRoot(stagedRoot);
+  await generateReport({
+    outputDir: stagedRoot,
+    outputFile: stagedReportPath,
+  });
+  assertRegularFile(stagedReportPath, 'Staged report');
+  const stagedPreservedArtifactsFingerprint = fingerprintArtifactTree(
+    stagedRoot,
+    mutableArtifactPaths,
+  );
+  if (
+    stagedPreservedArtifactsFingerprint
+    !== sourcePreservedArtifactsFingerprint
+  ) {
+    throw new Error(
+      'Details-only repair changed a preserved non-details artifact',
+    );
+  }
+
+  const plan: DetailsRepairPlan = {
+    version: DETAILS_REPAIR_PLAN_VERSION,
+    jobId: input.job.id,
+    platform: input.platform,
+    createdAt: now.toISOString(),
+    sourceArtifactRoot: sourceRoot,
+    sourceReportPath: input.job.reportPath,
+    sourceStateFingerprint: input.job.sourceStateFingerprint,
+    sourceManifestFingerprint,
+    sourcePreservedArtifactsFingerprint,
+    stagedArtifactRoot: stagedRoot,
+    stagedReportPath,
+    stagedReportFingerprint: fingerprintFile(stagedReportPath),
+    stagedManifestInvariantFingerprint:
+      manifestInvariantFingerprint(refreshedManifest, targetKeys),
+    stagedPreservedArtifactsFingerprint,
+    listings: plannedListings,
+    totalAddedFields,
+  };
+  fs.writeFileSync(
+    path.join(stagedRoot, DETAILS_REPAIR_PLAN_FILE),
+    JSON.stringify(plan, null, 2),
+  );
+  return plan;
+}
+
+export function readReviewJobDetailsRepairPlan(
+  stagedRoot: string,
+): DetailsRepairPlan {
+  const resolvedRoot = path.resolve(stagedRoot);
+  if (!isReviewJobArtifactRootAvailable(resolvedRoot)) {
+    throw new Error(`Staged artifact root is unavailable: ${resolvedRoot}`);
+  }
+  const planPath = path.join(resolvedRoot, DETAILS_REPAIR_PLAN_FILE);
+  assertRegularFile(planPath, 'Details repair plan');
+  const plan = JSON.parse(
+    fs.readFileSync(planPath, 'utf8'),
+  ) as DetailsRepairPlan;
+  if (plan.version !== DETAILS_REPAIR_PLAN_VERSION) {
+    throw new Error(
+      `Unsupported details repair plan version: ${String(plan.version)}`,
+    );
+  }
+  if (path.resolve(plan.stagedArtifactRoot) !== resolvedRoot) {
+    throw new Error('Details repair plan does not match the staged root');
+  }
+  if (
+    path.dirname(path.resolve(plan.sourceArtifactRoot))
+    !== path.dirname(resolvedRoot)
+  ) {
+    throw new Error(
+      'Staged artifact root is not a sibling of the source run',
+    );
+  }
+  return plan;
+}
+
+export function validateReviewJobDetailsRepairForApply(input: {
+  plan: DetailsRepairPlan;
+  job: DetailsRepairJobInput;
+}): DetailsRepairApplyUpdate[] {
+  const { plan, job } = input;
+  assertIdleJob(job);
+  if (job.id !== plan.jobId) {
+    throw new Error(
+      `Repair plan is for ${plan.jobId}, not ${job.id}`,
+    );
+  }
+  if (path.resolve(job.artifactRoot ?? '') !== plan.sourceArtifactRoot) {
+    throw new Error(
+      'Review job artifact root changed after the dry run; refusing apply',
+    );
+  }
+  if (job.reportPath !== plan.sourceReportPath) {
+    throw new Error(
+      'Review job report path changed after the dry run; refusing apply',
+    );
+  }
+  if (job.sourceStateFingerprint !== plan.sourceStateFingerprint) {
+    throw new Error(
+      'Review job state changed after the dry run; refusing apply',
+    );
+  }
+
+  const sourceManifest = readManifest(plan.sourceArtifactRoot);
+  if (
+    fingerprintDetailsRepairValue(sourceManifest)
+    !== plan.sourceManifestFingerprint
+  ) {
+    throw new Error(
+      'Source manifest changed after the dry run; refusing apply',
+    );
+  }
+  const mutableArtifactPaths = repairMutableArtifactPaths(
+    plan.listings.map((listing) => listing.detailsFile),
+  );
+  if (
+    fingerprintArtifactTree(
+      plan.sourceArtifactRoot,
+      mutableArtifactPaths,
+    ) !== plan.sourcePreservedArtifactsFingerprint
+  ) {
+    throw new Error(
+      'Source non-details artifacts changed after the dry run; refusing apply',
+    );
+  }
+  const stagedManifest = readManifest(plan.stagedArtifactRoot);
+  const targetKeys = new Set(
+    plan.listings.map((listing) =>
+      getListingMatchKey(listing.platform, listing.url)),
+  );
+  if (
+    manifestInvariantFingerprint(stagedManifest, targetKeys)
+    !== plan.stagedManifestInvariantFingerprint
+  ) {
+    throw new Error(
+      'Staged non-details manifest state changed after the dry run',
+    );
+  }
+  if (
+    fingerprintArtifactTree(
+      plan.stagedArtifactRoot,
+      mutableArtifactPaths,
+    ) !== plan.stagedPreservedArtifactsFingerprint
+  ) {
+    throw new Error(
+      'Staged preserved artifacts changed after the dry run',
+    );
+  }
+  assertRegularFile(plan.stagedReportPath, 'Staged report');
+  if (
+    fingerprintFile(plan.stagedReportPath)
+    !== plan.stagedReportFingerprint
+  ) {
+    throw new Error('Staged report changed after the dry run');
+  }
+
+  const currentListings = new Map(
+    job.listings.map((listing) => [listing.rowId, listing]),
+  );
+  const plannedTotalAddedFields = plan.listings.reduce(
+    (sum, listing) => sum + listing.addedFields.length,
+    0,
+  );
+  if (plannedTotalAddedFields !== plan.totalAddedFields) {
+    throw new Error('Repair plan added-field total is inconsistent');
+  }
+  const updates: DetailsRepairApplyUpdate[] = [];
+  for (const planned of plan.listings) {
+    const current = currentListings.get(planned.rowId);
+    if (
+      !current
+      || current.analysisId !== planned.analysisId
+      || current.listingId !== planned.listingId
+      || current.platform !== planned.platform
+      || current.url !== planned.url
+    ) {
+      throw new Error(
+        `Review job listing changed after dry run: ${planned.listingId}`,
+      );
+    }
+    if (
+      fingerprintDetailsRepairValue(current.details)
+      !== planned.beforeDetailsFingerprint
+    ) {
+      throw new Error(
+        `Persisted details changed after dry run: ${planned.listingId}`,
+      );
+    }
+    const currentCoverage = getDetailsRepairCoverage(current.details);
+    if (
+      fingerprintDetailsRepairValue(currentCoverage)
+      !== fingerprintDetailsRepairValue(planned.beforeCoverage)
+    ) {
+      throw new Error(
+        `Persisted details coverage changed after dry run: `
+        + `${planned.listingId}`,
+      );
+    }
+
+    const entry = getManifestEntry(
+      stagedManifest,
+      planned.platform,
+      planned.url,
+    )?.[1];
+    if (!entry || entry.details.file !== planned.detailsFile) {
+      throw new Error(
+        `Staged manifest details changed: ${planned.listingId}`,
+      );
+    }
+    if (entry.details.status !== planned.afterDetailsStatus) {
+      throw new Error(
+        `Staged manifest details status changed: ${planned.listingId}`,
+      );
+    }
+    const sourceEntry = getManifestEntry(
+      sourceManifest,
+      planned.platform,
+      planned.url,
+    )?.[1];
+    if (!sourceEntry?.details.file) {
+      throw new Error(
+        `Source manifest details disappeared: ${planned.listingId}`,
+      );
+    }
+    const sourceDetailsPath = resolveArtifactFile(
+      plan.sourceArtifactRoot,
+      sourceEntry.details.file,
+      'Source details path',
+    );
+    assertRegularFile(sourceDetailsPath, 'Source details artifact');
+    if (
+      fingerprintFile(sourceDetailsPath)
+      !== planned.sourceDetailsArtifactFingerprint
+    ) {
+      throw new Error(
+        `Source details artifact changed after dry run: `
+        + `${planned.listingId}`,
+      );
+    }
+    const detailsPath = resolveArtifactFile(
+      plan.stagedArtifactRoot,
+      planned.detailsFile,
+      'Planned details path',
+    );
+    assertRegularFile(detailsPath, 'Planned details artifact');
+    const details = JSON.parse(
+      fs.readFileSync(detailsPath, 'utf8'),
+    ) as unknown;
+    if (
+      fingerprintDetailsRepairValue(details)
+      !== planned.afterDetailsFingerprint
+    ) {
+      throw new Error(
+        `Staged details changed after dry run: ${planned.listingId}`,
+      );
+    }
+    const afterCoverage = getDetailsRepairCoverage(details);
+    if (
+      fingerprintDetailsRepairValue(afterCoverage)
+      !== fingerprintDetailsRepairValue(planned.afterCoverage)
+    ) {
+      throw new Error(
+        `Staged details coverage changed after dry run: ${planned.listingId}`,
+      );
+    }
+    const regressions = getCoverageRegressions(
+      planned.beforeCoverage,
+      afterCoverage,
+    );
+    if (
+      regressions.length > 0
+      || afterCoverage.total < planned.beforeCoverage.total
+    ) {
+      throw new Error(
+        `Staged details regress core fields for ${planned.listingId}`,
+      );
+    }
+    const addedFields = CORE_FIELDS.filter(
+      (field) => !currentCoverage[field] && afterCoverage[field],
+    );
+    if (
+      fingerprintDetailsRepairValue(addedFields)
+      !== fingerprintDetailsRepairValue(planned.addedFields)
+    ) {
+      throw new Error(
+        `Staged added fields changed after dry run: ${planned.listingId}`,
+      );
+    }
+    if (
+      (planned.outcome === 'repaired') !== (addedFields.length > 0)
+    ) {
+      throw new Error(
+        `Repair outcome is inconsistent for ${planned.listingId}`,
+      );
+    }
+    if (planned.outcome === 'repaired') {
+      const record = asRecord(details);
+      if (!record) {
+        throw new Error(
+          `Staged details are not an object: ${planned.listingId}`,
+        );
+      }
+      const expectedDetails = mergeMissingCoreFields(
+        current.details,
+        details,
+      ).details;
+      if (
+        fingerprintDetailsRepairValue(expectedDetails)
+        !== fingerprintDetailsRepairValue(record)
+      ) {
+        throw new Error(
+          `Staged details changed fields outside the missing-core repair: `
+          + `${planned.listingId}`,
+        );
+      }
+      updates.push({
+        analysisId: planned.analysisId,
+        listingId: planned.listingId,
+        details: record,
+        detailsStatus: toDbDetailsStatus(planned.afterDetailsStatus),
+      });
+    }
+  }
+
+  if (updates.length === 0) {
+    throw new Error('Repair plan contains no persisted details updates');
+  }
+  return updates;
+}


### PR DESCRIPTION
Follow-up to #77.

## Why

The existing `refresh-prices` queue is intentionally forceful and can recompute stored affordability. It is therefore the wrong mechanism for repairing parser-derived fields in Victor's persisted NYC job: it would make unnecessary Booking network requests and mutate real trip state outside the promised details-only scope.

## What changed

- Adds `npm run repair:job-details -- --job <id> --platform airbnb`, dry-run by default.
- Requires an idle job, clones the current artifact run into a sibling run, removes only the cloned Airbnb details files, and calls `runBatch` with details enabled and reviews/photos/AI/triage disabled, `force=false`, and the existing manifest retained.
- Uses the #77 `airbnb-pdp-v2` cache variant, so pre-fix Airbnb cache entries miss while Booking is not processed at all.
- Fills only previously missing `title`, `rating`, `reviewCount`, `subRatings`, and `amenities` values. Existing populated core values and every non-core details value remain unchanged.
- Preserves the old entry and artifact when a provider fetch fails or adds no field. A dry run cannot produce an apply plan unless at least one core field is recovered.
- Prints per-listing before/after coverage and retains the staged run for review.
- Adds explicit apply reuse through `--apply --staged-root <dry-run-root>`; apply performs no provider work.

## Fail-closed apply contract

Before the single serializable transaction, apply revalidates:

- the exact unchanged job/listing/analysis/curation/cost/duplicate state fingerprint;
- original artifact and report pointers;
- the original manifest and every source details artifact;
- the staged manifest outside target details;
- the regenerated report;
- every preserved non-details artifact byte;
- each staged details artifact, coverage matrix, added-field list, and the rule that only previously missing core fields changed.

The transaction locks the job, listing, analysis, and duplicate-pair rows, then updates only repaired `ReviewJobListingAnalysis.details` / `detailsStatus` fields and the job's artifact/report pointers. The previous artifact root is retained. Reviews, photos, AI/triage JSON, verdicts, costs, curation, duplicate decisions, listing cards, and price snapshots are not rewritten.

## Validation

- `pnpm test` — 184 passed
- `pnpm run lint`
- `pnpm run build`
- `npm run test:ui` — 19 passed
- `npm run test:pricing` — 3 passed
- `npm run test:dependencies` — 1 passed
- `npm run lint` in `web/`
- `npm run build` in `web/`
- Disposable Postgres acceptance using the real CLI apply path: exactly one analysis details row plus the two canonical artifact pointers changed; Booking, costs, curation, duplicate decision, AI/triage JSON, and all other persisted fields remained identical; the original artifact run remained intact.

No live database or persisted artifact was written while preparing this PR. The read-only NYC baseline is 27 Airbnb listings, all currently missing all five measured core fields. After merge, the required next step is the supervised dry run only; `--apply` still waits for a separate explicit go.
