### PR TITLE
Track evidence staleness for saved verdicts

### DIFF
--- a/docs/triage-rubric.md
+++ b/docs/triage-rubric.md
@@ -42,7 +42,8 @@ Code builds this key in one shared helper used by the native results page and CL
 or different classifier version makes a verdict non-comparable even when its requirement
 definitions match. `modelId` is persisted for audit but is deliberately outside the key: provider
 model aliases can change on an external release schedule, and that churn must not silently
-invalidate every saved verdict.
+invalidate every saved verdict. Evidence fingerprints are likewise outside the comparability key:
+materially improved evidence suggests a regrade without invalidating the existing verdict.
 
 ## Canonical requirement set
 
@@ -330,6 +331,13 @@ invalidate verdicts. The marker survives queued, running, failed, and partial re
 clears only after every listing completes successfully. Structured budget-only edits never set
 the marker and never invoke the LLM.
 
+Each new verdict also stores a versioned evidence fingerprint for the exact details, AI-review,
+and AI-photo artifacts consumed by triage. The fingerprint records layer presence, SHA-256 hashes,
+and core details coverage for title, rating, review count, sub-ratings, and amenities. Artifact
+byte drift or layer metadata alone does not make a saved verdict stale. Improving core-field
+coverage marks only the affected listing as `regrade_suggested`; the job keeps that durable
+suggestion until those verdicts are successfully recomputed.
+
 ## Legacy and mixed verdicts
 
 Stored JSON without `scoreSource`, `rubricVersion`, and `requirementSetId` is
@@ -347,10 +355,12 @@ Stored JSON without `scoreSource`, `rubricVersion`, and `requirementSetId` is
 - The native results page offers an explicit whole-job regrade with an estimated cost. Regrading
   covers every non-hidden listing, reuses saved review and photo analysis, and runs triage only; at
   the measured ~$0.006/listing, a 54-listing job is estimated at ~$0.32.
-- Brief changes, classifier-policy changes, and requirement-set mismatches share one
-  `Regrade needed` presentation with distinct reasons. A brief change preserves the prior verdicts
-  and paid evidence for audit, labels them as reflecting the previous brief, and excludes them from
-  current peer ranks until a fully completed whole-job regrade.
+- Brief changes, evidence improvements, classifier-policy changes, and requirement-set mismatches
+  share one `Regrade needed` presentation with distinct reasons. A brief change preserves the prior
+  verdicts and paid evidence for audit, labels them as reflecting the previous brief, and excludes
+  them from current peer ranks until a fully completed whole-job regrade. Evidence-improved
+  verdicts remain valid and ranked, but identify the affected listings as having been graded from
+  thinner evidence.
 - Never interleave old model-authored or old-classifier scores with current-policy scores.
 
 CLI/report output follows the same source/version and grouping rules.

--- a/src/triage-evidence.ts
+++ b/src/triage-evidence.ts
@@ -1,0 +1,260 @@
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+
+export const TRIAGE_EVIDENCE_FINGERPRINT_VERSION = 1;
+
+export const TRIAGE_DETAILS_CORE_FIELDS = [
+  'title',
+  'rating',
+  'reviewCount',
+  'subRatings',
+  'amenities',
+] as const;
+
+export type TriageDetailsCoreField =
+  typeof TRIAGE_DETAILS_CORE_FIELDS[number];
+
+export interface TriageDetailsCoreCoverage {
+  title: boolean;
+  rating: boolean;
+  reviewCount: boolean;
+  subRatings: boolean;
+  amenities: boolean;
+  total: number;
+}
+
+export interface TriageEvidenceFingerprint {
+  version: typeof TRIAGE_EVIDENCE_FINGERPRINT_VERSION;
+  hash: string;
+  layers: {
+    details: true;
+    reviews: boolean;
+    photos: boolean;
+  };
+  artifacts: {
+    detailsSha256: string;
+    reviewsSha256: string | null;
+    photosSha256: string | null;
+  };
+  detailsCoreCoverage: TriageDetailsCoreCoverage;
+}
+
+interface EvidenceArtifact {
+  content: string;
+  data: unknown;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function finiteNumber(value: unknown): number | null {
+  if (
+    value == null
+    || (typeof value === 'string' && value.trim() === '')
+  ) {
+    return null;
+  }
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function hasSubRatings(value: unknown): boolean {
+  const record = asRecord(value);
+  return !!record && Object.values(record).some(
+    (rating) => finiteNumber(rating) != null,
+  );
+}
+
+function hasAmenities(value: unknown): boolean {
+  return Array.isArray(value) && value.some((amenity) => {
+    if (typeof amenity === 'string') {
+      return nonEmptyString(amenity) != null;
+    }
+    return nonEmptyString(asRecord(amenity)?.name) != null;
+  });
+}
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === 'string' && /^[a-f0-9]{64}$/.test(value);
+}
+
+function isCoverage(value: unknown): value is TriageDetailsCoreCoverage {
+  const record = asRecord(value);
+  if (!record) return false;
+  const coveredFields = TRIAGE_DETAILS_CORE_FIELDS.filter(
+    (field) => record[field] === true,
+  ).length;
+  return (
+    TRIAGE_DETAILS_CORE_FIELDS.every(
+      (field) => typeof record[field] === 'boolean',
+    )
+    && typeof record.total === 'number'
+    && Number.isInteger(record.total)
+    && record.total >= 0
+    && record.total <= TRIAGE_DETAILS_CORE_FIELDS.length
+    && record.total === coveredFields
+  );
+}
+
+export function getTriageDetailsCoreCoverage(
+  value: unknown,
+): TriageDetailsCoreCoverage {
+  const details = asRecord(value);
+  const coverage = {
+    title: nonEmptyString(details?.title) != null,
+    rating: finiteNumber(details?.rating) != null,
+    reviewCount:
+      finiteNumber(details?.reviewCount) != null
+      && (finiteNumber(details?.reviewCount) as number) >= 0,
+    subRatings: hasSubRatings(details?.subRatings),
+    amenities: hasAmenities(details?.amenities),
+  };
+  return {
+    ...coverage,
+    total: TRIAGE_DETAILS_CORE_FIELDS.filter(
+      (field) => coverage[field],
+    ).length,
+  };
+}
+
+export function createTriageEvidenceFingerprint(input: {
+  details: EvidenceArtifact;
+  reviews?: EvidenceArtifact | null;
+  photos?: EvidenceArtifact | null;
+}): TriageEvidenceFingerprint {
+  const payload: Omit<TriageEvidenceFingerprint, 'hash'> = {
+    version: TRIAGE_EVIDENCE_FINGERPRINT_VERSION,
+    layers: {
+      details: true as const,
+      reviews: !!input.reviews,
+      photos: !!input.photos,
+    },
+    artifacts: {
+      detailsSha256: sha256(input.details.content),
+      reviewsSha256:
+        input.reviews ? sha256(input.reviews.content) : null,
+      photosSha256:
+        input.photos ? sha256(input.photos.content) : null,
+    },
+    detailsCoreCoverage:
+      getTriageDetailsCoreCoverage(input.details.data),
+  };
+
+  return {
+    ...payload,
+    hash: sha256(JSON.stringify(payload)),
+  };
+}
+
+export function parseTriageEvidenceFingerprint(
+  value: unknown,
+): TriageEvidenceFingerprint | null {
+  const record = asRecord(value);
+  const layers = asRecord(record?.layers);
+  const artifacts = asRecord(record?.artifacts);
+  if (
+    record?.version !== TRIAGE_EVIDENCE_FINGERPRINT_VERSION
+    || !isSha256(record.hash)
+    || layers?.details !== true
+    || typeof layers.reviews !== 'boolean'
+    || typeof layers.photos !== 'boolean'
+    || !isSha256(artifacts?.detailsSha256)
+    || !(
+      artifacts?.reviewsSha256 === null
+      || isSha256(artifacts?.reviewsSha256)
+    )
+    || !(
+      artifacts?.photosSha256 === null
+      || isSha256(artifacts?.photosSha256)
+    )
+    || layers.reviews !== (artifacts?.reviewsSha256 != null)
+    || layers.photos !== (artifacts?.photosSha256 != null)
+    || !isCoverage(record.detailsCoreCoverage)
+  ) {
+    return null;
+  }
+
+  const candidate = record as unknown as TriageEvidenceFingerprint;
+  const canonicalPayload: Omit<TriageEvidenceFingerprint, 'hash'> = {
+    version: candidate.version,
+    layers: {
+      details: true,
+      reviews: candidate.layers.reviews,
+      photos: candidate.layers.photos,
+    },
+    artifacts: {
+      detailsSha256: candidate.artifacts.detailsSha256,
+      reviewsSha256: candidate.artifacts.reviewsSha256,
+      photosSha256: candidate.artifacts.photosSha256,
+    },
+    detailsCoreCoverage: {
+      title: candidate.detailsCoreCoverage.title,
+      rating: candidate.detailsCoreCoverage.rating,
+      reviewCount: candidate.detailsCoreCoverage.reviewCount,
+      subRatings: candidate.detailsCoreCoverage.subRatings,
+      amenities: candidate.detailsCoreCoverage.amenities,
+      total: candidate.detailsCoreCoverage.total,
+    },
+  };
+  const expected = createHash('sha256')
+    .update(JSON.stringify(canonicalPayload))
+    .digest('hex');
+  return candidate.hash === expected ? candidate : null;
+}
+
+export function didTriageEvidenceMateriallyImprove(
+  before: TriageEvidenceFingerprint,
+  after: TriageEvidenceFingerprint,
+): boolean {
+  return TRIAGE_DETAILS_CORE_FIELDS.some(
+    (field) =>
+      !before.detailsCoreCoverage[field]
+      && after.detailsCoreCoverage[field],
+  );
+}
+
+function readJsonArtifact(filePath: string): EvidenceArtifact {
+  const content = fs.readFileSync(filePath, 'utf8');
+  return {
+    content,
+    data: JSON.parse(content) as unknown,
+  };
+}
+
+function readOptionalJsonArtifact(
+  filePath: string | null | undefined,
+): EvidenceArtifact | null {
+  if (!filePath || !fs.existsSync(filePath)) return null;
+  try {
+    const artifact = readJsonArtifact(filePath);
+    return artifact.data ? artifact : null;
+  } catch {
+    return null;
+  }
+}
+
+export function fingerprintTriageEvidenceFiles(input: {
+  detailsFile: string;
+  reviewsFile?: string | null;
+  photosFile?: string | null;
+}): TriageEvidenceFingerprint {
+  return createTriageEvidenceFingerprint({
+    details: readJsonArtifact(input.detailsFile),
+    reviews: readOptionalJsonArtifact(input.reviewsFile),
+    photos: readOptionalJsonArtifact(input.photosFile),
+  });
+}

--- a/src/triage.ts
+++ b/src/triage.ts
@@ -25,6 +25,9 @@ import {
   TRIAGE_CLASSIFIER_VERSION,
   type TriageClassifierVersion,
 } from './triage-comparability.js';
+import {
+  createTriageEvidenceFingerprint,
+} from './triage-evidence.js';
 
 // --- Types ---
 
@@ -882,7 +885,8 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
   if (!fs.existsSync(listingPath)) {
     throw new Error(`Listing file not found: ${listingPath}`);
   }
-  const listingData = JSON.parse(fs.readFileSync(listingPath, 'utf-8'));
+  const listingContent = fs.readFileSync(listingPath, 'utf-8');
+  const listingData = JSON.parse(listingContent);
   const trimmedListing = trimListingData(listingData);
   const stayContext = normalizeTriageStayContext(
     options.stayContext,
@@ -892,11 +896,16 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
 
   // 3. Read AI reviews (optional)
   let aiReviewsData: any = null;
+  let aiReviewsContent: string | null = null;
   if (aiReviewsFile) {
     const reviewsPath = path.resolve(aiReviewsFile);
     if (fs.existsSync(reviewsPath)) {
       try {
-        aiReviewsData = JSON.parse(fs.readFileSync(reviewsPath, 'utf-8'));
+        const content = fs.readFileSync(reviewsPath, 'utf-8');
+        aiReviewsData = JSON.parse(content);
+        if (aiReviewsData) {
+          aiReviewsContent = content;
+        }
       } catch (err: any) {
         console.warn(`  Warning: could not parse AI reviews file: ${err.message}`);
       }
@@ -908,11 +917,16 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
 
   // 4. Read AI photos (optional)
   let aiPhotosData: any = null;
+  let aiPhotosContent: string | null = null;
   if (aiPhotosFile) {
     const photosPath = path.resolve(aiPhotosFile);
     if (fs.existsSync(photosPath)) {
       try {
-        aiPhotosData = JSON.parse(fs.readFileSync(photosPath, 'utf-8'));
+        const content = fs.readFileSync(photosPath, 'utf-8');
+        aiPhotosData = JSON.parse(content);
+        if (aiPhotosData) {
+          aiPhotosContent = content;
+        }
       } catch (err: any) {
         console.warn(`  Warning: could not parse AI photos file: ${err.message}`);
       }
@@ -1037,6 +1051,20 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
     price,
     availability,
   });
+  const evidenceFingerprint = createTriageEvidenceFingerprint({
+    details: {
+      content: listingContent,
+      data: listingData,
+    },
+    reviews:
+      aiReviewsContent
+        ? { content: aiReviewsContent, data: aiReviewsData }
+        : null,
+    photos:
+      aiPhotosContent
+        ? { content: aiPhotosContent, data: aiPhotosData }
+        : null,
+  });
   const triageData = {
     ...parsed,
     ...score,
@@ -1047,6 +1075,7 @@ export async function runTriage(options: TriageOptions): Promise<TriageResult> {
     stayContext,
     affordability,
     evidenceGaps: normalizedEvidenceGaps,
+    evidenceFingerprint,
   };
 
   // 9. Log and return combined parser + classifier usage.

--- a/tests/results-rubric.test.ts
+++ b/tests/results-rubric.test.ts
@@ -21,6 +21,7 @@ import {
 function listing(
   id: string,
   triage: Record<string, unknown> | null,
+  regradeSuggested = false,
 ): ReviewJobListing {
   return {
     id,
@@ -42,6 +43,7 @@ function listing(
           triage,
           aiReviews: null,
           aiPhotos: null,
+          regradeSuggested,
         }
       : null,
   } as unknown as ReviewJobListing;
@@ -374,17 +376,27 @@ test('brief and comparability staleness share ordered regrade reason codes', () 
     tier: 'top_pick',
     rankingStatus: 'ranked',
   });
+  const improved = listing('improved', {
+    scoreSource: 'deterministic_rubric',
+    rubricVersion: '1',
+    requirementSetId: 'reqset_active',
+    classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+    fitScore: 82,
+    tier: 'top_pick',
+    rankingStatus: 'ranked',
+  }, true);
   const activeComparison =
     getCurrentTriageComparability('reqset_active');
 
   assert.deepEqual(
     getTriageRegradeReasons(
-      [current, oldPolicy, mismatched],
+      [current, improved, oldPolicy, mismatched],
       activeComparison,
       true,
     ),
     [
       'brief_changed',
+      'evidence_improved',
       'classifier_policy_changed',
       'requirement_set_mismatch',
     ],
@@ -394,6 +406,25 @@ test('brief and comparability staleness share ordered regrade reason codes', () 
       getListingResultsSnapshot(current).triage,
       activeComparison,
       { regradeRequired: true },
+    ),
+    'regrade_required',
+  );
+  assert.equal(
+    getTriageComparisonStatus(
+      getListingResultsSnapshot(improved).triage,
+      activeComparison,
+      { regradeSuggested: true },
+    ),
+    'regrade_suggested',
+  );
+  assert.equal(
+    getTriageComparisonStatus(
+      getListingResultsSnapshot(improved).triage,
+      activeComparison,
+      {
+        regradeRequired: true,
+        regradeSuggested: true,
+      },
     ),
     'regrade_required',
   );

--- a/tests/review-job-details-repair.test.ts
+++ b/tests/review-job-details-repair.test.ts
@@ -13,9 +13,13 @@ import {
   getDetailsRepairCoverage,
   readReviewJobDetailsRepairPlan,
   stageReviewJobDetailsRepair,
+  validateAppliedDetailsRepairForEvidenceReconciliation,
   validateReviewJobDetailsRepairForApply,
   type DetailsRepairJobInput,
 } from '../web/src/lib/review-job-details-repair.js';
+import {
+  fingerprintTriageEvidenceFiles,
+} from '../src/triage-evidence.js';
 
 function writeJson(filePath: string, value: unknown): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -99,9 +103,15 @@ function seedEntryArtifacts(
   writeJson(path.join(rootDir, entry.aiPhotos.file), {
     analysis: `photos:${entry.id}`,
   });
+  const evidenceFingerprint = fingerprintTriageEvidenceFiles({
+    detailsFile: path.join(rootDir, entry.details.file),
+    reviewsFile: path.join(rootDir, entry.aiReviews.file),
+    photosFile: path.join(rootDir, entry.aiPhotos.file),
+  });
   writeJson(path.join(rootDir, entry.triage.file), {
     verdict: 'unchanged',
     listingId: entry.id,
+    evidenceFingerprint,
   });
 }
 
@@ -239,6 +249,9 @@ test('details repair stages only missing core fields and preserves every non-det
         url: airbnbOneUrl,
         detailsStatus: 'completed',
         details: firstBefore,
+        triageEvidenceFingerprint: null,
+        regradeSuggested: false,
+        hasTriageVerdict: true,
       },
       {
         rowId: 'row-222',
@@ -248,6 +261,9 @@ test('details repair stages only missing core fields and preserves every non-det
         url: airbnbTwoUrl,
         detailsStatus: 'completed',
         details: secondBefore,
+        triageEvidenceFingerprint: null,
+        regradeSuggested: false,
+        hasTriageVerdict: true,
       },
       {
         rowId: 'row-booking',
@@ -257,6 +273,9 @@ test('details repair stages only missing core fields and preserves every non-det
         url: bookingUrl,
         detailsStatus: 'completed',
         details: bookingBefore,
+        triageEvidenceFingerprint: null,
+        regradeSuggested: false,
+        hasTriageVerdict: true,
       },
     ],
   };
@@ -405,9 +424,64 @@ test('details repair stages only missing core fields and preserves every non-det
     assert.equal(updates.length, 1);
     assert.equal(updates[0].analysisId, 'analysis-111');
     assert.equal(updates[0].detailsStatus, 'completed');
+    assert.equal(updates[0].regradeSuggested, true);
+    assert.deepEqual(
+      updates[0].triageEvidenceFingerprint?.detailsCoreCoverage,
+      plan.listings[0].beforeCoverage,
+    );
     assert.equal(
       fingerprintDetailsRepairValue(updates[0].details),
       plan.listings[0].afterDetailsFingerprint,
+    );
+
+    const appliedJob: DetailsRepairJobInput = {
+      ...job,
+      artifactRoot: stagedRoot,
+      reportPath: plan.stagedReportPath,
+      sourceStateFingerprint: 'db-state-after',
+      listings: job.listings.map((listing) =>
+        listing.listingId === '111'
+          ? {
+              ...listing,
+              details: repairedDetails,
+            }
+          : listing),
+    };
+    const reconciliation =
+      validateAppliedDetailsRepairForEvidenceReconciliation({
+        plan: loadedPlan,
+        job: appliedJob,
+      });
+    assert.equal(reconciliation.length, 1);
+    assert.equal(reconciliation[0].listingId, '111');
+    assert.equal(reconciliation[0].regradeSuggested, true);
+    assert.deepEqual(
+      reconciliation[0].triageEvidenceFingerprint
+        .detailsCoreCoverage,
+      plan.listings[0].beforeCoverage,
+    );
+
+    const currentEvidence = fingerprintTriageEvidenceFiles({
+      detailsFile: path.join(stagedRoot, airbnbOne.details.file),
+      reviewsFile: path.join(stagedRoot, airbnbOne.aiReviews.file),
+      photosFile: path.join(stagedRoot, airbnbOne.aiPhotos.file),
+    });
+    assert.deepEqual(
+      validateAppliedDetailsRepairForEvidenceReconciliation({
+        plan: loadedPlan,
+        job: {
+          ...appliedJob,
+          listings: appliedJob.listings.map((listing) =>
+            listing.listingId === '111'
+              ? {
+                  ...listing,
+                  triageEvidenceFingerprint: currentEvidence,
+                  regradeSuggested: false,
+                }
+              : listing),
+        },
+      }),
+      [],
     );
 
     assert.throws(
@@ -529,6 +603,9 @@ test('details repair refuses a no-op plan and leaves the source root unchanged',
             url,
             detailsStatus: 'completed',
             details: before,
+            triageEvidenceFingerprint: null,
+            regradeSuggested: false,
+            hasTriageVerdict: true,
           }],
         },
         platform: 'airbnb',

--- a/tests/review-job-persistence.test.ts
+++ b/tests/review-job-persistence.test.ts
@@ -23,6 +23,7 @@ function makeJob(overrides: Record<string, unknown> = {}) {
     location: 'London',
     prompt: 'quiet and close to POI',
     regradeRequired: false,
+    regradeSuggested: false,
     boundingBox: null,
     circle: null,
     poi: null,
@@ -119,6 +120,8 @@ function makeListing(overrides: Record<string, unknown> = {}) {
       aiReviews: { overallSentiment: 'great' },
       aiPhotos: { overallImpression: 'clean' },
       triage: { fitScore: 88, tier: 'shortlist' },
+      triageEvidenceFingerprint: null,
+      regradeSuggested: false,
       reviewCount: 10,
       photoCount: 12,
       aiReviewsCostUsd: 0.0142,
@@ -189,6 +192,7 @@ test('native results readiness is derived from persisted analysis state, not rep
   assert.equal(response.job.legacyReportAvailable, false);
   assert.equal(response.job.artifactArchiveAvailable, false);
   assert.equal(response.job.regradeRequired, false);
+  assert.equal(response.job.regradeSuggested, false);
   assert.deepEqual(response.job.costs, {
     aiReviewsUsd: 0.0142,
     aiPhotosUsd: 0.0061,
@@ -219,6 +223,37 @@ test('job responses expose the durable quality regrade requirement', () => {
 
   assert.equal(response.job.regradeRequired, true);
   assert.equal(response.job.reportReady, true);
+});
+
+test('job responses expose suggested regrades and consumed evidence', () => {
+  const fingerprint = {
+    version: 1,
+    hash: 'a'.repeat(64),
+  };
+  const response = toReviewJobResponse({
+    job: makeJob({ regradeSuggested: true }),
+    listings: [
+      makeListing({
+        analysis: {
+          ...makeListing().analysis,
+          triageEvidenceFingerprint: fingerprint,
+          regradeSuggested: true,
+        },
+      }),
+    ],
+    events: [],
+  });
+
+  assert.equal(response.job.regradeRequired, false);
+  assert.equal(response.job.regradeSuggested, true);
+  assert.equal(
+    response.listings[0].analysis?.regradeSuggested,
+    true,
+  );
+  assert.deepEqual(
+    response.listings[0].analysis?.triageEvidenceFingerprint,
+    fingerprint,
+  );
 });
 
 test('job responses expose duplicate decisions only while both offers are present', () => {

--- a/tests/triage-evidence.test.ts
+++ b/tests/triage-evidence.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  createTriageEvidenceFingerprint,
+  didTriageEvidenceMateriallyImprove,
+  parseTriageEvidenceFingerprint,
+} from '../src/triage-evidence.js';
+
+function artifact(data: unknown, suffix = '') {
+  return {
+    data,
+    content: `${JSON.stringify(data)}${suffix}`,
+  };
+}
+
+test('triage evidence fingerprints record layers, artifact hashes, and core coverage', () => {
+  const fingerprint = createTriageEvidenceFingerprint({
+    details: artifact({
+      title: 'Recovered title',
+      rating: 4.9,
+      reviewCount: 0,
+      subRatings: { cleanliness: 4.8 },
+      amenities: [{ name: 'Elevator' }],
+    }),
+    reviews: artifact({ themes: [] }),
+  });
+
+  assert.deepEqual(fingerprint.layers, {
+    details: true,
+    reviews: true,
+    photos: false,
+  });
+  assert.deepEqual(fingerprint.detailsCoreCoverage, {
+    title: true,
+    rating: true,
+    reviewCount: true,
+    subRatings: true,
+    amenities: true,
+    total: 5,
+  });
+  assert.match(fingerprint.artifacts.detailsSha256, /^[a-f0-9]{64}$/);
+  assert.match(fingerprint.artifacts.reviewsSha256 ?? '', /^[a-f0-9]{64}$/);
+  assert.equal(fingerprint.artifacts.photosSha256, null);
+  assert.deepEqual(
+    parseTriageEvidenceFingerprint(fingerprint),
+    fingerprint,
+  );
+  assert.ok(parseTriageEvidenceFingerprint({
+    hash: fingerprint.hash,
+    version: fingerprint.version,
+    detailsCoreCoverage: {
+      total: fingerprint.detailsCoreCoverage.total,
+      amenities: fingerprint.detailsCoreCoverage.amenities,
+      subRatings: fingerprint.detailsCoreCoverage.subRatings,
+      reviewCount: fingerprint.detailsCoreCoverage.reviewCount,
+      rating: fingerprint.detailsCoreCoverage.rating,
+      title: fingerprint.detailsCoreCoverage.title,
+    },
+    artifacts: {
+      photosSha256: fingerprint.artifacts.photosSha256,
+      reviewsSha256: fingerprint.artifacts.reviewsSha256,
+      detailsSha256: fingerprint.artifacts.detailsSha256,
+    },
+    layers: {
+      photos: fingerprint.layers.photos,
+      reviews: fingerprint.layers.reviews,
+      details: fingerprint.layers.details,
+    },
+  }));
+});
+
+test('byte drift alone changes the fingerprint without suggesting a regrade', () => {
+  const details = {
+    title: 'Same coverage',
+    rating: 4.8,
+    reviewCount: 20,
+    subRatings: { location: 4.7 },
+    amenities: ['Wifi'],
+    description: 'Before',
+  };
+  const before = createTriageEvidenceFingerprint({
+    details: artifact(details),
+  });
+  const after = createTriageEvidenceFingerprint({
+    details: artifact({ ...details, description: 'After' }, '\n'),
+  });
+
+  assert.notEqual(before.hash, after.hash);
+  assert.equal(
+    didTriageEvidenceMateriallyImprove(before, after),
+    false,
+  );
+});
+
+test('new core coverage is material but layer presence alone is not', () => {
+  const sparse = createTriageEvidenceFingerprint({
+    details: artifact({
+      title: '',
+      rating: null,
+      reviewCount: null,
+      subRatings: {},
+      amenities: [],
+    }),
+  });
+  const richerDetails = createTriageEvidenceFingerprint({
+    details: artifact({
+      title: 'Recovered',
+      rating: null,
+      reviewCount: 0,
+      subRatings: {},
+      amenities: [],
+    }),
+  });
+  const richerLayers = createTriageEvidenceFingerprint({
+    details: artifact({
+      title: '',
+      rating: null,
+      reviewCount: null,
+      subRatings: {},
+      amenities: [],
+    }),
+    photos: artifact({ observations: [] }),
+  });
+
+  assert.equal(
+    didTriageEvidenceMateriallyImprove(sparse, richerDetails),
+    true,
+  );
+  assert.equal(
+    didTriageEvidenceMateriallyImprove(sparse, richerLayers),
+    false,
+  );
+});

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "worker:dev": "dotenv -e ../.env -e .env.local -- tsx watch src/lib/search-worker.ts",
     "backfill:ai-costs": "dotenv -e ../.env -e .env.local -- tsx scripts/backfill-ai-costs.ts",
     "repair:job-details": "dotenv -e ../.env -e .env.local -- tsx scripts/refresh-job-details.ts",
+    "reconcile:job-evidence": "dotenv -e ../.env -e .env.local -- tsx scripts/reconcile-job-evidence.ts",
     "cleanup:artifacts": "dotenv -e ../.env -e .env.local -- tsx scripts/cleanup-artifacts.ts",
     "test:pricing": "tsx --test src/lib/pricing.test.ts",
     "test:ui": "tsx --test src/components/*.test.tsx",

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -120,6 +120,7 @@ model ReviewJob {
   location       String?
   prompt         String?
   regradeRequired Boolean         @default(false)
+  regradeSuggested Boolean        @default(false)
   boundingBox    Json?
   circle         Json?
   poi            Json?
@@ -226,6 +227,8 @@ model ReviewJobListingAnalysis {
   aiReviews       Json?
   aiPhotos        Json?
   triage          Json?
+  triageEvidenceFingerprint Json?
+  regradeSuggested Boolean  @default(false)
   reviewCount     Int?
   photoCount      Int?
   aiReviewsCostUsd Float    @default(0)

--- a/web/scripts/reconcile-job-evidence.ts
+++ b/web/scripts/reconcile-job-evidence.ts
@@ -1,0 +1,251 @@
+import * as path from 'node:path';
+import {
+  Prisma,
+  PrismaClient,
+  type Platform,
+} from '@prisma/client';
+import { config as loadDotEnv } from 'dotenv';
+import {
+  fingerprintDetailsRepairValue,
+  readReviewJobDetailsRepairPlan,
+  validateAppliedDetailsRepairForEvidenceReconciliation,
+  type DetailsRepairJobInput,
+} from '../src/lib/review-job-details-repair.js';
+
+for (const envPath of [
+  path.resolve(process.cwd(), '.env.local'),
+  path.resolve(process.cwd(), '.env'),
+  path.resolve(process.cwd(), '../.env'),
+]) {
+  loadDotEnv({ path: envPath, override: false, quiet: true });
+}
+
+const jobInclude = Prisma.validator<Prisma.ReviewJobInclude>()({
+  listings: {
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    include: { analysis: true },
+  },
+});
+
+type JobRecord = Prisma.ReviewJobGetPayload<{
+  include: typeof jobInclude;
+}>;
+type DbClient = PrismaClient | Prisma.TransactionClient;
+
+function toInputJsonValue(value: unknown): Prisma.InputJsonValue {
+  return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+}
+
+function parseArgs(args: string[]): {
+  jobId: string;
+  apply: boolean;
+} {
+  let jobId = '';
+  let apply = false;
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    if (argument === '--job') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error('--job requires a review-job ID');
+      }
+      jobId = value;
+      index++;
+      continue;
+    }
+    if (argument === '--apply') {
+      apply = true;
+      continue;
+    }
+    if (argument === '--help' || argument === '-h') {
+      console.log(
+        'Usage: npm run reconcile:job-evidence -- --job <id> [--apply]',
+      );
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+  if (!jobId) throw new Error('--job is required');
+  return { jobId, apply };
+}
+
+async function readJob(
+  client: DbClient,
+  jobId: string,
+): Promise<JobRecord | null> {
+  return client.reviewJob.findUnique({
+    where: { id: jobId },
+    include: jobInclude,
+  });
+}
+
+function toJobInput(job: JobRecord): DetailsRepairJobInput {
+  return {
+    id: job.id,
+    status: job.status,
+    currentPhase: job.currentPhase,
+    analysisStatus: job.analysisStatus,
+    analysisCurrentPhase: job.analysisCurrentPhase,
+    priceRefreshStatus: job.priceRefreshStatus,
+    priceRefreshCurrentPhase: job.priceRefreshCurrentPhase,
+    artifactRoot: job.artifactRoot,
+    reportPath: job.reportPath,
+    checkin: job.checkin,
+    checkout: job.checkout,
+    adults: job.adults,
+    sourceStateFingerprint: fingerprintDetailsRepairValue(job),
+    listings: job.listings.map((listing) => {
+      if (!listing.analysis) {
+        throw new Error(
+          `Review job listing ${listing.id} has no analysis row`,
+        );
+      }
+      return {
+        rowId: listing.id,
+        analysisId: listing.analysis.id,
+        listingId: listing.listingId,
+        platform: listing.platform as Platform,
+        url: listing.url,
+        detailsStatus: listing.analysis.detailsStatus,
+        details: listing.analysis.details,
+        triageEvidenceFingerprint:
+          listing.analysis.triageEvidenceFingerprint,
+        regradeSuggested: listing.analysis.regradeSuggested,
+        hasTriageVerdict: listing.analysis.triage != null,
+      };
+    }),
+  };
+}
+
+function getUpdates(job: JobRecord) {
+  if (!job.artifactRoot) {
+    throw new Error(`Review job ${job.id} has no artifact root`);
+  }
+  const plan = readReviewJobDetailsRepairPlan(job.artifactRoot);
+  return validateAppliedDetailsRepairForEvidenceReconciliation({
+    plan,
+    job: toJobInput(job),
+  });
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const prisma = new PrismaClient();
+  try {
+    const job = await readJob(prisma, options.jobId);
+    if (!job) throw new Error(`Review job ${options.jobId} not found`);
+    const updates = getUpdates(job);
+    console.log('listing_id\tevidence_hash\tregrade_suggested');
+    for (const update of updates) {
+      console.log([
+        update.listingId,
+        update.triageEvidenceFingerprint.hash,
+        '1',
+      ].join('\t'));
+    }
+    console.log(`Summary: affected=${updates.length}`);
+    if (!options.apply || updates.length === 0) {
+      console.log(
+        options.apply
+          ? 'No reconciliation changes were needed.'
+          : 'Dry run only. Re-run with --apply to persist.',
+      );
+      return;
+    }
+
+    let appliedCount = 0;
+    await prisma.$transaction(async (tx) => {
+      await tx.$queryRaw(
+        Prisma.sql`
+          SELECT "id"
+          FROM "ReviewJob"
+          WHERE "id" = ${options.jobId}
+          FOR UPDATE
+        `,
+      );
+      await tx.$queryRaw(
+        Prisma.sql`
+          SELECT analysis."id"
+          FROM "ReviewJobListingAnalysis" analysis
+          INNER JOIN "ReviewJobListing" listing
+            ON listing."id" = analysis."jobListingId"
+          WHERE listing."jobId" = ${options.jobId}
+          FOR UPDATE OF analysis
+        `,
+      );
+      const lockedJob = await readJob(tx, options.jobId);
+      if (!lockedJob) {
+        throw new Error(
+          `Review job ${options.jobId} disappeared during apply`,
+        );
+      }
+      const lockedUpdates = getUpdates(lockedJob);
+      appliedCount = lockedUpdates.length;
+      for (const update of lockedUpdates) {
+        await tx.reviewJobListingAnalysis.update({
+          where: { id: update.analysisId },
+          data: {
+            triageEvidenceFingerprint: toInputJsonValue(
+              update.triageEvidenceFingerprint,
+            ),
+            regradeSuggested: true,
+          },
+        });
+      }
+      const suggestedCount =
+        await tx.reviewJobListingAnalysis.count({
+          where: {
+            jobListing: {
+              jobId: options.jobId,
+              hidden: false,
+            },
+            regradeSuggested: true,
+          },
+        });
+      await tx.reviewJob.update({
+        where: { id: options.jobId },
+        data: { regradeSuggested: suggestedCount > 0 },
+      });
+      if (lockedUpdates.length > 0) {
+        await tx.reviewJobEvent.create({
+          data: {
+            jobId: options.jobId,
+            phase: 'triage',
+            level: 'warning',
+            message:
+              'Listing evidence improved; saved verdicts should be regraded.',
+            payload: {
+              reason: 'evidence_improved',
+              listingCount: lockedUpdates.length,
+              listingIds: lockedUpdates.map(
+                (update) => update.listingId,
+              ),
+            },
+          },
+        });
+      }
+    }, {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+      maxWait: 10_000,
+      timeout: 30_000,
+    });
+
+    const applied = await readJob(prisma, options.jobId);
+    if (!applied || getUpdates(applied).length !== 0) {
+      throw new Error(
+        'Evidence reconciliation committed but did not verify',
+      );
+    }
+    console.log(
+      `Applied evidence staleness to ${appliedCount} listing`
+      + `${appliedCount === 1 ? '' : 's'}.`,
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/web/scripts/refresh-job-details.ts
+++ b/web/scripts/refresh-job-details.ts
@@ -47,6 +47,10 @@ type RepairJobRecord = Prisma.ReviewJobGetPayload<{
 
 type RepairDbClient = PrismaClient | Prisma.TransactionClient;
 
+function toInputJsonValue(value: unknown): Prisma.InputJsonValue {
+  return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+}
+
 function usage(): string {
   return (
     'Usage:\n'
@@ -166,6 +170,10 @@ function toRepairJobInput(job: RepairJobRecord): DetailsRepairJobInput {
         url: listing.url,
         detailsStatus: listing.analysis.detailsStatus,
         details: listing.analysis.details,
+        triageEvidenceFingerprint:
+          listing.analysis.triageEvidenceFingerprint,
+        regradeSuggested: listing.analysis.regradeSuggested,
+        hasTriageVerdict: listing.analysis.triage != null,
       };
     }),
   };
@@ -234,10 +242,13 @@ function postApplyInvariant(
   };
   delete clone.artifactRoot;
   delete clone.reportPath;
+  delete clone.regradeSuggested;
   for (const listing of clone.listings ?? []) {
     if (!repairedRowIds.has(listing.id) || !listing.analysis) continue;
     delete listing.analysis.details;
     delete listing.analysis.detailsStatus;
+    delete listing.analysis.triageEvidenceFingerprint;
+    delete listing.analysis.regradeSuggested;
     delete listing.analysis.updatedAt;
   }
   return fingerprintDetailsRepairValue(clone);
@@ -346,16 +357,55 @@ async function applyPlan(
           details:
             update.details as unknown as Prisma.InputJsonValue,
           detailsStatus: update.detailsStatus,
+          triageEvidenceFingerprint:
+            update.triageEvidenceFingerprint == null
+              ? Prisma.DbNull
+              : toInputJsonValue(
+                  update.triageEvidenceFingerprint,
+                ),
+          regradeSuggested: update.regradeSuggested,
         },
       });
     }
+    const regradeSuggestedListingCount =
+      await tx.reviewJobListingAnalysis.count({
+        where: {
+          jobListing: {
+            jobId: options.jobId,
+            hidden: false,
+          },
+          regradeSuggested: true,
+        },
+      });
     await tx.reviewJob.update({
       where: { id: options.jobId },
       data: {
         artifactRoot: plan.stagedArtifactRoot,
         reportPath: plan.stagedReportPath,
+        regradeSuggested: regradeSuggestedListingCount > 0,
       },
     });
+    const suggestedUpdates = updates.filter(
+      (update) => update.regradeSuggested,
+    );
+    if (suggestedUpdates.length > 0) {
+      await tx.reviewJobEvent.create({
+        data: {
+          jobId: options.jobId,
+          phase: 'triage',
+          level: 'warning',
+          message:
+            'Listing evidence improved; saved verdicts should be regraded.',
+          payload: {
+            reason: 'evidence_improved',
+            listingCount: suggestedUpdates.length,
+            listingIds: suggestedUpdates.map(
+              (update) => update.listingId,
+            ),
+          },
+        },
+      });
+    }
   }, {
     isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
     maxWait: 10_000,

--- a/web/src/components/JobWorkspace.tsx
+++ b/web/src/components/JobWorkspace.tsx
@@ -274,6 +274,7 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
     !== normalizeQualityBriefForComparison(savedPrompt);
   const qualityRegradeNeeded =
     data.job.regradeRequired
+    || data.job.regradeSuggested
     || (
       qualityBriefDirty
       && (
@@ -415,7 +416,10 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
 
       const savedData: ReviewJobResponse = await saveRes.json();
       const triageOnly =
-        savedData.job.regradeRequired
+        (
+          savedData.job.regradeRequired
+          || savedData.job.regradeSuggested
+        )
         && savedData.job.artifactArchiveAvailable;
       const analyzeRes = await fetch(`/api/jobs/${data.job.id}/analyze`, {
         method: 'POST',
@@ -585,11 +589,12 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
               <span
                 className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${
                   data.job.regradeRequired
+                  || data.job.regradeSuggested
                     ? 'border-amber-300/20 bg-amber-300/10 text-amber-100'
                     : statusClassName(data.job.status)
                 }`}
               >
-                {data.job.regradeRequired
+                {data.job.regradeRequired || data.job.regradeSuggested
                   ? 'Regrade needed'
                   : statusLabel(
                       data.job.status,
@@ -644,7 +649,7 @@ export default function JobWorkspace({ initialData }: JobWorkspaceProps) {
                 </span>
                 <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1.5">
                   Analysis:{' '}
-                  {data.job.regradeRequired
+                  {data.job.regradeRequired || data.job.regradeSuggested
                     ? 'Regrade needed'
                     : phaseStatusLabel(data.job.analysisStatus)}
                 </span>

--- a/web/src/components/PrioritiesMatrix.test.tsx
+++ b/web/src/components/PrioritiesMatrix.test.tsx
@@ -34,6 +34,7 @@ function listing(
   options: {
     insufficient?: boolean;
     evidenceGaps?: string[];
+    regradeSuggested?: boolean;
   } = {},
 ): ReviewJobListing {
   return {
@@ -72,6 +73,7 @@ function listing(
       overByPercent: null,
     },
     analysis: {
+      regradeSuggested: options.regradeSuggested ?? false,
       triage: {
         scoreSource: 'deterministic_rubric',
         rubricVersion: TRIAGE_RUBRIC_VERSION,
@@ -186,6 +188,26 @@ test('priorities matrix preserves paid evidence after a quality brief edit', () 
   assert.match(html, /42 of 250 AI-analyzed reviews/);
   assert.match(html, /Regrade whole job/);
   assert.match(html, /Estimated triage cost: \$0\.012/);
+});
+
+test('evidence improvement reuses regrade presentation without invalidating ranking', () => {
+  const html = renderToStaticMarkup(
+    <PrioritiesMatrix
+      listings={[
+        listing('sleep-test', { regradeSuggested: true }),
+      ]}
+      regradeReasons={['evidence_improved']}
+      onRegrade={() => undefined}
+    />,
+  );
+
+  assert.match(html, /Regrade needed to use improved evidence/);
+  assert.match(html, /materially richer evidence/);
+  assert.match(
+    html,
+    /Existing verdicts remain comparable and ranked/,
+  );
+  assert.match(html, /Comparable ranked results/);
 });
 
 test('duplicate conflicts keep their evidence in a separate unranked group', () => {

--- a/web/src/components/PrioritiesMatrix.tsx
+++ b/web/src/components/PrioritiesMatrix.tsx
@@ -302,6 +302,20 @@ export default function PrioritiesMatrix({
 }) {
   const regradeNeeded = regradeReasons.length > 0;
   const briefChanged = regradeReasons.includes('brief_changed');
+  const evidenceImproved =
+    regradeReasons.includes('evidence_improved');
+  const verdictsRequireRegrade = regradeReasons.some(
+    (reason) => reason !== 'evidence_improved',
+  );
+  const suggestedListingKeys = useMemo(
+    () => new Set(
+      listings
+        .filter((listing) =>
+          listing.analysis?.regradeSuggested === true)
+        .map((listing) => `${listing.platform}:${listing.id}`),
+    ),
+    [listings],
+  );
   const wholeJobListingCount =
     regradeListingCount
     ?? listings.filter((listing) => !listing.hidden).length;
@@ -381,7 +395,9 @@ export default function PrioritiesMatrix({
           <div className="mt-4 flex flex-col gap-3 rounded-2xl border border-amber-300/20 bg-amber-300/[0.08] p-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-xs font-semibold text-amber-100">
-                Regrade needed before comparing verdicts
+                {verdictsRequireRegrade
+                  ? 'Regrade needed before comparing verdicts'
+                  : 'Regrade needed to use improved evidence'}
               </p>
               <ul className="mt-1 max-w-3xl space-y-1 text-[11px] leading-5 text-amber-100/70">
                 {regradeReasons.map((reason) => (
@@ -391,13 +407,27 @@ export default function PrioritiesMatrix({
                 ))}
               </ul>
               <p className="mt-1 max-w-3xl text-[11px] leading-5 text-amber-100/70">
-                Evidence snippets, frequencies, and years remain valid audit
-                data.
-                {briefChanged
-                  ? ' The priority columns reflect the previous brief.'
-                  : ' Some verdicts use a different policy or priority set.'}
-                {' '}Peer comparison is not current until the whole job is
-                regraded. Regrading reuses saved review and photo analysis and
+                {verdictsRequireRegrade
+                  ? (
+                    <>
+                      Evidence snippets, frequencies, and years remain valid
+                      audit data.
+                      {briefChanged
+                        ? ' The priority columns reflect the previous brief.'
+                        : ' Some verdicts use a different policy or priority set.'}
+                      {' '}Peer comparison is not current until the whole job
+                      is regraded.
+                    </>
+                  )
+                  : evidenceImproved
+                    ? (
+                      <>
+                        Existing verdicts remain comparable and ranked, but
+                        affected listings were graded from thinner evidence.
+                      </>
+                    )
+                    : null}
+                {' '}Regrading reuses saved review and photo analysis and
                 calls only triage.
               </p>
               <p className="mt-1 text-[11px] leading-5 text-amber-100/60">
@@ -489,9 +519,17 @@ export default function PrioritiesMatrix({
             </thead>
             <tbody>
               {rows.map((row, index) => {
-                const duplicateConflict = duplicateConflictKeys.has(
-                  `${row.platform}:${row.id}`,
-                );
+                const listingKey = `${row.platform}:${row.id}`;
+                const duplicateConflict =
+                  duplicateConflictKeys.has(listingKey);
+                const evidenceStale =
+                  suggestedListingKeys.has(listingKey);
+                const rowRegradeNeeded =
+                  (
+                    briefChanged
+                    && row.rankingStatus !== 'unscored'
+                  )
+                  || evidenceStale;
                 const showGroup =
                   index === 0
                   || rowGroupKey(row) !== rowGroupKey(rows[index - 1]);
@@ -538,8 +576,7 @@ export default function PrioritiesMatrix({
                             className={`rounded-full border px-2 py-0.5 text-[9px] font-bold uppercase tracking-[0.1em] ${
                               duplicateConflict
                                 ? statusClassName('unmet')
-                                : briefChanged
-                                && row.rankingStatus !== 'unscored'
+                                : rowRegradeNeeded
                                 ? statusClassName('partial')
                                 : row.rankingStatus === 'ranked'
                                 ? statusClassName('met')
@@ -550,8 +587,7 @@ export default function PrioritiesMatrix({
                           >
                             {duplicateConflict
                               ? 'Cross-platform conflict'
-                              : briefChanged
-                              && row.rankingStatus !== 'unscored'
+                              : rowRegradeNeeded
                               ? 'Regrade needed'
                               : rankingLabel(row.rankingStatus)}
                           </span>

--- a/web/src/components/ResultsWorkspace.tsx
+++ b/web/src/components/ResultsWorkspace.tsx
@@ -119,6 +119,7 @@ function formatPercent(value: number | null): string {
 function comparisonRank(status: ResultsComparisonStatus): number {
   switch (status) {
     case 'ranked':
+    case 'regrade_suggested':
       return 0;
     case 'duplicate_conflict':
       return 1;
@@ -134,6 +135,12 @@ function comparisonRank(status: ResultsComparisonStatus): number {
     case 'unscored':
       return 6;
   }
+}
+
+function isPeerComparableStatus(
+  status: ResultsComparisonStatus,
+): boolean {
+  return status === 'ranked' || status === 'regrade_suggested';
 }
 
 function displayedTier(
@@ -217,6 +224,13 @@ function VerdictSourceBadge({
     return (
       <span className="rounded-full border border-amber-300/20 bg-amber-300/10 px-2 py-1 text-[10px] font-semibold text-amber-100">
         Regrade needed · brief changed
+      </span>
+    );
+  }
+  if (status === 'regrade_suggested') {
+    return (
+      <span className="rounded-full border border-amber-300/20 bg-amber-300/10 px-2 py-1 text-[10px] font-semibold text-amber-100">
+        Regrade needed · evidence improved
       </span>
     );
   }
@@ -1482,10 +1496,12 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       data.listings,
       activeTriageComparison,
       data.job.regradeRequired,
+      data.job.regradeSuggested,
     ),
     [
       activeTriageComparison,
       data.job.regradeRequired,
+      data.job.regradeSuggested,
       data.listings,
     ],
   );
@@ -1520,13 +1536,20 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
   const comparisonGateActive =
     activeTriageComparison != null
     || data.job.regradeRequired
+    || data.job.regradeSuggested
     || materialDuplicateConflictKeys.size > 0;
   const resolveComparisonStatus = useCallback(
-    (triage: ParsedTriage | null) =>
+    (
+      triage: ParsedTriage | null,
+      regradeSuggested = false,
+    ) =>
       getTriageComparisonStatus(
         triage,
         activeTriageComparison,
-        { regradeRequired: data.job.regradeRequired },
+        {
+          regradeRequired: data.job.regradeRequired,
+          regradeSuggested,
+        },
       ),
     [activeTriageComparison, data.job.regradeRequired],
   );
@@ -1536,6 +1559,7 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
         ? 'duplicate_conflict'
         : resolveComparisonStatus(
             getListingResultsSnapshot(listing).triage,
+            listing.analysis?.regradeSuggested === true,
           ),
     [materialDuplicateConflictKeys, resolveComparisonStatus],
   );
@@ -1674,9 +1698,13 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       if (!sortAsc) return next;
       if (!comparisonGateActive) return [...next].reverse();
       const ranked = next.filter((listing) =>
-        resolveListingComparisonStatus(listing) === 'ranked');
+        isPeerComparableStatus(
+          resolveListingComparisonStatus(listing),
+        ));
       const unranked = next.filter((listing) =>
-        resolveListingComparisonStatus(listing) !== 'ranked');
+        !isPeerComparableStatus(
+          resolveListingComparisonStatus(listing),
+        ));
       return [...ranked.reverse(), ...unranked];
     }
 
@@ -1790,7 +1818,10 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
           resolveListingComparisonStatus(listing);
         const tier = triage?.tier ?? 'unscored';
         if (
-          (!comparisonGateActive || comparisonStatus === 'ranked')
+          (
+            !comparisonGateActive
+            || isPeerComparableStatus(comparisonStatus)
+          )
           && !activeTiers.has(tier)
         ) {
           return false;
@@ -1858,7 +1889,9 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
         listing.staySnapshot.bookingEligibility.actionable
         && (
         !comparisonGateActive
-        || resolveListingComparisonStatus(listing) === 'ranked'
+        || isPeerComparableStatus(
+          resolveListingComparisonStatus(listing),
+        )
         ),
     );
     const topPicks = comparable.filter(
@@ -1880,7 +1913,9 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
       const triage = getListingResultsSnapshot(listing).triage;
       if (
         comparisonGateActive
-        && resolveListingComparisonStatus(listing) !== 'ranked'
+        && !isPeerComparableStatus(
+          resolveListingComparisonStatus(listing),
+        )
       ) {
         continue;
       }
@@ -2101,7 +2136,8 @@ export default function ResultsWorkspace({ initialData }: ResultsWorkspaceProps)
                 : 'Unscored listings'
             : null;
         const showPeerRank =
-          !comparisonGateActive || comparisonStatus === 'ranked';
+          !comparisonGateActive
+          || isPeerComparableStatus(comparisonStatus);
         const priceInfo = getPriceDisplayInfo(listing, priceDisplay, {
           checkin: data.job.checkin,
           checkout: data.job.checkout,

--- a/web/src/lib/results.ts
+++ b/web/src/lib/results.ts
@@ -162,6 +162,7 @@ export interface ParsedTriage {
 export type TriageComparisonStatus =
   | 'ranked'
   | 'regrade_required'
+  | 'regrade_suggested'
   | 'insufficient_evidence'
   | 'legacy'
   | 'stale_requirement_set'
@@ -171,6 +172,7 @@ export type TriageComparisonStatus =
 export type ActiveTriageComparison = TriageComparabilityDescriptor;
 export type TriageRegradeReason =
   | 'brief_changed'
+  | 'evidence_improved'
   | 'classifier_policy_changed'
   | 'requirement_set_mismatch';
 export type AffordabilityStatus =
@@ -182,6 +184,8 @@ export const TRIAGE_REGRADE_REASON_COPY: Record<
 > = {
   brief_changed:
     'The quality brief changed, so these verdicts reflect the previous brief.',
+  evidence_improved:
+    'Some listings now have materially richer evidence than their saved verdicts used.',
   classifier_policy_changed:
     'Some verdicts use an older classifier policy.',
   requirement_set_mismatch:
@@ -190,6 +194,7 @@ export const TRIAGE_REGRADE_REASON_COPY: Record<
 
 const TRIAGE_REGRADE_REASON_ORDER: TriageRegradeReason[] = [
   'brief_changed',
+  'evidence_improved',
   'classifier_policy_changed',
   'requirement_set_mismatch',
 ];
@@ -372,9 +377,20 @@ export function getTriageRegradeReasons(
   listings: ReviewJobListing[],
   activeComparison: ActiveTriageComparison | null,
   briefChanged: boolean,
+  evidenceImproved = false,
 ): TriageRegradeReason[] {
   const reasons = new Set<TriageRegradeReason>();
   if (briefChanged) reasons.add('brief_changed');
+  if (
+    evidenceImproved
+    || listings.some(
+      (listing) =>
+        !listing.hidden
+        && listing.analysis?.regradeSuggested === true,
+    )
+  ) {
+    reasons.add('evidence_improved');
+  }
 
   for (const listing of listings) {
     if (listing.hidden) continue;
@@ -396,10 +412,14 @@ export function getTriageRegradeReasons(
 export function getTriageComparisonStatus(
   triage: ParsedTriage | null,
   activeComparison: ActiveTriageComparison | null,
-  options: { regradeRequired?: boolean } = {},
+  options: {
+    regradeRequired?: boolean;
+    regradeSuggested?: boolean;
+  } = {},
 ): TriageComparisonStatus {
   if (!triage) return 'unscored';
   if (options.regradeRequired) return 'regrade_required';
+  if (options.regradeSuggested) return 'regrade_suggested';
   if (triage.scoreSource === 'model_legacy') return 'legacy';
   if (
     activeComparison

--- a/web/src/lib/review-job-details-repair.ts
+++ b/web/src/lib/review-job-details-repair.ts
@@ -17,26 +17,23 @@ import {
   getReviewJobArtifactRunDir,
   isReviewJobArtifactRootAvailable,
 } from './reviewJobArtifacts.js';
+import {
+  TRIAGE_DETAILS_CORE_FIELDS,
+  didTriageEvidenceMateriallyImprove,
+  fingerprintTriageEvidenceFiles,
+  getTriageDetailsCoreCoverage,
+  parseTriageEvidenceFingerprint,
+  type TriageDetailsCoreCoverage,
+  type TriageDetailsCoreField,
+  type TriageEvidenceFingerprint,
+} from '../../../src/triage-evidence.js';
 
 export const DETAILS_REPAIR_PLAN_VERSION = 1;
 export const DETAILS_REPAIR_PLAN_FILE = 'details-repair-plan.json';
 
 export type DetailsRepairPlatform = 'airbnb';
-export type DetailsRepairCoreField =
-  | 'title'
-  | 'rating'
-  | 'reviewCount'
-  | 'subRatings'
-  | 'amenities';
-
-export interface DetailsRepairCoverage {
-  title: boolean;
-  rating: boolean;
-  reviewCount: boolean;
-  subRatings: boolean;
-  amenities: boolean;
-  total: number;
-}
+export type DetailsRepairCoreField = TriageDetailsCoreField;
+export type DetailsRepairCoverage = TriageDetailsCoreCoverage;
 
 export interface DetailsRepairListingInput {
   rowId: string;
@@ -46,6 +43,9 @@ export interface DetailsRepairListingInput {
   url: string;
   detailsStatus: string;
   details: unknown;
+  triageEvidenceFingerprint: unknown;
+  regradeSuggested: boolean;
+  hasTriageVerdict: boolean;
 }
 
 export interface DetailsRepairJobInput {
@@ -109,6 +109,15 @@ export interface DetailsRepairApplyUpdate {
   listingId: string;
   details: Record<string, unknown>;
   detailsStatus: 'completed' | 'partial';
+  triageEvidenceFingerprint: TriageEvidenceFingerprint | null;
+  regradeSuggested: boolean;
+}
+
+export interface DetailsRepairEvidenceReconciliationUpdate {
+  analysisId: string;
+  listingId: string;
+  triageEvidenceFingerprint: TriageEvidenceFingerprint;
+  regradeSuggested: true;
 }
 
 type RunBatch = (
@@ -131,11 +140,7 @@ interface StageDetailsRepairInput {
 }
 
 const CORE_FIELDS: DetailsRepairCoreField[] = [
-  'title',
-  'rating',
-  'reviewCount',
-  'subRatings',
-  'amenities',
+  ...TRIAGE_DETAILS_CORE_FIELDS,
 ];
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -145,56 +150,10 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
-function nonEmptyString(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-  const normalized = value.trim();
-  return normalized || null;
-}
-
-function finiteNumber(value: unknown): number | null {
-  if (
-    value == null
-    || (typeof value === 'string' && value.trim() === '')
-  ) {
-    return null;
-  }
-  const parsed = typeof value === 'number' ? value : Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function hasSubRatings(value: unknown): boolean {
-  const record = asRecord(value);
-  return !!record && Object.values(record).some(
-    (rating) => finiteNumber(rating) != null,
-  );
-}
-
-function hasAmenities(value: unknown): boolean {
-  return Array.isArray(value) && value.some((amenity) => {
-    if (typeof amenity === 'string') {
-      return nonEmptyString(amenity) != null;
-    }
-    return nonEmptyString(asRecord(amenity)?.name) != null;
-  });
-}
-
 export function getDetailsRepairCoverage(
   value: unknown,
 ): DetailsRepairCoverage {
-  const details = asRecord(value);
-  const coverage = {
-    title: nonEmptyString(details?.title) != null,
-    rating: finiteNumber(details?.rating) != null,
-    reviewCount:
-      finiteNumber(details?.reviewCount) != null
-      && (finiteNumber(details?.reviewCount) as number) >= 0,
-    subRatings: hasSubRatings(details?.subRatings),
-    amenities: hasAmenities(details?.amenities),
-  };
-  return {
-    ...coverage,
-    total: CORE_FIELDS.filter((field) => coverage[field]).length,
-  };
+  return getTriageDetailsCoreCoverage(value);
 }
 
 function cloneJson<T>(value: T): T {
@@ -347,6 +306,66 @@ function getManifestEntry(
     ([, entry]) =>
       getListingMatchKey(entry.platform, entry.url) === matchKey,
   ) ?? null;
+}
+
+function getTriageEvidenceFingerprintFromArtifacts(input: {
+  artifactRoot: string;
+  entry: ManifestEntry;
+}): TriageEvidenceFingerprint | null {
+  if (
+    input.entry.triage.status !== 'fetched'
+    || !input.entry.triage.file
+    || !input.entry.details.file
+  ) {
+    return null;
+  }
+  const triagePath = resolveArtifactFile(
+    input.artifactRoot,
+    input.entry.triage.file,
+    'Triage artifact path',
+  );
+  const detailsPath = resolveArtifactFile(
+    input.artifactRoot,
+    input.entry.details.file,
+    'Details artifact path',
+  );
+  assertRegularFile(triagePath, 'Triage artifact');
+  assertRegularFile(detailsPath, 'Details artifact');
+  const triage = asRecord(
+    JSON.parse(fs.readFileSync(triagePath, 'utf8')) as unknown,
+  );
+  const evidenceGaps = new Set([
+    ...(Array.isArray(input.entry.triage.evidenceGaps)
+      ? input.entry.triage.evidenceGaps
+      : []),
+    ...(Array.isArray(triage?.evidenceGaps)
+      ? triage.evidenceGaps
+      : []),
+  ]);
+  const optionalArtifactPath = (
+    relativePath: string | undefined,
+    gap: 'reviews' | 'photos',
+  ): string | null => {
+    if (!relativePath || evidenceGaps.has(gap)) return null;
+    const artifactPath = resolveArtifactFile(
+      input.artifactRoot,
+      relativePath,
+      `${gap} evidence artifact path`,
+    );
+    return fs.existsSync(artifactPath) ? artifactPath : null;
+  };
+
+  return fingerprintTriageEvidenceFiles({
+    detailsFile: detailsPath,
+    reviewsFile: optionalArtifactPath(
+      input.entry.aiReviews.file,
+      'reviews',
+    ),
+    photosFile: optionalArtifactPath(
+      input.entry.aiPhotos.file,
+      'photos',
+    ),
+  });
 }
 
 function manifestInvariantValue(
@@ -901,33 +920,12 @@ export function readReviewJobDetailsRepairPlan(
   return plan;
 }
 
-export function validateReviewJobDetailsRepairForApply(input: {
-  plan: DetailsRepairPlan;
-  job: DetailsRepairJobInput;
-}): DetailsRepairApplyUpdate[] {
-  const { plan, job } = input;
-  assertIdleJob(job);
-  if (job.id !== plan.jobId) {
-    throw new Error(
-      `Repair plan is for ${plan.jobId}, not ${job.id}`,
-    );
-  }
-  if (path.resolve(job.artifactRoot ?? '') !== plan.sourceArtifactRoot) {
-    throw new Error(
-      'Review job artifact root changed after the dry run; refusing apply',
-    );
-  }
-  if (job.reportPath !== plan.sourceReportPath) {
-    throw new Error(
-      'Review job report path changed after the dry run; refusing apply',
-    );
-  }
-  if (job.sourceStateFingerprint !== plan.sourceStateFingerprint) {
-    throw new Error(
-      'Review job state changed after the dry run; refusing apply',
-    );
-  }
-
+function validateDetailsRepairArtifacts(
+  plan: DetailsRepairPlan,
+): {
+  sourceManifest: BatchManifest;
+  stagedManifest: BatchManifest;
+} {
   const sourceManifest = readManifest(plan.sourceArtifactRoot);
   if (
     fingerprintDetailsRepairValue(sourceManifest)
@@ -980,6 +978,38 @@ export function validateReviewJobDetailsRepairForApply(input: {
   ) {
     throw new Error('Staged report changed after the dry run');
   }
+  return { sourceManifest, stagedManifest };
+}
+
+export function validateReviewJobDetailsRepairForApply(input: {
+  plan: DetailsRepairPlan;
+  job: DetailsRepairJobInput;
+}): DetailsRepairApplyUpdate[] {
+  const { plan, job } = input;
+  assertIdleJob(job);
+  if (job.id !== plan.jobId) {
+    throw new Error(
+      `Repair plan is for ${plan.jobId}, not ${job.id}`,
+    );
+  }
+  if (path.resolve(job.artifactRoot ?? '') !== plan.sourceArtifactRoot) {
+    throw new Error(
+      'Review job artifact root changed after the dry run; refusing apply',
+    );
+  }
+  if (job.reportPath !== plan.sourceReportPath) {
+    throw new Error(
+      'Review job report path changed after the dry run; refusing apply',
+    );
+  }
+  if (job.sourceStateFingerprint !== plan.sourceStateFingerprint) {
+    throw new Error(
+      'Review job state changed after the dry run; refusing apply',
+    );
+  }
+
+  const { sourceManifest, stagedManifest } =
+    validateDetailsRepairArtifacts(plan);
 
   const currentListings = new Map(
     job.listings.map((listing) => [listing.rowId, listing]),
@@ -1140,11 +1170,45 @@ export function validateReviewJobDetailsRepairForApply(input: {
           + `${planned.listingId}`,
         );
       }
+      const consumedEvidence =
+        parseTriageEvidenceFingerprint(
+          current.triageEvidenceFingerprint,
+        )
+        ?? getTriageEvidenceFingerprintFromArtifacts({
+          artifactRoot: plan.sourceArtifactRoot,
+          entry: sourceEntry,
+        });
+      const refreshedEvidence =
+        getTriageEvidenceFingerprintFromArtifacts({
+          artifactRoot: plan.stagedArtifactRoot,
+          entry,
+        });
+      if (
+        current.hasTriageVerdict
+        && (!consumedEvidence || !refreshedEvidence)
+      ) {
+        throw new Error(
+          `Cannot fingerprint saved triage evidence for `
+          + `${planned.listingId}`,
+        );
+      }
+      const evidenceImproved =
+        !!consumedEvidence
+        && !!refreshedEvidence
+        && didTriageEvidenceMateriallyImprove(
+          consumedEvidence,
+          refreshedEvidence,
+        );
       updates.push({
         analysisId: planned.analysisId,
         listingId: planned.listingId,
         details: record,
         detailsStatus: toDbDetailsStatus(planned.afterDetailsStatus),
+        triageEvidenceFingerprint:
+          current.hasTriageVerdict ? consumedEvidence : null,
+        regradeSuggested:
+          current.regradeSuggested
+          || (current.hasTriageVerdict && evidenceImproved),
       });
     }
   }
@@ -1152,5 +1216,140 @@ export function validateReviewJobDetailsRepairForApply(input: {
   if (updates.length === 0) {
     throw new Error('Repair plan contains no persisted details updates');
   }
+  return updates;
+}
+
+export function validateAppliedDetailsRepairForEvidenceReconciliation(
+  input: {
+    plan: DetailsRepairPlan;
+    job: DetailsRepairJobInput;
+  },
+): DetailsRepairEvidenceReconciliationUpdate[] {
+  const { plan, job } = input;
+  assertIdleJob(job);
+  if (job.id !== plan.jobId) {
+    throw new Error(
+      `Repair plan is for ${plan.jobId}, not ${job.id}`,
+    );
+  }
+  if (path.resolve(job.artifactRoot ?? '') !== plan.stagedArtifactRoot) {
+    throw new Error(
+      'Review job does not point at the applied repair artifact root',
+    );
+  }
+  if (job.reportPath !== plan.stagedReportPath) {
+    throw new Error(
+      'Review job does not point at the applied repair report',
+    );
+  }
+  const { sourceManifest, stagedManifest } =
+    validateDetailsRepairArtifacts(plan);
+  const currentListings = new Map(
+    job.listings.map((listing) => [listing.rowId, listing]),
+  );
+  const updates: DetailsRepairEvidenceReconciliationUpdate[] = [];
+
+  for (const planned of plan.listings) {
+    if (planned.outcome !== 'repaired') continue;
+    const current = currentListings.get(planned.rowId);
+    if (
+      !current
+      || current.analysisId !== planned.analysisId
+      || current.listingId !== planned.listingId
+      || current.platform !== planned.platform
+      || current.url !== planned.url
+    ) {
+      throw new Error(
+        `Applied repair listing no longer matches: ${planned.listingId}`,
+      );
+    }
+    if (
+      fingerprintDetailsRepairValue(current.details)
+      !== planned.afterDetailsFingerprint
+    ) {
+      throw new Error(
+        `Applied repair details changed: ${planned.listingId}`,
+      );
+    }
+    if (!current.hasTriageVerdict) continue;
+
+    const sourceEntry = getManifestEntry(
+      sourceManifest,
+      planned.platform,
+      planned.url,
+    )?.[1];
+    const stagedEntry = getManifestEntry(
+      stagedManifest,
+      planned.platform,
+      planned.url,
+    )?.[1];
+    if (!sourceEntry || !stagedEntry) {
+      throw new Error(
+        `Applied repair artifacts are missing ${planned.listingId}`,
+      );
+    }
+    const sourceDetailsPath = resolveArtifactFile(
+      plan.sourceArtifactRoot,
+      sourceEntry.details.file ?? '',
+      'Source details path',
+    );
+    const stagedDetailsPath = resolveArtifactFile(
+      plan.stagedArtifactRoot,
+      stagedEntry.details.file ?? '',
+      'Staged details path',
+    );
+    assertRegularFile(sourceDetailsPath, 'Source details artifact');
+    assertRegularFile(stagedDetailsPath, 'Staged details artifact');
+    if (
+      fingerprintFile(sourceDetailsPath)
+      !== planned.sourceDetailsArtifactFingerprint
+      || fingerprintDetailsRepairValue(
+        JSON.parse(fs.readFileSync(stagedDetailsPath, 'utf8')),
+      ) !== planned.afterDetailsFingerprint
+    ) {
+      throw new Error(
+        `Applied repair evidence artifacts changed: ${planned.listingId}`,
+      );
+    }
+
+    const storedEvidence = parseTriageEvidenceFingerprint(
+      current.triageEvidenceFingerprint,
+    );
+    const consumedEvidence =
+      storedEvidence
+      ?? getTriageEvidenceFingerprintFromArtifacts({
+        artifactRoot: plan.sourceArtifactRoot,
+        entry: sourceEntry,
+      });
+    const refreshedEvidence =
+      getTriageEvidenceFingerprintFromArtifacts({
+        artifactRoot: plan.stagedArtifactRoot,
+        entry: stagedEntry,
+      });
+    if (!consumedEvidence || !refreshedEvidence) {
+      throw new Error(
+        `Cannot reconcile triage evidence for ${planned.listingId}`,
+      );
+    }
+    if (current.regradeSuggested && storedEvidence) {
+      continue;
+    }
+    if (
+      !current.regradeSuggested
+      && !didTriageEvidenceMateriallyImprove(
+        consumedEvidence,
+        refreshedEvidence,
+      )
+    ) {
+      continue;
+    }
+    updates.push({
+      analysisId: current.analysisId,
+      listingId: current.listingId,
+      triageEvidenceFingerprint: consumedEvidence,
+      regradeSuggested: true,
+    });
+  }
+
   return updates;
 }

--- a/web/src/lib/reviewJobs.ts
+++ b/web/src/lib/reviewJobs.ts
@@ -391,6 +391,9 @@ function toReviewJobListingAnalysisState(
     aiReviews: asJsonObject(row.aiReviews),
     aiPhotos: asJsonObject(row.aiPhotos),
     triage: asJsonObject(row.triage),
+    triageEvidenceFingerprint:
+      asJsonObject(row.triageEvidenceFingerprint),
+    regradeSuggested: row.regradeSuggested,
     reviewCount: row.reviewCount ?? null,
     reviewSample:
       reviewSample
@@ -552,6 +555,7 @@ export function toReviewJobState(
     location: job.location ?? null,
     prompt: job.prompt ?? null,
     regradeRequired: job.regradeRequired,
+    regradeSuggested: job.regradeSuggested,
     boundingBox: parseStoredBoundingBox(job.boundingBox) ?? null,
     circle: asCircleFilter(job.circle),
     poi: asMapPoint(job.poi),

--- a/web/src/lib/search-worker.ts
+++ b/web/src/lib/search-worker.ts
@@ -75,6 +75,9 @@ import type { SearchResult } from '../types.js';
 import { filterResultsForRequest } from './resultFilters.js';
 import { parseStaySnapshot } from '../../../src/stay-snapshot.js';
 import {
+  parseTriageEvidenceFingerprint,
+} from '../../../src/triage-evidence.js';
+import {
   computeReviewJobSnapshotAffordability,
   getReviewJobStaySnapshotReadModel,
   resolveStaySnapshotTtlMs,
@@ -757,6 +760,9 @@ interface ReviewJobListingAnalysisSnapshot {
   aiReviews: Prisma.InputJsonValue | typeof Prisma.DbNull;
   aiPhotos: Prisma.InputJsonValue | typeof Prisma.DbNull;
   triage: Prisma.InputJsonValue | typeof Prisma.DbNull;
+  triageEvidenceFingerprint:
+    Prisma.InputJsonValue | typeof Prisma.DbNull;
+  regradeSuggested: boolean;
   reviewCount: number | null;
   photoCount: number | null;
   aiReviewsCostUsd: number;
@@ -791,6 +797,8 @@ function createReviewJobAnalysisSnapshot(
       aiReviews: Prisma.JsonValue | null;
       aiPhotos: Prisma.JsonValue | null;
       triage: Prisma.JsonValue | null;
+      triageEvidenceFingerprint: Prisma.JsonValue | null;
+      regradeSuggested: boolean;
       reviewCount: number | null;
       photoCount: number | null;
       aiReviewsCostUsd: number;
@@ -822,6 +830,10 @@ function createReviewJobAnalysisSnapshot(
     aiReviews: toStoredAnalysisValue(listing.analysis.aiReviews),
     aiPhotos: toStoredAnalysisValue(listing.analysis.aiPhotos),
     triage: toStoredAnalysisValue(listing.analysis.triage),
+    triageEvidenceFingerprint: toStoredAnalysisValue(
+      listing.analysis.triageEvidenceFingerprint,
+    ),
+    regradeSuggested: listing.analysis.regradeSuggested,
     reviewCount: listing.analysis.reviewCount,
     photoCount: listing.analysis.photoCount,
     aiReviewsCostUsd: listing.analysis.aiReviewsCostUsd,
@@ -856,6 +868,9 @@ async function restoreReviewJobAnalysisSnapshots(
         aiReviews: snapshot.aiReviews,
         aiPhotos: snapshot.aiPhotos,
         triage: snapshot.triage,
+        triageEvidenceFingerprint:
+          snapshot.triageEvidenceFingerprint,
+        regradeSuggested: snapshot.regradeSuggested,
         reviewCount: snapshot.reviewCount,
         photoCount: snapshot.photoCount,
         aiReviewsCostUsd: snapshot.aiReviewsCostUsd,
@@ -880,6 +895,9 @@ async function restoreReviewJobAnalysisSnapshots(
         aiReviews: snapshot.aiReviews,
         aiPhotos: snapshot.aiPhotos,
         triage: snapshot.triage,
+        triageEvidenceFingerprint:
+          snapshot.triageEvidenceFingerprint,
+        regradeSuggested: snapshot.regradeSuggested,
         reviewCount: snapshot.reviewCount,
         photoCount: snapshot.photoCount,
         aiReviewsCostUsd: snapshot.aiReviewsCostUsd,
@@ -1173,6 +1191,19 @@ async function persistReviewJobManifestEntryToDb(input: {
   const aiReviews = readArtifactJson(input.artifactRoot, input.entry.aiReviews.file);
   const aiPhotos = readArtifactJson(input.artifactRoot, input.entry.aiPhotos.file);
   const triage = readArtifactJson(input.artifactRoot, input.entry.triage.file);
+  const triageEvidenceFingerprint =
+    parseTriageEvidenceFingerprint(triage?.evidenceFingerprint);
+  const triageWasRefreshed =
+    !!triageEvidenceFingerprint
+    && input.entry.triage.status === 'fetched'
+    && (input.currentPhase === 'triage' || input.finalize === true);
+  const refreshedEvidenceFields = triageWasRefreshed
+    ? {
+        triageEvidenceFingerprint:
+          triageEvidenceFingerprint as unknown as Prisma.InputJsonValue,
+        regradeSuggested: false,
+      }
+    : {};
   const staySnapshot = parseStaySnapshot(details?.staySnapshot);
   const aiCostFields = getManifestEntryAiCostFields(input.entry);
   const terminalStatus = summarizeManifestEntryStatus(input.entry);
@@ -1217,6 +1248,7 @@ async function persistReviewJobManifestEntryToDb(input: {
         aiReviews: aiReviews == null ? Prisma.DbNull : (aiReviews as Prisma.InputJsonValue),
         aiPhotos: aiPhotos == null ? Prisma.DbNull : (aiPhotos as Prisma.InputJsonValue),
         triage: triage == null ? Prisma.DbNull : (triage as Prisma.InputJsonValue),
+        ...refreshedEvidenceFields,
         reviewCount: input.entry.reviews.count ?? null,
         photoCount: input.entry.photos.count ?? null,
         aiReviewsCostUsd: aiCostFields.aiReviewsCostUsd,
@@ -1240,6 +1272,7 @@ async function persistReviewJobManifestEntryToDb(input: {
         aiReviews: aiReviews == null ? Prisma.DbNull : (aiReviews as Prisma.InputJsonValue),
         aiPhotos: aiPhotos == null ? Prisma.DbNull : (aiPhotos as Prisma.InputJsonValue),
         triage: triage == null ? Prisma.DbNull : (triage as Prisma.InputJsonValue),
+        ...refreshedEvidenceFields,
         reviewCount: input.entry.reviews.count ?? null,
         photoCount: input.entry.photos.count ?? null,
         aiReviewsCostUsd: aiCostFields.aiReviewsCostUsd,
@@ -2150,6 +2183,16 @@ async function runReviewJobAnalysis(
         select: { status: true },
       });
       overallStatus = summarizeAnalysisStatus(finalAnalyses);
+      const regradeSuggestedListingCount =
+        await tx.reviewJobListingAnalysis.count({
+          where: {
+            jobListing: {
+              jobId: reviewJobId,
+              hidden: false,
+            },
+            regradeSuggested: true,
+          },
+        });
       const resultsReady =
         overallStatus === 'completed' || overallStatus === 'partial';
       const aggregatedAiCosts =
@@ -2182,6 +2225,7 @@ async function runReviewJobAnalysis(
                   jobRecord.regradeRequired,
                   overallStatus,
                 ),
+          regradeSuggested: regradeSuggestedListingCount > 0,
           artifactRoot,
           reportPath,
           ...aggregatedAiCosts,
@@ -2254,6 +2298,16 @@ async function runReviewJobAnalysis(
                 tx,
                 reviewJobId,
               );
+        const regradeSuggestedListingCount =
+          await tx.reviewJobListingAnalysis.count({
+            where: {
+              jobListing: {
+                jobId: reviewJobId,
+                hidden: false,
+              },
+              regradeSuggested: true,
+            },
+          });
         await tx.reviewJob.update({
           where: { id: reviewJobId },
           data: {
@@ -2265,6 +2319,7 @@ async function runReviewJobAnalysis(
             analysisErrorMessage: error.message,
             analysisCompletedAt: completedAt,
             analysisDurationMs: completedAt.getTime() - startedAt.getTime(),
+            regradeSuggested: regradeSuggestedListingCount > 0,
             artifactRoot,
             reportPath: null,
             ...aggregatedAiCosts,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -210,6 +210,8 @@ export interface ReviewJobListingAnalysis {
   aiReviews: Record<string, unknown> | null;
   aiPhotos: Record<string, unknown> | null;
   triage: Record<string, unknown> | null;
+  triageEvidenceFingerprint: Record<string, unknown> | null;
+  regradeSuggested: boolean;
   reviewCount: number | null;
   reviewSample: ReviewAnalysisSample;
   photoCount: number | null;
@@ -261,6 +263,7 @@ export interface ReviewJobState {
   location: string | null;
   prompt: string | null;
   regradeRequired: boolean;
+  regradeSuggested: boolean;
   boundingBox: BoundingBox | null;
   circle: CircleFilter | null;
   poi: MapPoint | null;


### PR DESCRIPTION
## What changed

- Add a versioned per-listing triage evidence fingerprint recording exact details, AI-review, and AI-photo artifact hashes, layer presence, and core details coverage.
- Add durable `regradeSuggested` state at listing and job level, separate from `regradeRequired`.
- Keep suggested verdicts peer-rankable while reusing the existing **Regrade needed** UI with the `evidence_improved` reason.
- Refresh fingerprints and clear suggestions only when triage successfully recomputes a verdict; rerun rollback preserves the prior fingerprint and state.
- Make details repair compare consumed vs refreshed evidence and flag only core-field coverage improvements, never arbitrary byte drift.
- Add a dry-run-first reconciliation command for the already-repaired NYC job using its retained repair plan and source artifacts.

## Root cause

The comparison key covered rubric, requirement set, and classifier policy, but persisted no identity for the evidence artifacts used by a verdict. The #77 repair could therefore replace empty Airbnb details with materially richer evidence while the old verdict still appeared current.

## Validation

- `pnpm run build`
- `pnpm run lint`
- `pnpm test` — 191 passed
- `cd web && npm run build`
- `cd web && npm run lint`
- `cd web && npm run test:ui` — 22 passed
- `cd web && npm run test:pricing` — 3 passed
- `cd web && npm run test:dependencies` — 1 passed
- Read-only validation against job `cmrxmsjeu0000ykrhh7lqm6aa` and its retained repair artifacts found exactly 27 affected verdicts; all 27 lacked title and rating at grade time. No database writes were performed.

## Deployment note

The standard schema push must run before the new worker/app code starts. After that, reconcile the already-applied NYC repair with a dry run, then apply only after its 27-listing output is confirmed:

```bash
cd web
npm run reconcile:job-evidence -- --job cmrxmsjeu0000ykrhh7lqm6aa
npm run reconcile:job-evidence -- --job cmrxmsjeu0000ykrhh7lqm6aa --apply
```

Closes #83
