### PR TITLE
Fix regrade suggestion precedence

### DIFF
--- a/tests/results-rubric.test.ts
+++ b/tests/results-rubric.test.ts
@@ -10,6 +10,7 @@ import {
   getTriageComparisonStatus,
   getTriageRegradeReasons,
   getTriageRegradeListingCount,
+  isPeerComparableTriageStatus,
   matchesAffordabilityFilter,
 } from '../web/src/lib/results.js';
 import type { ReviewJobListing } from '../web/src/types.js';
@@ -291,6 +292,102 @@ test('older classifier policy is preserved but excluded from comparison', () => 
     ),
     'stale_classifier_policy',
   );
+});
+
+test('evidence improvement never overrides a status that excludes peer comparison', () => {
+  const activeComparison =
+    getCurrentTriageComparability('reqset_active');
+  const cases = [
+    {
+      name: 'legacy model-authored verdict',
+      listing: listing('legacy-suggested', {
+        fitScore: 100,
+        tier: 'top_pick',
+      }, true),
+      expected: 'legacy',
+    },
+    {
+      name: 'mismatched requirement set',
+      listing: listing('requirement-set-suggested', {
+        scoreSource: 'deterministic_rubric',
+        rubricVersion: '1',
+        requirementSetId: 'reqset_old',
+        classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+        fitScore: 100,
+        tier: 'top_pick',
+        rankingStatus: 'ranked',
+      }, true),
+      expected: 'stale_requirement_set',
+    },
+    {
+      name: 'stale classifier policy',
+      listing: listing('classifier-policy-suggested', {
+        scoreSource: 'deterministic_rubric',
+        rubricVersion: '1',
+        requirementSetId: 'reqset_active',
+        fitScore: 100,
+        tier: 'top_pick',
+        rankingStatus: 'ranked',
+      }, true),
+      expected: 'stale_classifier_policy',
+    },
+    {
+      name: 'insufficient evidence',
+      listing: listing('insufficient-suggested', {
+        scoreSource: 'deterministic_rubric',
+        rubricVersion: '1',
+        requirementSetId: 'reqset_active',
+        classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+        fitScore: 100,
+        tier: 'top_pick',
+        rankingStatus: 'insufficient_evidence',
+      }, true),
+      expected: 'insufficient_evidence',
+    },
+  ] as const;
+
+  for (const fixture of cases) {
+    const status = getTriageComparisonStatus(
+      getListingResultsSnapshot(fixture.listing).triage,
+      activeComparison,
+      { regradeSuggested: true },
+    );
+    assert.equal(status, fixture.expected, fixture.name);
+    assert.equal(
+      isPeerComparableTriageStatus(status),
+      false,
+      fixture.name,
+    );
+  }
+  assert.deepEqual(
+    getTriageRegradeReasons(
+      cases.map((fixture) => fixture.listing),
+      activeComparison,
+      false,
+    ),
+    [
+      'evidence_improved',
+      'classifier_policy_changed',
+      'requirement_set_mismatch',
+    ],
+  );
+
+  const current = listing('current-suggested', {
+    scoreSource: 'deterministic_rubric',
+    rubricVersion: '1',
+    requirementSetId: 'reqset_active',
+    classifierVersion: TRIAGE_CLASSIFIER_VERSION,
+    fitScore: 82,
+    tier: 'top_pick',
+    rankingStatus: 'ranked',
+  }, true);
+  const currentStatus = getTriageComparisonStatus(
+    getListingResultsSnapshot(current).triage,
+    activeComparison,
+    { regradeSuggested: true },
+  );
+  assert.equal(currentStatus, 'regrade_suggested');
+  assert.equal(isPeerComparableTriageStatus(currentStatus), true);
 });
 
 test('model identity is audit metadata and does not gate comparison', () => {

--- a/web/src/components/ResultsWorkspace.tsx
+++ b/web/src/components/ResultsWorkspace.tsx
@@ -31,6 +31,7 @@ import {
   getTriageRegradeReasons,
   getTriageRegradeListingCount,
   getTierRank,
+  isPeerComparableTriageStatus,
   matchesAffordabilityFilter,
   type AffordabilityStatus,
   type ParsedTriage,
@@ -140,7 +141,10 @@ function comparisonRank(status: ResultsComparisonStatus): number {
 function isPeerComparableStatus(
   status: ResultsComparisonStatus,
 ): boolean {
-  return status === 'ranked' || status === 'regrade_suggested';
+  return (
+    status !== 'duplicate_conflict'
+    && isPeerComparableTriageStatus(status)
+  );
 }
 
 function displayedTier(

--- a/web/src/lib/results.ts
+++ b/web/src/lib/results.ts
@@ -169,6 +169,12 @@ export type TriageComparisonStatus =
   | 'stale_classifier_policy'
   | 'unscored';
 
+export function isPeerComparableTriageStatus(
+  status: TriageComparisonStatus,
+): boolean {
+  return status === 'ranked' || status === 'regrade_suggested';
+}
+
 export type ActiveTriageComparison = TriageComparabilityDescriptor;
 export type TriageRegradeReason =
   | 'brief_changed'
@@ -419,7 +425,6 @@ export function getTriageComparisonStatus(
 ): TriageComparisonStatus {
   if (!triage) return 'unscored';
   if (options.regradeRequired) return 'regrade_required';
-  if (options.regradeSuggested) return 'regrade_suggested';
   if (triage.scoreSource === 'model_legacy') return 'legacy';
   if (
     activeComparison
@@ -436,6 +441,9 @@ export function getTriageComparisonStatus(
   if (triage.rankingStatus === 'insufficient_evidence') {
     return 'insufficient_evidence';
   }
+  // Evidence improvement is advisory and must not override a status that
+  // already excludes the verdict from peer comparison.
+  if (options.regradeSuggested) return 'regrade_suggested';
   return 'ranked';
 }
 


### PR DESCRIPTION
## What changed

- Resolve exclusionary triage states before the `regrade_suggested` advisory.
- Keep legacy, requirement-set-stale, classifier-policy-stale, and insufficient-evidence verdicts outside peer comparison even when their evidence improved.
- Centralize the peer-comparability predicate used by `ResultsWorkspace`.
- Add regression coverage for all four exclusionary states and for a current comparable verdict that should still resolve to `regrade_suggested`.

## Why

Follow-up to #85. The evidence reconciliation correctly marked 27 Airbnb rows as having improved evidence, but status resolution checked the advisory first. That promoted legacy model-authored verdicts into the comparable rank group even though identical-provenance Booking verdicts remained legacy and unranked.

This PR changes display/ranking resolution only. It does not alter or revert the reconciliation data and does not trigger a regrade.

## Live read-only verification

Using the patched resolver against job `cmrxmsjeu0000ykrhh7lqm6aa`:

- 27 persisted listing suggestions remain set.
- All 54 verdicts resolve to `legacy`.
- 0 suggested legacy verdicts are peer-comparable.
- The job-level reason remains exactly `evidence_improved`.

## Checks

- `pnpm run build`
- `pnpm run lint`
- `pnpm test` — 192 passed
- `cd web && npm run build`
- `cd web && npm run lint`
- `cd web && npm run test:ui` — 22 passed
- `cd web && npm run test:pricing` — 3 passed
- `cd web && npm run test:dependencies` — 1 passed
