### PR TITLE
Stream full-search listings with honest combined progress

### DIFF
--- a/tests/review-job-search-persistence.test.ts
+++ b/tests/review-job-search-persistence.test.ts
@@ -1,0 +1,123 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { SearchResult } from '../src/search/types.js';
+import {
+  persistIncrementalReviewJobListings,
+} from '../web/src/lib/reviewJobSearchPersistence.js';
+
+function result(
+  id: string,
+  platform: 'airbnb' | 'booking',
+  name = `${platform} ${id}`,
+): SearchResult {
+  return {
+    id,
+    platform,
+    name,
+    url:
+      platform === 'airbnb'
+        ? `https://www.airbnb.com/rooms/${id}`
+        : `https://www.booking.com/hotel/us/${id}.html`,
+    rating: 4.8,
+    reviewCount: 20,
+    pricing: null,
+    coordinates: { lat: 40.72, lng: -74 },
+    propertyType: null,
+    photoUrl: null,
+  };
+}
+
+test('incremental persistence deduplicates pages and creates analysis rows immediately', async () => {
+  const listings = new Map<string, {
+    id: string;
+    jobId: string;
+    listingId: string;
+    platform: 'airbnb' | 'booking';
+    name: string;
+  }>();
+  const analysisListingIds = new Set<string>();
+  let nextRowId = 1;
+
+  const tx = {
+    reviewJobListing: {
+      async createMany(input: {
+        data: Array<{
+          jobId: string;
+          listingId: string;
+          platform: 'airbnb' | 'booking';
+          name: string;
+        }>;
+      }) {
+        let count = 0;
+        for (const row of input.data) {
+          const key = `${row.jobId}:${row.platform}:${row.listingId}`;
+          if (listings.has(key)) continue;
+          listings.set(key, {
+            ...row,
+            id: `row_${nextRowId++}`,
+          });
+          count++;
+        }
+        return { count };
+      },
+      async findMany(input: {
+        where: {
+          jobId: string;
+          OR: Array<{
+            listingId: string;
+            platform: 'airbnb' | 'booking';
+          }>;
+        };
+      }) {
+        const keys = new Set(
+          input.where.OR.map((key) =>
+            `${input.where.jobId}:${key.platform}:${key.listingId}`),
+        );
+        return Array.from(listings.entries())
+          .filter(([key]) => keys.has(key))
+          .map(([, listing]) => ({ id: listing.id }));
+      },
+      async count(input: { where: { jobId: string } }) {
+        return Array.from(listings.values()).filter(
+          (listing) => listing.jobId === input.where.jobId,
+        ).length;
+      },
+    },
+    reviewJobListingAnalysis: {
+      async createMany(input: {
+        data: Array<{ jobListingId: string }>;
+      }) {
+        let count = 0;
+        for (const row of input.data) {
+          if (analysisListingIds.has(row.jobListingId)) continue;
+          analysisListingIds.add(row.jobListingId);
+          count++;
+        }
+        return { count };
+      },
+    },
+  } as unknown as Parameters<typeof persistIncrementalReviewJobListings>[0];
+
+  const firstTotal = await persistIncrementalReviewJobListings(tx, {
+    jobId: 'job_1',
+    results: [
+      result('a1', 'airbnb', 'Original Airbnb card'),
+      result('b1', 'booking'),
+    ],
+  });
+  const secondTotal = await persistIncrementalReviewJobListings(tx, {
+    jobId: 'job_1',
+    results: [
+      result('a1', 'airbnb', 'Duplicate callback card'),
+      result('a2', 'airbnb'),
+    ],
+  });
+
+  assert.equal(firstTotal, 2);
+  assert.equal(secondTotal, 3);
+  assert.equal(analysisListingIds.size, 3);
+  assert.equal(
+    listings.get('job_1:airbnb:a1')?.name,
+    'Original Airbnb card',
+  );
+});

--- a/tests/review-job-search-progress.test.ts
+++ b/tests/review-job-search-progress.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getReviewJobSearchProgress,
+} from '../web/src/lib/reviewJobSearch.js';
+
+test('combined progress advances through explicit platform segments', () => {
+  const airbnbStart = getReviewJobSearchProgress({
+    platform: 'airbnb',
+    stage: 'starting',
+  });
+  const airbnbPage = getReviewJobSearchProgress({
+    platform: 'airbnb',
+    stage: 'searching',
+    platformPages: 1,
+  });
+  const airbnbManyPages = getReviewJobSearchProgress({
+    platform: 'airbnb',
+    stage: 'searching',
+    platformPages: 100,
+  });
+  const airbnbComplete = getReviewJobSearchProgress({
+    platform: 'airbnb',
+    stage: 'completed',
+  });
+  const bookingBootstrap = getReviewJobSearchProgress({
+    platform: 'booking',
+    stage: 'starting',
+  });
+  const bookingPage = getReviewJobSearchProgress({
+    platform: 'booking',
+    stage: 'searching',
+    platformPages: 1,
+  });
+  const bookingComplete = getReviewJobSearchProgress({
+    platform: 'booking',
+    stage: 'completed',
+  });
+
+  assert.equal(airbnbStart.currentPhase, 'search:airbnb');
+  assert.ok(airbnbPage.progress > airbnbStart.progress);
+  assert.ok(airbnbManyPages.progress < airbnbComplete.progress);
+  assert.equal(airbnbComplete.progress, 0.48);
+  assert.equal(bookingBootstrap.currentPhase, 'search:booking:bootstrap');
+  assert.ok(bookingBootstrap.progress > airbnbComplete.progress);
+  assert.ok(bookingPage.progress > bookingBootstrap.progress);
+  assert.ok(bookingPage.progress < bookingComplete.progress);
+  assert.equal(bookingComplete.progress, 0.95);
+});
+
+test('unknown page totals never let an active platform claim completion', () => {
+  const airbnb = getReviewJobSearchProgress({
+    platform: 'airbnb',
+    stage: 'searching',
+    platformPages: Number.MAX_SAFE_INTEGER,
+  });
+  const booking = getReviewJobSearchProgress({
+    platform: 'booking',
+    stage: 'searching',
+    platformPages: Number.MAX_SAFE_INTEGER,
+  });
+
+  assert.ok(airbnb.progress < 0.48);
+  assert.ok(booking.progress < 0.95);
+});

--- a/web/src/components/JobWorkspace.tsx
+++ b/web/src/components/JobWorkspace.tsx
@@ -27,6 +27,7 @@ import EvidenceGapBadge from './EvidenceGapBadge';
 import ResultCard from './ResultCard';
 import StaySnapshotStatus from './StaySnapshotStatus';
 import PriceRefreshControls from './PriceRefreshControls';
+import ReviewJobSearchProgress from './ReviewJobSearchProgress';
 
 const JobMap = dynamic(() => import('./JobMap'), {
   ssr: false,
@@ -665,18 +666,11 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
                 )}
               </div>
               {(data.job.status === 'pending' || data.job.status === 'running') && (
-                <div className="mt-4">
-                  <div className="flex items-center justify-between text-xs font-medium text-stone-400">
-                    <span>{data.job.currentPhase}</span>
-                    <span>{Math.round(data.job.progress * 100)}%</span>
-                  </div>
-                  <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/[0.08]">
-                    <div
-                      className="h-full rounded-full bg-[linear-gradient(90deg,#3bcf93,#88e2bc)] transition-all"
-                      style={{ width: `${Math.max(4, Math.round(data.job.progress * 100))}%` }}
-                    />
-                  </div>
-                </div>
+                <ReviewJobSearchProgress
+                  currentPhase={data.job.currentPhase}
+                  progress={data.job.progress}
+                  listingCount={data.listings.length}
+                />
               )}
               {(data.job.analysisStatus === 'pending' || data.job.analysisStatus === 'running') && (
                 <div className="mt-4">

--- a/web/src/components/ReviewJobSearchProgress.test.tsx
+++ b/web/src/components/ReviewJobSearchProgress.test.tsx
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import ReviewJobSearchProgress from './ReviewJobSearchProgress.js';
+
+test('booking bootstrap names the slow phase and preserves incremental count', () => {
+  const html = renderToStaticMarkup(
+    <ReviewJobSearchProgress
+      currentPhase="search:booking:bootstrap"
+      progress={0.52}
+      listingCount={37}
+    />,
+  );
+
+  assert.match(html, /Booking browser session/);
+  assert.match(html, /52%/);
+  assert.match(html, /37 listings saved so far/);
+  assert.match(html, /first Booking results can take a few minutes/);
+});
+
+test('airbnb progress explains that listings arrive incrementally', () => {
+  const html = renderToStaticMarkup(
+    <ReviewJobSearchProgress
+      currentPhase="search:airbnb"
+      progress={0.24}
+      listingCount={12}
+    />,
+  );
+
+  assert.match(html, /Airbnb area search/);
+  assert.match(html, /12 listings saved so far/);
+  assert.match(html, /pages and cells complete/);
+});

--- a/web/src/components/ReviewJobSearchProgress.tsx
+++ b/web/src/components/ReviewJobSearchProgress.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+export function getReviewJobSearchPhaseLabel(currentPhase: string): string {
+  if (currentPhase === 'search:booking:bootstrap') {
+    return 'Booking browser session';
+  }
+  if (currentPhase === 'search:booking') {
+    return 'Booking area search';
+  }
+  if (currentPhase === 'search:booking:completed') {
+    return 'Booking search complete';
+  }
+  if (currentPhase === 'search:booking:failed') {
+    return 'Booking search ended with a warning';
+  }
+  if (currentPhase === 'search:airbnb') {
+    return 'Airbnb area search';
+  }
+  if (currentPhase === 'search:airbnb:completed') {
+    return 'Airbnb search complete';
+  }
+  if (currentPhase === 'search:airbnb:failed') {
+    return 'Airbnb search ended with a warning';
+  }
+  return 'Combined Airbnb + Booking search';
+}
+
+function searchExpectation(
+  currentPhase: string,
+  listingCount: number,
+): string {
+  const saved = `${listingCount} listing${listingCount === 1 ? '' : 's'} saved so far.`;
+
+  if (currentPhase === 'search:booking:bootstrap') {
+    return `${saved} Starting Booking's browser session; the first Booking results can take a few minutes.`;
+  }
+  if (currentPhase.startsWith('search:booking')) {
+    return `${saved} Booking is scanning the area and may take a few minutes.`;
+  }
+  if (currentPhase.startsWith('search:airbnb')) {
+    return `${saved} New listings appear as Airbnb search pages and cells complete.`;
+  }
+  return 'Preparing the combined Airbnb + Booking search.';
+}
+
+export default function ReviewJobSearchProgress({
+  currentPhase,
+  progress,
+  listingCount,
+}: {
+  currentPhase: string;
+  progress: number;
+  listingCount: number;
+}) {
+  const percentage = Math.max(0, Math.min(100, Math.round(progress * 100)));
+
+  return (
+    <div className="mt-4">
+      <div className="flex items-center justify-between text-xs font-medium text-stone-400">
+        <span>{getReviewJobSearchPhaseLabel(currentPhase)}</span>
+        <span>{percentage}%</span>
+      </div>
+      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/[0.08]">
+        <div
+          className="h-full rounded-full bg-[linear-gradient(90deg,#3bcf93,#88e2bc)] transition-all"
+          style={{ width: `${Math.max(4, percentage)}%` }}
+        />
+      </div>
+      <p className="mt-2 text-xs leading-5 text-stone-500">
+        {searchExpectation(currentPhase, listingCount)}
+      </p>
+    </div>
+  );
+}

--- a/web/src/lib/reviewJobSearch.ts
+++ b/web/src/lib/reviewJobSearch.ts
@@ -10,6 +10,82 @@ export interface ReviewJobSearchSummary {
   failureMessage: string | null;
 }
 
+export type ReviewJobSearchPlatform = 'airbnb' | 'booking';
+export type ReviewJobSearchStage =
+  | 'starting'
+  | 'searching'
+  | 'completed'
+  | 'failed';
+
+export interface ReviewJobSearchProgressState {
+  currentPhase: string;
+  progress: number;
+}
+
+const PLATFORM_PROGRESS = {
+  airbnb: {
+    starting: 0.05,
+    scanningBase: 0.05,
+    scanningSpan: 0.4,
+    completed: 0.48,
+  },
+  booking: {
+    starting: 0.52,
+    scanningBase: 0.55,
+    scanningSpan: 0.4,
+    completed: 0.95,
+  },
+} as const;
+
+function boundedUnknownWorkProgress(
+  base: number,
+  span: number,
+  completedUnits: number,
+): number {
+  const units = Math.max(0, completedUnits);
+  // Exhaustive searches discover their own adaptive cells, so the final page
+  // count is unknowable up front. This curve moves within the active platform
+  // segment without ever claiming that the segment is complete.
+  return base + span * (units / (units + 8));
+}
+
+export function getReviewJobSearchProgress(input: {
+  platform: ReviewJobSearchPlatform;
+  stage: ReviewJobSearchStage;
+  platformPages?: number;
+}): ReviewJobSearchProgressState {
+  const segment = PLATFORM_PROGRESS[input.platform];
+
+  if (input.stage === 'starting') {
+    return {
+      currentPhase:
+        input.platform === 'booking'
+          ? 'search:booking:bootstrap'
+          : 'search:airbnb',
+      progress: segment.starting,
+    };
+  }
+
+  if (input.stage === 'completed' || input.stage === 'failed') {
+    return {
+      currentPhase: `search:${input.platform}:${input.stage}`,
+      progress: segment.completed,
+    };
+  }
+
+  return {
+    currentPhase: `search:${input.platform}`,
+    progress: Math.min(
+      segment.completed - 0.001,
+      boundedUnknownWorkProgress(
+        segment.scanningBase,
+        segment.scanningSpan,
+        input.platformPages ?? 0,
+      ),
+    ),
+  };
+}
+
 export function summarizeReviewJobSearchOutcome(input: {
   successfulPlatforms: Array<'airbnb' | 'booking'>;
   warnings: ReviewJobSearchPlatformFailure[];

--- a/web/src/lib/reviewJobSearchPersistence.ts
+++ b/web/src/lib/reviewJobSearchPersistence.ts
@@ -1,0 +1,55 @@
+import type { Prisma } from '@prisma/client';
+import type { MapPoint, SearchResult } from '../types';
+import { toReviewJobListingRecord } from './reviewJobs';
+
+export async function persistIncrementalReviewJobListings(
+  tx: Prisma.TransactionClient,
+  input: {
+    jobId: string;
+    results: SearchResult[];
+    poi?: MapPoint | null;
+  },
+): Promise<number> {
+  const rows = input.results.map((result) =>
+    toReviewJobListingRecord(input.jobId, result, { poi: input.poi }),
+  );
+
+  if (rows.length > 0) {
+    await tx.reviewJobListing.createMany({
+      data: rows,
+      skipDuplicates: true,
+    });
+
+    const keys = Array.from(
+      new Map(
+        rows.map((row) => [
+          `${row.platform}:${row.listingId}`,
+          {
+            platform: row.platform,
+            listingId: row.listingId,
+          },
+        ]),
+      ).values(),
+    );
+    const persistedListings = await tx.reviewJobListing.findMany({
+      where: {
+        jobId: input.jobId,
+        OR: keys,
+      },
+      select: { id: true },
+    });
+
+    if (persistedListings.length > 0) {
+      await tx.reviewJobListingAnalysis.createMany({
+        data: persistedListings.map((listing) => ({
+          jobListingId: listing.id,
+        })),
+        skipDuplicates: true,
+      });
+    }
+  }
+
+  return tx.reviewJobListing.count({
+    where: { jobId: input.jobId },
+  });
+}

--- a/web/src/lib/search-worker.ts
+++ b/web/src/lib/search-worker.ts
@@ -26,7 +26,6 @@ import {
 import {
   buildReviewJobEventData,
   buildReviewJobPlatformParams,
-  toReviewJobListingRecord,
 } from './reviewJobs.js';
 import {
   getListingMatchKey,
@@ -47,9 +46,15 @@ import {
   type AnalysisManifest,
 } from './review-job-analysis.js';
 import {
+  getReviewJobSearchProgress,
   summarizeReviewJobSearchOutcome,
+  type ReviewJobSearchPlatform,
+  type ReviewJobSearchStage,
   type ReviewJobSearchPlatformFailure,
 } from './reviewJobSearch.js';
+import {
+  persistIncrementalReviewJobListings,
+} from './reviewJobSearchPersistence.js';
 import { createSearchLogger } from './searchLog.js';
 import {
   addPersistedAiCostFields,
@@ -65,9 +70,8 @@ import {
   formatArtifactBytes,
   resolveReviewJobArtifactPolicy,
 } from './reviewJobArtifacts.js';
-import type {
-  SearchResult,
-} from '../types.js';
+import type { SearchPage } from '../../../src/search/types.js';
+import type { SearchResult } from '../types.js';
 import { filterResultsForRequest } from './resultFilters.js';
 import { parseStaySnapshot } from '../../../src/stay-snapshot.js';
 import {
@@ -347,15 +351,27 @@ async function runReviewJobSearch(reviewJobId: string) {
     },
   });
 
-  await prisma.reviewJob.update({
-    where: { id: reviewJobId },
-    data: {
-      status: 'running',
-      currentPhase: 'search',
-      startedAt,
-      progress: 0.05,
-      errorMessage: null,
-    },
+  await prisma.$transaction(async (tx) => {
+    await tx.reviewJobDuplicatePair.deleteMany({
+      where: { jobId: reviewJobId },
+    });
+    await tx.reviewJobListing.deleteMany({
+      where: { jobId: reviewJobId },
+    });
+    await tx.reviewJob.update({
+      where: { id: reviewJobId },
+      data: {
+        status: 'running',
+        currentPhase: 'search',
+        startedAt,
+        completedAt: null,
+        durationMs: null,
+        progress: 0.05,
+        totalResults: 0,
+        pagesScanned: 0,
+        errorMessage: null,
+      },
+    });
   });
 
   await appendReviewJobEvent(reviewJobId, {
@@ -378,45 +394,116 @@ async function runReviewJobSearch(reviewJobId: string) {
       minBeds: storedFilters.minBeds,
     };
 
-    const persistProgress = (platform: 'airbnb' | 'booking') => {
-      const nextPagesScanned = pagesScanned + 1;
-      pagesScanned = nextPagesScanned;
-      progressWriter.push(async () => {
-        await prisma.reviewJob.update({
+    const platformPages: Record<ReviewJobSearchPlatform, number> = {
+      airbnb: 0,
+      booking: 0,
+    };
+
+    const persistSearchState = async (input: {
+      platform: ReviewJobSearchPlatform;
+      stage: ReviewJobSearchStage;
+      results: SearchResult[];
+      nextPagesScanned: number;
+      nextPlatformPages: number;
+    }) => {
+      const state = getReviewJobSearchProgress({
+        platform: input.platform,
+        stage: input.stage,
+        platformPages: input.nextPlatformPages,
+      });
+      return prisma.$transaction(async (tx) => {
+        const totalResults = await persistIncrementalReviewJobListings(tx, {
+          jobId: reviewJobId,
+          results: input.results,
+          poi: storedPoi,
+        });
+        await tx.reviewJob.update({
           where: { id: reviewJobId },
           data: {
             status: 'running',
-            currentPhase: `search:${platform}`,
-            pagesScanned: nextPagesScanned,
-            progress: Math.min(0.95, 0.05 + nextPagesScanned * 0.02),
+            currentPhase: state.currentPhase,
+            pagesScanned: input.nextPagesScanned,
+            totalResults,
+            progress: state.progress,
           },
+        });
+        return totalResults;
+      });
+    };
+
+    const persistProgress = (
+      platform: ReviewJobSearchPlatform,
+      page: SearchPage,
+    ) => {
+      const nextPagesScanned = pagesScanned + 1;
+      const nextPlatformPages = platformPages[platform] + 1;
+      pagesScanned = nextPagesScanned;
+      platformPages[platform] = nextPlatformPages;
+      const incrementalResults = filterResultsForRequest(
+        page.results,
+        requestFilters,
+      );
+      progressWriter.push(async () => {
+        await persistSearchState({
+          platform,
+          stage: 'searching',
+          results: incrementalResults,
+          nextPagesScanned,
+          nextPlatformPages,
         });
       });
     };
 
-    const platforms: Array<'airbnb' | 'booking'> = ['airbnb', 'booking'];
-    const allResults: SearchResult[] = [];
+    const platforms: ReviewJobSearchPlatform[] = ['airbnb', 'booking'];
     const warnings: ReviewJobSearchPlatformFailure[] = [];
-    const successfulPlatforms: Array<'airbnb' | 'booking'> = [];
+    const successfulPlatforms: ReviewJobSearchPlatform[] = [];
 
     for (const platform of platforms) {
+      const startingState = getReviewJobSearchProgress({
+        platform,
+        stage: 'starting',
+      });
+      await prisma.reviewJob.update({
+        where: { id: reviewJobId },
+        data: startingState,
+      });
       await appendReviewJobEvent(reviewJobId, {
         phase: 'search',
         level: 'info',
-        message: `Searching ${platform}`,
-        payload: { platform },
+        message:
+          platform === 'booking'
+            ? 'Starting Booking search — browser session setup can take a few minutes'
+            : 'Searching Airbnb',
+        payload: {
+          platform,
+          stage: platform === 'booking' ? 'bootstrap' : 'search',
+        },
       });
 
       let output;
       try {
         if (platform === 'airbnb') {
           const params = buildReviewJobPlatformParams(jobRecord, platform);
-          output = await searchAirbnb(params, () => persistProgress(platform));
+          output = await searchAirbnb(
+            params,
+            (page) => persistProgress(platform, page),
+          );
         } else {
           const params = buildReviewJobPlatformParams(jobRecord, platform);
-          output = await searchBooking(params, () => persistProgress(platform));
+          output = await searchBooking(
+            params,
+            (page) => persistProgress(platform, page),
+          );
         }
       } catch (error) {
+        await progressWriter.flush();
+        await persistSearchState({
+          platform,
+          stage: 'failed',
+          results: [],
+          nextPagesScanned: pagesScanned,
+          nextPlatformPages: platformPages[platform],
+        });
         const message =
           error instanceof Error ? error.message : 'Platform search failed';
         warnings.push({ platform, message });
@@ -437,7 +524,14 @@ async function runReviewJobSearch(reviewJobId: string) {
       }
 
       const filteredResults = filterResultsForRequest(output.results, requestFilters);
-      allResults.push(...filteredResults);
+      await progressWriter.flush();
+      const visibleTotalResults = await persistSearchState({
+        platform,
+        stage: 'completed',
+        results: filteredResults,
+        nextPagesScanned: pagesScanned,
+        nextPlatformPages: platformPages[platform],
+      });
       successfulPlatforms.push(platform);
       searchLogger.log('platform_completed', {
         platform,
@@ -456,6 +550,7 @@ async function runReviewJobSearch(reviewJobId: string) {
           fetched: output.results.length,
           kept: filteredResults.length,
           pagesScanned: output.pagesScanned,
+          visibleTotalResults,
         },
       });
     }
@@ -471,30 +566,14 @@ async function runReviewJobSearch(reviewJobId: string) {
       throw new Error(searchSummary.failureMessage ?? 'Review job search failed');
     }
 
-    const rows = allResults.map((result) =>
-      toReviewJobListingRecord(reviewJobId, result, { poi: storedPoi }),
-    );
     const completedAt = new Date();
     const durationMs = completedAt.getTime() - startedAt.getTime();
+    let totalResults = 0;
 
     await prisma.$transaction(async (tx) => {
-      await tx.reviewJobListing.deleteMany({ where: { jobId: reviewJobId } });
-      if (rows.length > 0) {
-        await tx.reviewJobListing.createMany({
-          data: rows,
-          skipDuplicates: true,
-        });
-        const insertedListings = await tx.reviewJobListing.findMany({
-          where: { jobId: reviewJobId },
-          select: { id: true },
-        });
-        await tx.reviewJobListingAnalysis.createMany({
-          data: insertedListings.map((listing) => ({
-            jobListingId: listing.id,
-          })),
-          skipDuplicates: true,
-        });
-      }
+      totalResults = await tx.reviewJobListing.count({
+        where: { jobId: reviewJobId },
+      });
       await syncReviewJobDuplicatePairs(tx, reviewJobId);
       await tx.reviewJob.update({
         where: { id: reviewJobId },
@@ -505,7 +584,7 @@ async function runReviewJobSearch(reviewJobId: string) {
           analysisCurrentPhase: null,
           analysisProgress: 0,
           analysisErrorMessage: null,
-          totalResults: rows.length,
+          totalResults,
           pagesScanned,
           progress: 1,
           completedAt,
@@ -522,7 +601,7 @@ async function runReviewJobSearch(reviewJobId: string) {
           level: searchSummary.completedEventLevel,
           message: searchSummary.completedEventMessage,
           payload: {
-            totalResults: rows.length,
+            totalResults,
             pagesScanned,
             durationMs,
             successfulPlatforms,
@@ -535,7 +614,7 @@ async function runReviewJobSearch(reviewJobId: string) {
       });
     });
     searchLogger.log('completed', {
-      totalResults: rows.length,
+      totalResults,
       pagesScanned,
       durationMs,
       successfulPlatforms,
@@ -543,7 +622,7 @@ async function runReviewJobSearch(reviewJobId: string) {
     });
 
     console.log(
-      `[review-worker] completed ${reviewJobId} with ${rows.length} results`,
+      `[review-worker] completed ${reviewJobId} with ${totalResults} results`,
     );
   } catch (error) {
     const message =
@@ -552,12 +631,17 @@ async function runReviewJobSearch(reviewJobId: string) {
     await progressWriter.flush();
 
     await prisma.$transaction(async (tx) => {
+      const totalResults = await tx.reviewJobListing.count({
+        where: { jobId: reviewJobId },
+      });
+      await syncReviewJobDuplicatePairs(tx, reviewJobId);
       await tx.reviewJob.update({
         where: { id: reviewJobId },
         data: {
           status: 'failed',
           currentPhase: 'search',
           errorMessage: message,
+          totalResults,
           pagesScanned,
           completedAt,
           durationMs: completedAt.getTime() - startedAt.getTime(),


### PR DESCRIPTION
## What changed

- Persist filtered Airbnb and Booking listings from each search page/cell callback instead of waiting for both platforms to finish.
- Create placeholder analysis rows in the same transaction so incremental listings are immediately valid workspace records.
- Keep listing row IDs stable through finalization; the final search step now counts and reconciles the already-persisted set instead of deleting and recreating it.
- Split full-search progress into bounded Airbnb and Booking segments. Platform completion and Booking bootstrap are explicit milestones, while unknown adaptive page totals can never claim completion early.
- Show readable progress labels and saved-listing counts in the workspace, including a clear warning that Booking browser-session startup can take a few minutes.

## Root cause

The worker callback discarded `SearchPage.results` and only incremented one global page counter. All listings were written in a single transaction after both providers finished. Starting Booking added a timeline event but did not update `currentPhase` or `progress`, so the UI could say Airbnb had finished while the progress bar remained on `search:airbnb` and the listing count stayed at zero.

## User impact

Airbnb results now appear while Airbnb cells are still running and are guaranteed persisted before the `Finished Airbnb search` event. Booking results continue appearing page by page. The combined progress bar advances across explicit provider milestones and explains the expected Playwright bootstrap delay instead of looking stuck.

## Validation

- `pnpm test` - 187 passed
- `pnpm run lint`
- `pnpm run build`
- `npm --prefix web run test:ui` - 21 passed
- `npm --prefix web run test:pricing` - 3 passed
- `npm --prefix web run test:dependencies` - 1 passed
- `npm --prefix web run lint`
- `npm --prefix web run build`
- Disposable Postgres/Prisma smoke: immediate analysis-row creation, cross-page deduplication, and stable listing IDs verified; disposable container removed afterward

Closes #47
